### PR TITLE
Change EFS example to use alpine

### DIFF
--- a/mk8s/add-ons/aws_efs.mdx
+++ b/mk8s/add-ons/aws_efs.mdx
@@ -145,7 +145,7 @@ spec:
   terminationGracePeriodSeconds: 0
   containers:
     - name: app
-      image: centos
+      image: alpine:latest
       command: ['/bin/sh']
       args: ['-c', 'while true; do echo $(date -u) >> /data/out; sleep 5; done']
       volumeMounts:


### PR DESCRIPTION
centos is deprecated and the image referenced does not exist.

Thank you @hall for pointing this out.