### PR TITLE
RDS PrivateLink Terraform docs

### DIFF
--- a/guides/native-networking/aws-privatelink/privatelink-rds-terraform.mdx
+++ b/guides/native-networking/aws-privatelink/privatelink-rds-terraform.mdx
@@ -1,0 +1,97 @@
+---
+title: PrivateLink with RDS
+---
+
+## Overview
+
+Follow the steps below to provision (or integrate with existing) an [RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html) instance with a [PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/what-is-privatelink.html) endpoint in AWS for Control Plane connectivity.
+
+## Create using Control Plane Terraform
+
+### Modes
+1. **Create New Infrastructure (default)**
+    - RDS, Secret Manager Secret and VPC infrastructure will be created along with networking resources.
+2. **Existing Infrastructure**
+    - Uses your preexisting RDS, Secret Manager Secret and VPC infrastructure to create networking resources.
+    - To use this mode, you must provide your RDS ARN and Secret Manager Secret ARN.
+
+### What's Created
+<Accordion title="Using Create Infrastructure Mode:">
+    - VPC & Subnets
+    - RDS PostgreSQL Instance (multi-AZ)
+    - Secrets Manager (secure credential storage)
+    - RDS Proxy (connection pooling and failover)
+    - Network Load Balancer
+    - Lambda Function (dynamic IP updates)
+    - PrivateLink Endpoint Service
+</Accordion>
+<Accordion title="Using Existing Infrastructure Mode:">
+    - RDS Proxy (connection pooling and failover)
+    - Network Load Balancer
+    - Lambda Function (dynamic IP updates)
+    - PrivateLink Endpoint Service
+</Accordion>
+
+### Prerequisites
+
+**Software Requirements:**
+- Install AWS [CLI](https://aws.amazon.com/cli/).
+- Install Terraform [CLI](https://developer.hashicorp.com/terraform).
+- [Git](https://git-scm.com/) (for cloning the repository).
+
+**AWS Account Requirements:**
+- [Amazon Web Service (AWS)](https://aws.amazon.com/) account with billing enabled.
+- AWS IAM User/Role with appropriate permissions (VPC, RDS, Lambda, NLB, Secrets Manager, IAM, CloudWatch, etc.).
+- Deploy resources in the same region as your Control Plane [workload](/concepts/workload).
+
+**Existing RDS Requirements:**
+- VPC, subnets, and RDS infrastructure already created and available.
+- Create Secrets Manager Secret with database credentials in the following JSON format.
+    ```JSON
+    {
+    "username": "your_db_username",
+    "password": "your_db_password"
+    }
+    ```
+
+### Step 1 - Clone Control Plane Terraform
+```bash
+git clone https://github.com/controlplane-com/cpln-rds-producer
+cd cpln-rds-producer
+```
+- This repository contains Terraform modules for provisioning AWS infrastructure that integrates with Control Plane via PrivateLink.
+
+### Step 2 - Create Configuration File
+- Create a `terraform.tfvars` file in the root of the cloned repository.
+- **For using Create New Infrastructure mode:**
+    ```hcl terraform.tfvars
+    aws_region = "us-west-2"
+    db_username = "postgres"
+    db_password = "SecurePassword123!"
+    ```
+- **For using Existing Infrastructure mode:**
+    ```hcl terraform.tfvars
+    db_instance_arn = "arn:aws:rds:us-west-2:123456789012:db:my-db"
+    secret_arn = "arn:aws:secretsmanager:us-west-2:123456789012:secret:my-secret"
+    ```
+
+### Step 3 - Deploy Infrastructure
+- Run the Terraform with your configuration:
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+- The Terraform will automatically provision all necessary resources and output your PrivateLink endpoint service name.
+
+- For more information, refer to the [repository README](https://github.com/controlplane-com/cpln-rds-producer#control-plane-rds-producer-terraform-modules)
+
+## Next Steps
+- Contact <a href="mailto:support@mintlify.com">support@controlplane.com</a> with your service name and region.
+- Control Plane will use this to create the consumer-side endpoint connection.
+- Once notified that the consumer endpoint has been created, go to your AWS Console:
+    - Navigate to `VPC` and to `Endpoint Services`.
+    - Click on your PrivateLink service.
+    - Under Pending endpoint connections, select the pending request.
+    - Click the `Actions` dropdown and accept endpoint connection request.
+- Proceed to follow the [Native Networking Setup](/guides/native-networking/native-networking-setup) in Control Plane.

--- a/guides/native-networking/native-networking-setup.mdx
+++ b/guides/native-networking/native-networking-setup.mdx
@@ -10,7 +10,7 @@ Follow the steps to configure Native Networking within an [identity](/refrence/i
 
 - Review the [identity](/reference/identity) reference page.
 - Create a resource with one of the following:
-    - For AWS, a resource is created with PrivateLink configured.
+    - For AWS, a resource is created with PrivateLink configured [(see example)](/guides/native-networking/aws-privatelink/privatelink-rds-terraform).
     - For GCP, a resource is created with Private Service Connect configured [(see example)](/guides/native-networking/private-service-connect/cloud-sql).
 - Control Plane support has created an endpoint using your resource's service name (AWS) or service attachment (GCP).
 

--- a/guides/native-networking/private-service-connect/cloud-sql.mdx
+++ b/guides/native-networking/private-service-connect/cloud-sql.mdx
@@ -57,12 +57,15 @@ gcloud sql instances patch INSTANCE_NAME \
 <Tip>
 If you need to change the allowed consumer projects in the future, use the same command and omit the ```---enable-private-service-connect``` flag.
 </Tip>
+- Once your Cloud SQL instance is created with PSC enabled, you can find your service attachment under `Connections` in your instance.
 
 ### Next Steps
-
-- Once your Cloud SQL instance is created with PSC enabled, you can find your service attachment under `Connections` in your instance.
 - Contact <a href="mailto:support@mintlify.com">support@controlplane.com</a> with your service attachment and region.
-- Control Plane will use this service attachment to create the PSC endpoint on the consumer end in order for your workload to securely connect to the Cloud SQL.
+- Control Plane will use this to create the consumer-side endpoint connection.
+  <Note>
+  When using Cloud SQL, there is no manual required acceptance for new connections created by specified allowed consumer projects.
+  </Note>
+- Proceed to follow the [Native Networking Setup](/guides/native-networking/native-networking-setup) in Control Plane.
 
 ## Create using Terraform
 
@@ -404,9 +407,12 @@ terraform apply \
   -target=google_sql_user.users \
   -var-file=terraform.tfvars
 ```
+- Once your Cloud SQL instance is created with PSC enabled, your service attachment will be returned in the terraform output.
 
 ### Next Steps
-
-- Once your Cloud SQL instance is created with PSC enabled, your service attachment will be returned in the terraform output.
 - Contact <a href="mailto:support@mintlify.com">support@controlplane.com</a> with your service attachment and region.
-- Control Plane will use this service attachment to create the PSC endpoint on the consumer end in order for your workload to securely connect to the Cloud SQL.
+- Control Plane will use this to create the consumer-side endpoint connection.
+  <Note>
+  When using Cloud SQL, there is no manual required acceptance for new connections created by specified allowed consumer projects.
+  </Note>
+- Proceed to follow the [Native Networking Setup](/guides/native-networking/native-networking-setup) in Control Plane.

--- a/mint.json
+++ b/mint.json
@@ -135,9 +135,15 @@
           "group": "Native Networking",
           "pages": ["guides/native-networking/native-networking-setup",
             {
-              "group": "Private Service Connect",
+              "group": "GCP Private Service Connect",
               "pages": [
                 "guides/native-networking/private-service-connect/cloud-sql"
+              ]
+            },
+            {
+              "group": "AWS PrivateLink",
+              "pages": [
+                "guides/native-networking/aws-privatelink/privatelink-rds-terraform"
               ]
             }
           ]


### PR DESCRIPTION
Added docs on using RDS Terraform repository for using PrivateLink with Control Plane. Included repo and steps for customers to easily use. Also updated the Cloud SQL Example doc for Next Steps section.