### PR TITLE
Update aws workload identity instructions

### DIFF
--- a/mk8s/add-ons/aws_workload_identity.mdx
+++ b/mk8s/add-ons/aws_workload_identity.mdx
@@ -58,12 +58,41 @@ addOns:
 #### Using UI
 
 1. **Navigate to Control Plane Console**: Visit the [Control Plane Console](https://console.cpln.io/console/).
-2. **Navigate to the Kubernetes cluster**: In the Control Plane Console, navigate to `Kubernetes` in the left sidebar panel and click on the Kubernetes cluster for which you want to enable the dashboard.
-3. **Enable the Dashboard**: Choose `Add-ons` and locate the `AWS Workload Identity` add-on from the list of available add-ons, then toggle it on.
+1. **Navigate to the Kubernetes cluster**: In the Control Plane Console, navigate to `Kubernetes` in the left sidebar panel and click on the Kubernetes cluster for which you want to enable the dashboard.
+1. **Enable the Dashboard**: Choose `Add-ons` and locate the `AWS Workload Identity` add-on from the list of available add-ons, then toggle it on.
+
+## Setup
+
+After enabling AWS Workload Identity, an [OIDC Identity Provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) for each cluster must be created in your AWS account before it can be used.
+The `oidcProviderUrl` for the OIDC Identity Provider is in the status of the cluster.
+
+1. **Create OIDC Identity Provider in AWS**
+
+   1. Retrieve the cluster's **oidcProviderUrl**:
+
+      CLI
+
+      ```
+      cpln mk8s get -o json $cluster_name | jq -r '.status.oidcProviderUrl'
+      ```
+
+      UI
+
+      1. From the Managed Kubernetes cluster in the UI, select `View` from the `Actions` drop down in the upper right corner.
+         
+         A new window will open sowing the content of the Managed Kubernetes object in the Control Plane API.
+      
+      1. Toggle the `Slim` button so it is turned off.
+      1. The `providerUrl` is shown in the object at `.status.addOns.awsWorkloadIdentity.oidcProviderConfig`
+
+
+   1. Access the AWS console and navigate to **IAM**. In the left panel, under `Access management`, select `Identity providers` and then click `Add provider`.
+   1. Select `OpenID Connect`, paste the `Provider URL` obtained in the previous step, and click `Get thumbprint`.
+   1. In the `Audience` field, enter `sts.amazonaws.com`.
 
 ## Usage Instructions
 
-After enabling AWS Workload Identity, your Managed Kubernetes cluster becomes an identity provider for your Pods. Begin by creating an [OIDC Identity Provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) in your AWS account. Use the `oidcProviderUrl` from your cluster, which is located in the `status` section of the cluster. The method to access this URL is detailed below.
+After enabling AWS Workload Identity, your Managed Kubernetes cluster becomes an identity provider for your Pods.
 
 To grant a Pod access, ensure it uses a [Kubernetes Service Account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) with the annotation: `eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/IAM-ROLE-HERE"`. This setup is compatible with all [Kubernetes Workloads](https://kubernetes.io/docs/concepts/workloads/), as they ultimately provision Pods.
 
@@ -71,28 +100,18 @@ Follow these steps below to configure.
 
 ### Steps to configure access
 
-1. **Create OIDC Identity Provider in AWS**
-
-   1. Retrieve the cluster's **oidcProviderUrl**:
-      ```
-      cpln mk8s get -o json $cluster_name | jq -r '.status.oidcProviderUrl'
-      ```
-   2. Access the AWS console and navigate to **IAM**. In the left panel, under `Access management`, select `Identity providers` and then click `Add provider`.
-   3. Select `OpenID Connect`, paste the `Provider URL` obtained in the previous step, and click `Get thumbprint`.
-   4. In the `Audience` field, enter `sts.amazonaws.com`.
-
-2. **Retrieve and Save the Trust Policy JSON**
+1. **Retrieve and Save the Trust Policy JSON**
 
    1. Obtain the trust policy template:
       ```
       cpln mk8s get -o json $cluster_name | jq -r '.status.addOns.awsWorkloadIdentity.trustPolicy'
       ```
-   2. Save the obtained policy to a file named `example-trust-policy.json`. Then, modify the trust policy by replacing
+   1. Save the obtained policy to a file named `example-trust-policy.json`. Then, modify the trust policy by replacing
       `<SERVICE_ACCOUNT>` and `<NAMESPACE>` with the appropriate values:
       - For `<NAMESPACE>`, use `default`.
       - For `<SERVICE_ACCOUNT>`, use `mk8s-identity-example`.
 
-3. **Create an IAM Role**
+1. **Create an IAM Role**
    - You can create a new IAM Role using the AWS Console, or use an existing one. For creating a role via CLI, follow this example:
      - Replace `<ACCOUNT_ID>` with your AWS Account ID.
      - Used the obtained trust policy from the previous step as `default-trust-policy.json`
@@ -100,7 +119,7 @@ Follow these steps below to configure.
        ```
        aws iam create-role --role-name "arn:aws:iam::<ACCOUNT_ID>:role/mk8s-identity-example" --assume-role-policy-document file://default-trust-policy.json
        ```
-4. **Create Kubernetes Service Account and a Pod**  
+1. **Create Kubernetes Service Account and a Pod**  
    Create the Kubernetes Service Account and a Pod in your Managed Kubernetes cluster. For guidance on accessing your cluster, refer to the documentation page of your Provider.
 
    - Replace `<ACCOUNT_ID>` with your AWS Account ID in the following YAML configuration:


### PR DESCRIPTION
1. switched to standard markdown numbering format on this page
2. separated setup and usage instructions