### PR TITLE
created native networking setup

### DIFF
--- a/guides/native-networking/native-networking-setup.mdx
+++ b/guides/native-networking/native-networking-setup.mdx
@@ -1,0 +1,39 @@
+---
+title: Native Networking Setup
+---
+
+## Overview
+
+Follow the steps to configure Native Networking within an [identity](/refrence/identity) with [AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/what-is-privatelink.html) or [GCP Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect).
+
+### Prerequisites
+
+- Review the [identity](/reference/identity) reference page.
+- Create a resource with one of the following:
+    - For AWS, a resource is created with PrivateLink configured.
+    - For GCP, a resource is created with Private Service Connect configured [(see example)](/guides/native-networking/private-service-connect/cloud-sql).
+- Control Plane support has created an endpoint using your resource's service name (AWS) or service attachment (GCP).
+
+## Create using the UI Console
+
+1. Create or edit an [identity](/guides/create-identity).
+2. Navigate to the ```Native Networking``` tab on the left hand side.
+3. Select ```Add Native Networking```
+4. In the Fully Qualified Domain Name (FQDN) field, enter a unique name.
+5. In the Name field, enter another unique name that does not match the FQDN.
+<Tip>
+Your workload can reference either the FQDN or the Name as an environment variable to connect using the [identity](/reference/identity). If the internal resource is configured with TLS, the FQDN must be used.
+</Tip>
+6. Add a port number.
+<Note>
+You can configure multiple Native Networking connections to different resources by specifying different port numbers for each resource. Each new database that is created in the cloud will require a new PrivateLink/Private Service Connect endpoint.
+</Note>
+7. Select your ```Cloud Provider```.
+    - If using AWS choose ```AWS PrivateLink``` and paste your service name.
+    - If using GCP choose ```GCP Service Connect``` and paste your service attachment.
+8. Select ```Add``` to finish configuring Native Networking.
+
+## Next Steps
+
+- Finish creating/updating your [identity](/guides/create-identity).
+- The identity can be associated with one or more of your [workload's identity](/reference/workload#identity) setting.

--- a/mint.json
+++ b/mint.json
@@ -133,7 +133,7 @@
         },
         {
           "group": "Native Networking",
-          "pages": [
+          "pages": ["guides/native-networking/native-networking-setup",
             {
               "group": "Private Service Connect",
               "pages": [


### PR DESCRIPTION
Added section with Native Networking setup when creating an identity. The setup guide makes specifications for using AWS PrivateLink or GCP Private Service Connect.