### PR TITLE
Added Native Networking information

### DIFF
--- a/guides/create-identity.mdx
+++ b/guides/create-identity.mdx
@@ -26,9 +26,10 @@ Follow the steps below to create an identity (requires a [GVC](/reference/gvc)):
     access definition is optional. See [Cloud Access](#cloud-access) for additional details. Click `Next (Network Resources)`.
 4.  Click `Add Network Resource` and follow the wizard to configure a network resource. The wizard requires at least one [agent](/reference/agent)
     to exist. Each identity can have multiple network resources defined. Depending on the use case of this identity, creating a network
-    resource is optional. See [Network Resource](#network-resource) for additional details. Click `Next (Tags)`.
-5.  Enter any optional [tags](/reference/misc#tags). Click `Create`.
-6.  The identity has been successfully created and the identity info page will be shown. This identity will now be available
+    resource is optional. See [Network Resource](#network-resource) for additional details. Click `Next (Native Networking)`.
+5.  Click `Add Native Networking` and [configure Native Networking](/guides/native-networking/native-networking-setup). Creating a Native Networking connection is optional. See [Native Networking](/reference/identity#native-networking) for additional details. Click `Next (Tags)`.
+6.  Enter any optional [tags](/reference/misc#tags). Click `Create`.
+7.  The identity has been successfully created and the identity info page will be shown. This identity will now be available
     for use within your [workload's identity](/reference/workload#identity) setting.
 
 ## Cloud Access

--- a/reference/identity.mdx
+++ b/reference/identity.mdx
@@ -18,6 +18,10 @@ An **identity** is a named object that allows an authorized administrator to def
 
 - Network traversal rules from [workloads](/concepts/workload) into specific endpoints in private networks (e.g., a VPC). These rules connect an [agent](/reference/agent) in a private network to the Control Plane fabric allowing [workloads](/concepts/workload) to selectively access TCP endpoints inside private networks where [agents](/reference/agent) are installed and running.
 
+### Native Networking
+
+- Provides secure, private connectivity from a [workload](/concepts/workload) to cloud-hosted services across AWS and GCP without traversing the public internet. It leverages cloud provider-specific private networking services to route traffic over internal infrastructure. This enables low-latency, secure communication to private resources while maintaining strict network isolation and identity-based access control.
+
 An **identity** is scoped to a [GVC](/reference/gvc) and can be assigned to multiple [workloads](/concepts/workload) within the same [GVC](/reference/gvc) needing the same cloud resources and network access.
 
 A [workload](/concepts/workload) can be assigned exactly one **identity**. An **identity** is only required when a [workload](/concepts/workload) needs to consume cloud resources without embedding credentials and/or when a [workload](/concepts/workload) needs to consume resources in a private network such as a VPC. If neither is required, a [workload](/concepts/workload) can operate **without** assigning it an **identity**.


### PR DESCRIPTION
Added Native Networking information under "identity" in "references". Created a concise but informational description of Native Networking in Control Plane. Also added extra step in "create an identity" since that step was not included in the identity creation steps.