### PR TITLE
Jacob/cloud sql

### DIFF
--- a/guides/native-networking/private-service-connect/cloud-sql.mdx
+++ b/guides/native-networking/private-service-connect/cloud-sql.mdx
@@ -189,7 +189,7 @@ output "vpc_self_link" {
 
 <Warning>
 For Private Service Connect to be configured, it is required that:
-- ```ipv4_enabled``` is set to ```false```
+- ```ipv4_enabled``` is set to ```false```. This ensures that Cloud SQL uses a private IP and is not assigned a public IP.
 - ```psc_config``` is set up with ```psc_enabled``` as ```true```
 </Warning>
 


### PR DESCRIPTION
Added a note to specify the ipv4 disablement in Cloud SQL. This signifies that the instance would use a private IP and no public IP.