### PR TITLE
Add VM workload documentation

### DIFF
--- a/concepts/workload.mdx
+++ b/concepts/workload.mdx
@@ -1,7 +1,7 @@
 ---
 title: Workloads
-description: "Workloads are the primary deployment unit in Control Plane. Covers container configuration, autoscaling, Capacity AI, logging, and the four workload types."
-keywords: ['microservice', 'app', 'service', 'pod', 'replica', 'serverless', 'standard', 'stateful', 'cron', 'scheduled job', 'horizontal scaling', 'cpu utilization', 'memory utilization', 'capacity ai', 'hpa']
+description: "Workloads are the primary deployment unit in Control Plane. Covers container configuration, autoscaling, Capacity AI, logging, and the five workload types."
+keywords: ['microservice', 'app', 'service', 'pod', 'replica', 'serverless', 'standard', 'stateful', 'cron', 'vm', 'virtual machine', 'scheduled job', 'horizontal scaling', 'cpu utilization', 'memory utilization', 'capacity ai', 'hpa']
 ---
 
 ## Overview
@@ -109,3 +109,5 @@ The default is `none`, which blocks all inter-workload traffic.
   - Workloads that run on a schedule, and do not serve network traffic.
 - **Stateful**:
   - Similar to a `standard` workload, `stateful` workloads have stable replica identities and hostnames, and can mount a [volume set](/reference/volumeset) for persistent storage.
+- **VM**:
+  - Run a full [virtual machine](/reference/workload/vm) — its own guest OS and kernel — as a workload, inside the same service mesh, identity, networking, and observability as containers.

--- a/docs.json
+++ b/docs.json
@@ -104,6 +104,7 @@
                   "reference/workload/security",
                   "reference/workload/termination",
                   "reference/workload/types",
+                  "reference/workload/vm",
                   "reference/workload/volumes"
                 ]
               }
@@ -189,7 +190,7 @@
           {
             "group": "Images",
             "icon": "docker",
-            "pages": ["guides/push-image", "guides/pull-image", "guides/copy-image", "guides/buildpacks"]
+            "pages": ["guides/push-image", "guides/pull-image", "guides/copy-image", "guides/vm-images", "guides/buildpacks"]
           },
           {
             "group": "Native Networking",
@@ -310,6 +311,7 @@
               "mk8s/add-ons/aws_elb",
               "mk8s/add-ons/azure_acr",
               "mk8s/add-ons/byok",
+              "mk8s/add-ons/kubevirt",
               "mk8s/add-ons/local_path_storage",
               "mk8s/add-ons/metrics",
               "mk8s/add-ons/registry_mirror",

--- a/guides/vm-images.mdx
+++ b/guides/vm-images.mdx
@@ -1,0 +1,225 @@
+---
+title: Publishing & Converting VM Images
+description: Package a disk image as an OCI containerDisk and push it to your registry, boot from an HTTP(S) image, and convert VMDK/qcow2/VHD images for use with VM workloads.
+keywords: ['vm image', 'containerdisk', 'qcow2', 'vmdk', 'vhd convert', 'qemu-img', 'kubevirt image', 'boot disk image', 'cdi import', 'windows vm image']
+---
+
+A [VM workload](/reference/workload/vm) boots from a disk image. There are two ways to provide one:
+
+- An **OCI containerDisk** — a disk image packaged as a normal OCI image and pushed to a registry. Best for reproducibility and reuse.
+- An **HTTP(S) disk image** — a disk file (qcow2, raw, VMDK, VHD, …) hosted at a URL and imported into a persistent disk on first boot. Best for large images or a one‑time "lift and shift."
+
+This guide covers building and publishing both, and converting images that start in another format.
+
+## Choosing an approach
+
+<CardGroup cols={2}>
+  <Card title="OCI containerDisk" icon="box">
+    Reproducible, versioned, and pulled like any other image. Recommended for images you reuse or roll out across many VMs.
+  </Card>
+  <Card title="HTTP(S) import" icon="download">
+    No image build step. Point at a URL; Control Plane imports and converts it into a persistent disk. Good for large or one-off images.
+  </Card>
+</CardGroup>
+
+## Supported source formats
+
+The HTTP(S) importer accepts and auto‑converts these disk formats:
+
+| Format | Extensions | Notes |
+| :----- | :--------- | :---- |
+| QEMU copy‑on‑write | `.qcow2` | Recommended; compact and sparse. |
+| Raw | `.img`, `.raw` | Uncompressed full‑size disk. |
+| VMware | `.vmdk` | VMware exports. |
+| Hyper‑V | `.vhd`, `.vhdx` | Windows/Hyper‑V exports. |
+| VirtualBox | `.vdi` | VirtualBox exports. |
+| Optical | `.iso` | CD/DVD media. |
+
+Compressed variants (`.gz`, `.xz`) are also accepted and decompressed on import. **Both** the OCI containerDisk and HTTP(S) paths run the same conversion — CDI converts the source to the boot disk's native format on import — so you can ship a `.vmdk` (or `.vhd`, `.vdi`, …) directly without converting it first. Converting to `qcow2` at build time (see [Converting images](#converting-images)) is an optional optimization that moves the one-time conversion cost out of the import.
+
+## Option A — Publish an OCI containerDisk
+
+A containerDisk is an OCI image whose only contents are a single disk file placed in `/disk/`. KubeVirt loads that disk as the VM's boot device.
+
+<Steps>
+<Step title="Obtain a disk image">
+  Use any [supported format](#supported-source-formats) — `qcow2`, `raw`, `vmdk`, `vhd`/`vhdx`, or `vdi`. CDI converts it to the boot disk's native format on import, so no pre-conversion is needed. (Converting to `qcow2` first is optional — see [Converting images](#converting-images).)
+</Step>
+
+<Step title="Write a Dockerfile">
+  The image is built `FROM scratch` with the disk added to `/disk/`. The disk file must be readable by UID `107` (the `qemu` user that runs the VM), so set ownership with `--chown=107:107`:
+
+  ```dockerfile Dockerfile
+  FROM scratch
+  ADD --chown=107:107 my-disk.vmdk /disk/
+  ```
+
+  <Note>
+  Nothing else belongs in a containerDisk — no base OS, no entrypoint. The disk file alone is the payload (any supported format). Omitting `--chown=107:107` causes a permission error when KubeVirt tries to open the disk.
+  </Note>
+</Step>
+
+<Step title="Build and push to your registry">
+  Build for `linux/amd64` and push to your org's registry. Using the CLI:
+
+  ```bash
+  cpln image build --name my-vm-disk:v1 --push
+  ```
+
+  Or with Docker directly (registry path `ORG.registry.cpln.io/IMAGE:TAG`):
+
+  ```bash
+  cpln image docker-login
+  docker buildx build --platform=linux/amd64 \
+    -t my-org.registry.cpln.io/my-vm-disk:v1 .
+  docker push my-org.registry.cpln.io/my-vm-disk:v1
+  ```
+
+  See [Push Images to Registry](/guides/push-image) for authentication and CI/CD details.
+</Step>
+
+<Step title="Reference it in the VM workload">
+  Use the Control Plane image link format — `//image/<name>:<tag>` or `/org/<org>/image/<name>:<tag>`:
+
+  ```yaml YAML
+  spec:
+    type: vm
+    vm:
+      bootDisk:
+        source:
+          oci:
+            image: //image/my-vm-disk:v1
+  ```
+
+  Public containerDisks work too, e.g. `quay.io/containerdisks/ubuntu:22.04`.
+</Step>
+</Steps>
+
+<Tip>
+A VM's boot disk is always backed by a volume set, so `bootDisk.persist.volumeSet` is required alongside the source. See [Persistence](/reference/workload/vm#persistence-with-volume-sets).
+</Tip>
+
+## Option B — Boot from an HTTP(S) image
+
+Host the disk image at an HTTP(S) URL and let Control Plane import it. The import lands in a per‑replica persistent disk, so a boot volume set is **required**.
+
+<Steps>
+<Step title="Host the image">
+  Place the disk file (any [supported format](#supported-source-formats)) behind an `http(s)` URL the cluster can reach — an object store signed URL, a release asset, or a simple web server.
+</Step>
+
+<Step title="(Recommended) Compute a checksum">
+  ```bash
+  sha256sum my-disk.qcow2
+  ```
+</Step>
+
+<Step title="Reference it with a boot volume set">
+  ```yaml YAML
+  spec:
+    type: vm
+    vm:
+      bootDisk:
+        source:
+          http:
+            url: https://example.com/images/my-disk.qcow2
+            checksum: 'sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'
+        persist:
+          volumeSet: cpln://volumeset/my-vm-root
+  ```
+
+  On first boot the image is downloaded, verified against the checksum, converted to the disk's native format, and written to the replica's persistent disk. Subsequent boots reuse the imported disk.
+</Step>
+</Steps>
+
+<Info>
+Object‑store schemes (`s3://`, `gs://`) are not yet accepted directly — use a signed `http(s)` URL instead.
+</Info>
+
+## Converting images
+
+CDI converts disk formats for you on import, so this step is **optional** — reach for it only to shrink an image or to pay the conversion cost once at build time instead of on every import. `qemu-img` (from the `qemu-utils` package) converts between formats:
+
+<CodeGroup>
+
+```bash VMDK → qcow2
+qemu-img convert -p -O qcow2 disk.vmdk disk.qcow2
+```
+
+```bash VHD/VHDX → qcow2
+qemu-img convert -p -O qcow2 disk.vhdx disk.qcow2
+```
+
+```bash VDI → qcow2
+qemu-img convert -p -O qcow2 disk.vdi disk.qcow2
+```
+
+```bash raw → qcow2
+qemu-img convert -p -O qcow2 disk.img disk.qcow2
+```
+
+</CodeGroup>
+
+Inspect an image to confirm its format and virtual size:
+
+```bash
+qemu-img info disk.qcow2
+```
+
+<Tip>
+To shrink a sparse disk after conversion, run `virt-sparsify --in-place disk.qcow2` (from `libguestfs-tools`). Smaller images push and import faster.
+</Tip>
+
+### Building a containerDisk from a converted image
+
+Once converted, package and push it as in [Option A](#option-a--publish-an-oci-containerdisk):
+
+```dockerfile Dockerfile
+FROM scratch
+ADD --chown=107:107 disk.qcow2 /disk/
+```
+
+```bash
+cpln image build --name my-vm-disk:v1 --push
+```
+
+## Windows images
+
+Windows guests work the same way, with a few practicalities:
+
+- Set `spec.vm.guestOS: windows` so the correct DNS bootstrap is injected. See [Cloud-init & platform injection](/reference/workload/vm#cloud-init--platform-injection).
+- Windows disk images can be large; the [HTTP import](#option-b--boot-from-an-https-image) path avoids building a multi‑GB OCI image.
+- A generation‑1 (MBR) VHD boots with `firmware.bootloader: bios`; a UEFI image uses the default `efi`.
+- Ensure VirtIO drivers are present in the image so the guest sees its disk and network. Microsoft's evaluation VHDs typically need the VirtIO drivers slipstreamed in before upload.
+
+```yaml YAML
+spec:
+  type: vm
+  vm:
+    guestOS: windows
+    bootDisk:
+      source:
+        http:
+          url: https://example.com/images/windows-server-2022.vhd
+      persist:
+        volumeSet: cpln://volumeset/win-root
+    firmware:
+      bootloader: bios
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="VM Workloads" href="/reference/workload/vm" icon="server">
+    Configure and run the VM
+  </Card>
+  <Card title="Volume Sets" href="/reference/volumeset" icon="database">
+    Persist boot and data disks
+  </Card>
+  <Card title="Push Images" href="/guides/push-image" icon="upload">
+    Registry authentication and CI/CD
+  </Card>
+  <Card title="Create a Workload" href="/guides/create-workload" icon="cube">
+    Deploy from a manifest
+  </Card>
+</CardGroup>

--- a/mk8s/add-ons/kubevirt.mdx
+++ b/mk8s/add-ons/kubevirt.mdx
@@ -1,0 +1,122 @@
+---
+title: KubeVirt (VM Workloads)
+description: Enable VM workloads on a Managed Kubernetes (mk8s) cluster by installing KubeVirt and CDI, dedicating a node pool with hardware virtualization, and providing storage for boot disks.
+keywords: ['mk8s', 'kubevirt', 'cdi', 'vm workload', 'virtual machine', 'nested virtualization', 'kvm', 'nodeType vm', 'containerized data importer', 'bare metal']
+---
+
+## Overview
+
+The KubeVirt add-on lets an mk8s cluster run [VM workloads](/reference/workload/vm) (`spec.type: vm`). It installs the **KubeVirt** and **CDI** (Containerized Data Importer) operators and configures them for Control Plane: VM components are scoped to a dedicated VM node pool, the feature gates the platform needs are enabled, and boot-disk imports are wired through CDI.
+
+Once the add-on is enabled and at least one VM-capable node is present, the [location](/reference/location) reports `vm` in its capabilities and VM workloads can be scheduled there.
+
+## Supported providers
+
+Any provider whose nodes can expose hardware virtualization (`/dev/kvm`) — that means **bare-metal nodes** or instances with **nested virtualization** enabled. On AWS, nested virtualization is available on 8th-generation Intel instance types (`c8i`, `m8i`, `r8i` and variants); bare-metal (`.metal`) instances also work. On [generic / BYOK](/mk8s/generic) clusters, use bare-metal hosts or VMs that pass through KVM.
+
+## Requirements
+
+Setting up a cluster for VMs has four parts:
+
+<Steps>
+<Step title="A node pool with hardware virtualization">
+  VM nodes must be able to run KVM. On AWS, enable nested virtualization on a supported instance type via `cpuOptions.nestedVirtualization`; elsewhere use bare-metal / KVM-capable hosts.
+</Step>
+
+<Step title="Label (and ideally taint) the VM node pool">
+  KubeVirt's components and the VMs themselves are scoped to nodes labelled `cpln.io/nodeType: vm`. Add that label to the node pool. A matching taint `cpln.io/nodeType=vm:NoSchedule` is recommended to keep ordinary pods off the VM nodes — KubeVirt's VM placement tolerates it.
+</Step>
+
+<Step title="Enable the kubevirt add-on">
+  Add `kubevirt` to `addOns`. This installs the KubeVirt + CDI operators and their custom resources.
+</Step>
+
+<Step title="Provide storage for boot disks">
+  VM boot disks are imported by CDI into a PVC (backed by a [volume set](/reference/volumeset)), so the cluster needs a working CSI / default `StorageClass`. If your default StorageClass is **block-mode**, set `scratchSpaceStorageClass` to a filesystem-mode class so CDI has scratch space for imports.
+</Step>
+</Steps>
+
+<Note>
+The dedicated `cpln.io/nodeType: vm` node pool is what makes a node VM-capable. Without a labelled node, the KubeVirt components have nowhere to run and no VM workload can schedule.
+</Note>
+
+## How to enable
+
+### Cluster manifest (AWS example)
+
+A dedicated VM node pool with nested virtualization, the required label and taint, plus the add-on:
+
+```yaml YAML
+spec:
+  provider:
+    aws:
+      # ...existing provider config...
+      nodePools:
+        - name: vm
+          instanceTypes:
+            - c8i.xlarge          # 8th-gen Intel — supports nested virtualization
+          cpuOptions:
+            nestedVirtualization: true
+          labels:
+            cpln.io/nodeType: vm
+          taints:
+            - key: cpln.io/nodeType
+              value: vm
+              effect: NoSchedule
+          minSize: 1
+          maxSize: 4
+          bootDiskSize: 100
+          subnetIds:
+            - ${SUBNET_1}
+  addOns:
+    kubevirt: {}
+    nodeLocalDns: {}            # recommended (see DNS note below)
+```
+
+On **generic / BYOK** clusters, label and taint the node pool the same way and ensure the hosts expose `/dev/kvm`; nested-virtualization flags are provider-specific.
+
+### Console
+
+When creating or editing the cluster, open **Add-ons**, toggle on **KubeVirt**, and make sure you have a node pool labelled `cpln.io/nodeType: vm` on VM-capable instances.
+
+## Configuration
+
+| Option | Description |
+| :----- | :---------- |
+| `scratchSpaceStorageClass` | Filesystem-mode `StorageClass` CDI uses for import scratch space. **Required when the cluster default StorageClass is block-mode**; otherwise optional. |
+
+```yaml YAML
+addOns:
+  kubevirt:
+    scratchSpaceStorageClass: my-filesystem-sc
+```
+
+The add-on also configures the KubeVirt CR automatically — the `DataVolumes`, `BlockVolume`, and `Sidecar` feature gates, and the VM node placement — so you don't set these yourself.
+
+## DNS
+
+VM guests reach in-cluster services through a platform DNS forwarder. The [`nodeLocalDns`](/mk8s/add-ons) add-on (a per-node CoreDNS cache) is recommended alongside KubeVirt for reliable VM DNS. It is not strictly required — VM cloud-init falls back to TCP DNS (`options use-vc`) — but enabling it avoids edge cases.
+
+## Verify
+
+After the add-on reconciles and a VM node is ready:
+
+- The cluster's [location](/reference/location) reports `vm` under its workload-type capabilities.
+- A [VM workload](/reference/workload/vm) targeting this location schedules, imports its boot disk (watch `Importing boot disk: NN%` in the deployment status), and boots.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="VM Workloads" href="/reference/workload/vm" icon="server">
+    Configure and run a VM
+  </Card>
+  <Card title="Publishing VM Images" href="/guides/vm-images" icon="box">
+    Build boot images
+  </Card>
+  <Card title="Volume Sets" href="/reference/volumeset" icon="database">
+    Storage for boot and data disks
+  </Card>
+  <Card title="mk8s Overview" href="/mk8s/overview" icon="server">
+    Managed Kubernetes basics
+  </Card>
+</CardGroup>

--- a/reference/workload/types.mdx
+++ b/reference/workload/types.mdx
@@ -1,7 +1,7 @@
 ---
 title: Types
-description: "Comparison of workload types: Standard (default), Stateful (persistent storage), Cron (scheduled jobs), and Serverless (scale-to-zero). Capabilities matrix."
-keywords: ['workload kind comparison', 'pick workload type', 'cron job', 'batch job', 'lambda alternative', 'cloud run alternative', 'long running', 'web service', 'background job', 'scheduled task']
+description: "Comparison of workload types: Standard (default), Stateful (persistent storage), Cron (scheduled jobs), Serverless (scale-to-zero), and VM (virtual machines). Capabilities matrix."
+keywords: ['workload kind comparison', 'pick workload type', 'cron job', 'batch job', 'lambda alternative', 'cloud run alternative', 'long running', 'web service', 'background job', 'scheduled task', 'virtual machine', 'vm workload']
 ---
 
 |                                                                  | Standard | Stateful | Cron | Serverless |
@@ -299,3 +299,22 @@ Serverless workloads **must**:
 <Note>
 When a custom domain routes to a serverless workload, the `Host` header is set to the canonical endpoint, not the custom domain. The original domain is available in the `X-Forwarded-Host` header. See [Hostname Behavior](/reference/domain#hostname-behavior) for details.
 </Note>
+
+## VM
+
+VM workloads run a full virtual machine — its own guest OS and kernel — as a workload, while participating in the same service mesh, identity, networking, firewall, and observability as container workloads. Use them for Windows guests, custom kernels, appliance images, or lifting an existing VM image (VMDK/qcow2/VHD) onto Control Plane.
+
+VM workloads **may**:
+
+- Boot from an OCI containerDisk or an HTTP(S) disk image.
+- Persist the boot disk and attach additional data disks via [volume sets](/reference/volumeset).
+- Expose no endpoint, or serve traffic on multiple ports.
+- Run Linux or Windows guests.
+
+VM workloads **may not**:
+
+- Run more than one container entry (the single entry describes the VM).
+- Use a container `image`, `command`, or `args` — the guest comes from `spec.vm.bootDisk`.
+- Live‑migrate between nodes — a VM is **cold‑restarted** when its node is scaled down or replaced, so durable state must live on a volume set.
+
+See the dedicated [Virtual Machines](/reference/workload/vm) reference for the full configuration, lifecycle, networking, cloud-init, and persistence model, and [Publishing & converting VM images](/guides/vm-images) for building boot images.

--- a/reference/workload/vm.mdx
+++ b/reference/workload/vm.mdx
@@ -1,0 +1,404 @@
+---
+title: Virtual Machines
+description: Run full virtual machines as a workload type on Control Plane — inside the same service mesh, identity, networking, and observability as containers. Boot disks, persistence, cloud-init, and SSH.
+keywords: ['vm workload', 'virtual machine', 'kubevirt', 'windows vm', 'linux vm', 'containerdisk', 'boot disk', 'cloud-init', 'vm ssh', 'qemu', 'vmdk']
+---
+
+## Overview
+
+A **VM workload** (`spec.type: vm`) runs a full virtual machine — its own kernel, init system, and guest operating system — as a first‑class Control Plane workload. A VM is scheduled, networked, secured, and observed exactly like a [standard](/reference/workload/types#standard) container workload: it joins the [service mesh](/reference/workload/security), receives a [Universal Cloud Identity](/reference/identity), is governed by the same [firewall](/reference/workload/firewall) rules, and streams metrics and logs into the same observability stack.
+
+Use a VM workload when you need something a container cannot give you:
+
+- A "lift and shift" of an existing virtual machine image (VMDK, qcow2, VHD) without re‑platforming it into a container.
+- A specific guest OS or kernel (Windows, a custom Linux distribution, an appliance image).
+- Software that must run against real hardware abstractions (custom kernel modules, nested virtualization‑style tooling, legacy applications).
+
+<Note>
+VM workloads are backed by [KubeVirt](https://kubevirt.io/). You do not interact with KubeVirt directly — Control Plane translates your workload spec into the underlying VM definition, disk imports, networking, and mesh configuration.
+</Note>
+
+### A VM is just another workload
+
+Everything you already know about workloads applies to VMs:
+
+| Capability | Behavior for VMs |
+| :--------- | :--------------- |
+| **Service mesh / mTLS** | VM traffic flows through the Istio sidecar; workload‑to‑workload traffic is mutually authenticated with the workload's identity. |
+| **Service discovery** | Other workloads reach the VM at `<workload>.<gvc>.cpln.local`. The VM resolves in‑cluster names through a platform DNS forwarder (see [Cloud-init & platform injection](#cloud-init--platform-injection)). |
+| **Identity & cloud access** | The VM runs as the workload [identity](/reference/identity); cloud‑provider credentials are available to the guest via the same metadata endpoint used by containers. |
+| **Firewall** | The VM's inbound/outbound access is governed by [`firewallConfig`](/reference/workload/firewall), identical to other workloads. |
+| **Domains** | A [domain](/reference/domain) can route public traffic to a VM that exposes ports. |
+| **Metrics & logs** | Prometheus scraping, the serial console log, and the audit trail all work without extra configuration. |
+| **Autoscaling** | Manual replica counts via `minScale`/`maxScale`. (See [Scaling & lifecycle](#scaling--lifecycle).) |
+
+Because of this, most of the rest of the workload documentation — [firewall](/reference/workload/firewall), [identity](/reference/identity), [domains](/reference/domain), [custom metrics](/reference/workload/custom-metrics) — applies to VMs unchanged. This page covers what is **specific** to the VM type.
+
+## Lifecycle & disruption
+
+<Warning>
+**VMs can currently be disrupted.** A VM replica runs similar to a container workload on our platform. When we need to scale down, the VM can on occasion be **stopped and restarted elsewhere**. Control Plane does **not** offer live migration yet — there is no seamless, in‑memory hand‑off between nodes. A restart is a cold boot: in‑memory state is lost and the guest boots again from its disk. Data can be lost if the root disk is not configured with a volumeset.
+</Warning>
+
+Design your VM workloads to tolerate restarts:
+
+- **Persist anything you need to keep** on a [volume set](#persistence-with-volume-sets) — both the boot disk and any data disks. State written only to an ephemeral root disk does not survive rescheduling.
+- **Expect cold reboots** during node scale‑down, node upgrades, and cluster maintenance. When running with your own [Mk8s](/mk8s/overview) location you can control this in your nodepool settings.
+- **Make boot idempotent.** Your [cloud-init](#cloud-init--platform-injection) and guest services should converge to a working state on every boot, not just the first.
+
+This is the same operational model as a [stateful](/reference/workload/types#stateful) container workload: durable storage is explicit, and identity/storage are stable across restarts, but the running process itself is not pinned to a node.
+
+## Minimal example
+
+A single Ubuntu VM that installs and serves nginx on port 80, with a persisted boot disk:
+
+```yaml YAML
+kind: workload
+name: my-vm
+spec:
+  type: vm
+  containers:
+    - name: vm
+      cpu: 1000m
+      memory: 2Gi
+      ports:
+        - number: 80
+          protocol: http
+  vm:
+    bootDisk:
+      source:
+        oci:
+          image: quay.io/containerdisks/ubuntu:22.04
+      persist:
+        volumeSet: cpln://volumeset/my-vm-root
+    runStrategy: Always
+    cloudInit:
+      userData: |
+        #cloud-config
+        packages:
+          - nginx
+        runcmd:
+          - systemctl enable nginx
+          - systemctl start nginx
+  firewallConfig:
+    external:
+      inboundAllowCIDR: ['0.0.0.0/0']
+      outboundAllowCIDR: ['0.0.0.0/0']
+    internal:
+      inboundAllowType: same-gvc
+  defaultOptions:
+    autoscaling:
+      minScale: 1
+      maxScale: 1
+```
+
+<Note>
+A VM workload has exactly **one** container entry. It describes the VM's resources (`cpu`, `memory`), exposed `ports`, `metrics`, and attached `volumes`. The guest image comes from `spec.vm.bootDisk`, **not** from `containers[0].image` — setting a container image on a VM workload is rejected.
+</Note>
+
+## The container entry
+
+A VM workload reuses the [container](/reference/workload/containers) object for the VM's resource and networking surface, with VM‑specific rules:
+
+- **Exactly one container.** Multiple containers are rejected.
+- **`cpu` must be a whole number of cores** — a multiple of `1000m`, and at least `1000m`. The guest is presented this many vCPU cores. (`500m`, `1500m`, etc. are rejected.)
+- **`memory`** is the RAM presented to the guest (e.g. `2Gi`).
+- **`ports`** advertise the services the guest listens on, for service discovery and mesh routing. Use the `ports` array (`{ number, protocol }`); the singular `port` field is not valid for VMs.
+- **`metrics`** enables Prometheus scraping of a guest endpoint (see [Custom metrics](/reference/workload/custom-metrics)).
+- **`readinessProbe` / `livenessProbe`** support `tcpSocket` and `httpGet` only (`exec` and `grpc` are rejected).
+- **`volumes`** attach data disks to the VM (see [Persistence](#persistence-with-volume-sets)).
+- **Not valid for VMs:** `image`, `command`, `args`, `workingDir`, `lifecycle`, and the singular `port`. The guest OS owns process lifecycle.
+
+CPU topology (how those cores are presented) can optionally be shaped with `spec.vm.cpu.sockets` (1–32) and `spec.vm.cpu.threads` (1–8). By default the core count is derived from `containers[0].cpu`.
+
+## Boot disk
+
+`spec.vm.bootDisk` defines where the VM boots from. Exactly one **source** is required.
+
+### OCI containerDisk source
+
+The simplest path: package a disk image as an OCI image (a "containerDisk") and reference it. This is the recommended, most reproducible option.
+
+```yaml YAML
+bootDisk:
+  source:
+    oci:
+      image: quay.io/containerdisks/ubuntu:22.04
+```
+
+- The image may be a public containerDisk (e.g. `quay.io/containerdisks/ubuntu:22.04`), or one you publish to your org's [registry](/reference/image) and reference as `//image/<name>:<tag>` or `/org/<org>/image/<name>:<tag>`.
+- Cross‑org image links are rejected; the image must belong to the calling org or be a public registry reference.
+- `persist.volumeSet` is **required**. The boot disk is always a per‑replica PVC backed by a [volume set](#persistence-with-volume-sets); the image seeds it on first boot.
+
+See [Publishing & converting VM images](/guides/vm-images) for how to build and push a containerDisk and convert images from other formats.
+
+### HTTP(S) source
+
+Boot from a disk image hosted over HTTP(S). Control Plane imports it into a persistent disk on first boot, so `persist.volumeSet` is **required**.
+
+```yaml YAML
+bootDisk:
+  source:
+    http:
+      url: https://example.com/images/my-disk.qcow2
+      checksum: 'sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'
+    persist:
+      volumeSet: cpln://volumeset/my-vm-root
+```
+
+- The importer accepts common disk formats — **qcow2, raw, VMDK, VHD/VHDX, VDI, ISO** — and gzip/xz‑compressed variants, converting them to the disk's native format on import.
+- `checksum` is optional but recommended: `sha256:<hex>` or `sha512:<hex>`. The import is verified against it.
+- Import runs once per replica's persistent disk; subsequent boots reuse the imported disk.
+
+### Boot disk options
+
+| Field | Default | Notes |
+| :---- | :------ | :---- |
+| `bootDisk.source.oci.image` | — | OCI containerDisk reference. Mutually exclusive with `http`. |
+| `bootDisk.source.http.url` | — | HTTP(S) disk image URL. Requires `persist.volumeSet`. |
+| `bootDisk.source.http.checksum` | — | `sha256:<hex>` or `sha512:<hex>`. |
+| `bootDisk.persist.volumeSet` | — | **Required.** `cpln://volumeset/<name>`. The boot disk is always a per‑replica PVC. |
+| `bootDisk.bus` | `virtio` | Disk bus: `virtio`, `sata`, or `scsi`. |
+| `bootDisk.bootOrder` | `1` | Boot priority (1–16) when multiple bootable disks exist. |
+
+<Info>
+Object‑store sources (`s3://`, `gs://`) and snapshot restores are not yet exposed. To boot from an object store, use a signed `http(s)` URL. To boot from an existing volume set snapshot, use the volume set [`restoreVolume`](/reference/volumeset) command.
+</Info>
+
+## Persistence with volume sets
+
+VM storage is durable only when it is backed by a [volume set](/reference/volumeset). A volume set provisions one PVC per replica and keeps its contents across reschedules. There are two distinct uses.
+
+### Persisting the boot disk
+
+Set `bootDisk.persist.volumeSet` to make the root disk durable. The image source seeds the disk the first time; after that, the guest's changes to the root filesystem survive restarts and node moves.
+
+```yaml YAML
+vm:
+  bootDisk:
+    source:
+      oci:
+        image: quay.io/containerdisks/ubuntu:22.04
+    persist:
+      volumeSet: cpln://volumeset/my-vm-root
+```
+
+The disk size comes from the volume set's `initialCapacity` (defaulting to `20Gi` if the boot volume set is omitted entirely), and the storage class comes from the volume set's performance class.
+
+### Attaching additional data disks
+
+Additional volumes are attached to the VM as **block devices** through the container's `volumes` list. Each entry needs a `uri` and a `name`; the `name` identifies the device inside the guest.
+
+```yaml YAML
+containers:
+  - name: vm
+    cpu: 1000m
+    memory: 2Gi
+    volumes:
+      - uri: cpln://volumeset/my-vm-data
+        name: data
+        bus: virtio
+        serial: DATA001
+```
+
+<Warning>
+For VMs, a data volume is presented to the guest as a **raw block device** (e.g. `/dev/vdb`), **not** auto‑mounted at a path. This is different from container workloads, where a volume's `path` mounts it into the filesystem. The guest is responsible for partitioning, formatting, and mounting the device — typically once, then persisted on the device itself. Use the `serial` field to find the device reliably at `/dev/disk/by-id/...` and mount it from cloud-init.
+</Warning>
+
+Data‑disk volume fields:
+
+| Field | Default | Notes |
+| :---- | :------ | :---- |
+| `uri` | — | `cpln://volumeset/<name>` for a data disk, or `cpln://secret/<name>` to surface a [secret](/reference/secret) as a disk. |
+| `name` | — | Required. Device name inside the guest. |
+| `bus` | `virtio` | `virtio`, `sata`, or `scsi`. |
+| `serial` | — | Disk serial, surfaced to the guest for stable `by-id` lookup. |
+| `cdrom` | `false` | Attach as a read‑only CD‑ROM (useful for ISO/secret payloads). |
+| `bootOrder` | — | Optional boot priority if the disk is bootable. |
+
+Example: format and mount a data disk on first boot, idempotently, from cloud-init:
+
+```yaml YAML
+cloudInit:
+  userData: |
+    #cloud-config
+    runcmd:
+      - |
+        DEV=/dev/disk/by-id/*DATA001*
+        if ! blkid $DEV; then mkfs.ext4 -L data $DEV; fi
+        mkdir -p /mnt/data
+        echo 'LABEL=data /mnt/data ext4 defaults,nofail 0 2' >> /etc/fstab
+        mount -a
+```
+
+Volume set [considerations](/reference/workload/types#considerations-when-using-persistent-storage) apply: they are GVC‑scoped, a volume set is used by at most one workload (unless [shared](/reference/volumeset#shared-file-system)), and the URI must begin with `cpln://volumeset/`.
+
+## Networking & ports
+
+A VM is subject to the same [firewall](/reference/workload/firewall) and service‑mesh policy as any other workload.
+
+- **Exposed ports** come from `containers[0].ports`. These are the ports other workloads, domains, and probes can reach, and they flow through the service mesh.
+- **Port 22 (SSH)** is always reachable internally by Control Plane — SSH authenticates with its own certificate trust (see [SSH access](#ssh-access)).
+- **A single network interface** is supported (`spec.vm.networks` accepts one entry, default name `default`).
+- **Service discovery:** other workloads reach the VM at `<workload>.<gvc>.cpln.local` on its exposed ports, exactly like a container workload.
+
+<Tip>
+Inside the guest, Control Plane's internal service names (`*.cpln.local`) resolve through the platform DNS forwarder. On some Linux guests, large `cpln.local` answers resolve more reliably over TCP — adding `options use-vc` to `/etc/resolv.conf` from cloud-init forces TCP and avoids truncation issues.
+</Tip>
+
+## Connecting with RDP (Windows)
+
+A Windows VM has no public RDP endpoint by default. Use the [`cpln port-forward`](/guides/cli/cpln-port-forward) command to open a secure tunnel from your machine to the VM's RDP port (3389), then point any RDP client at `localhost`. This requires `connect` permission on the workload and never exposes RDP publicly.
+
+<Steps>
+<Step title="Enable RDP in the guest">
+  Ensure the Windows image has Remote Desktop enabled, the firewall allows it, and you have a user to log in as. You can do this in the image, or from [cloud-init](#cloud-init--platform-injection):
+
+  ```yaml YAML
+  vm:
+    guestOS: windows
+    cloudInit:
+      userData: |
+        #ps1_sysnative
+        Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'fDenyTSConnections' -Value 0
+        Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+        net user admin 'YourStrongPassword!' /add
+        net localgroup administrators admin /add
+  ```
+</Step>
+
+<Step title="Start the tunnel">
+  Forward a local port to 3389 on a VM replica. The port does **not** need to be listed in the workload's `ports` — `cpln port-forward` reaches the guest directly:
+
+  ```bash
+  cpln port-forward my-windows-vm 3389:3389 --gvc my-gvc --location aws-us-west-2
+  ```
+
+  Use a different local port (e.g. `13389:3389`) if 3389 is busy on your machine, and `--replica` to target a specific VM.
+</Step>
+
+<Step title="Connect your RDP client">
+  Point any RDP client at the local end of the tunnel and log in with the guest credentials:
+
+  ```text
+  localhost:3389
+  ```
+
+  On macOS use the **Windows App** (formerly Microsoft Remote Desktop); on Windows use **mstsc**; on Linux use a client such as **Remmina** or **xfreerdp**:
+
+  ```bash
+  xfreerdp /v:localhost:3389 /u:admin
+  ```
+</Step>
+</Steps>
+
+<Note>
+The same pattern works for any TCP service the guest listens on — `cpln port-forward` to the port and connect locally. The port does not need to be listed in the workload's `ports`; that list only governs in‑cluster service‑mesh traffic.
+</Note>
+
+## Cloud-init & platform injection
+
+`spec.vm.cloudInit` provides the guest's [cloud-init](https://cloudinit.readthedocs.io/) user‑data. Control Plane **merges** your content with a small amount of platform configuration so the VM works inside the mesh — your cloud-init is preserved and runs alongside the injected pieces.
+
+### Providing your own cloud-init
+
+Supply exactly one of:
+
+| Field | Use when |
+| :---- | :------- |
+| `cloudInit.userData` | Inline cloud-init (max 16 KiB). Convenient for non‑sensitive config. Not encrypted at rest in the data‑service. |
+| `cloudInit.userDataBase64` | Same as `userData`, base64‑encoded (max ~22 KB). |
+| `cloudInit.userDataSecret` | A [secret](/reference/secret) holding the user‑data (key `userdata` or `user-data`). Use this for sensitive payloads. |
+
+```yaml YAML
+cloudInit:
+  userDataSecret: //secret/my-vm-cloudinit
+```
+
+### What the platform injects
+
+On top of your user‑data, Control Plane adds (and keeps under its control):
+
+- **Network configuration.** A name‑based interface match with DNS pointed at the in‑cluster forwarder. This is platform‑managed and not user‑overridable: KubeVirt re‑randomizes the VM's MAC on every restart, and a MAC‑pinned network config would stall the guest after a reschedule.
+- **In‑cluster DNS.** So the guest can resolve `*.cpln.local` and other cluster service names, and so cross‑location ([wormhole](/reference/workload/general)) peers are reachable.
+- **Service‑mesh interception.** The VM's pod joins the Istio mesh; traffic on the exposed ports is mutually authenticated with the workload identity.
+- **SSH trust.** A platform SSH certificate authority is trusted by the guest and a platform user is provisioned, enabling certificate‑based SSH (see below). This is re‑applied on every boot so it survives image and platform updates.
+- **(Windows only)** A DNS bootstrap script that points the guest's adapters at the in‑cluster resolver and sets the cluster search suffixes.
+
+Set `spec.vm.guestOS` to `linux` (default) or `windows` so the correct per‑OS injection is applied.
+
+### SSH access
+
+There are two ways to get your SSH keys into the guest, in addition to the platform's certificate trust:
+
+- **`cloudInit.sshPublicKeySecrets`** — a list (max 8) of [secrets](/reference/secret) holding public keys, injected for the default user.
+- **`spec.vm.accessCredentials`** — per‑user key delivery. Each entry maps a key secret to one or more guest `users`, delivered via `qemuGuestAgent` (default) or `configDrive`.
+
+```yaml YAML
+vm:
+  accessCredentials:
+    - sshPublicKeySecret: //secret/team-ssh-keys
+      users: [ubuntu, ops]
+      deliveryMethod: qemuGuestAgent
+```
+
+<Note>
+`cpln workload connect` and `cpln workload exec` log into the guest as the platform `cpln` user using a CA‑signed certificate — both the user and the trusted CA come from the platform's cloud‑init injection. They therefore require a **cloud‑init‑capable guest** (standard Linux cloud images, or Windows with cloudbase‑init). Minimal images that don't process cloud‑init (e.g. CirrOS) won't accept these connections; reach those over the serial console instead.
+</Note>
+
+## Scaling & lifecycle
+
+- **Replicas** are controlled by `defaultOptions.autoscaling.minScale` / `maxScale`. Each replica is an independent VM with its own persistent disk(s).
+- **`runStrategy`** controls the power state:
+  - `Always` (default) — keep the VM running; restart it if it stops.
+  - `RerunOnFailure` — restart only on non‑zero exit.
+  - `Manual` — start/stop is driven explicitly.
+  - `Halted` — defined but powered off. Requires `minScale: 0`.
+- **`clock.timezone`** sets the guest clock (default `UTC`).
+- **`hostname`** / **`subdomain`** set the guest's hostname and DNS subdomain.
+- **`firmware`** selects the bootloader (`efi` default, or `bios`) and optional SMBIOS identifiers (`uuid`, `serial`, `smbios.*`).
+
+<Info>
+**Secure Boot is not yet available.** `firmware.secureBoot` is rejected by validation. It requires persistent EFI NVRAM, which is not yet provisioned; without it a Secure Boot guest would lose its boot state on reboot.
+</Info>
+
+## Settings reference
+
+All fields below live under `spec.vm`. In the **Req.** column, **✓** means required, **—** optional, and **Cond.** conditionally required (see Notes). A VM must have a boot source — exactly one of `bootDisk.source.oci.image` or `bootDisk.source.http.url`.
+
+| Field | Req. | Type | Default | Notes |
+| :---- | :--: | :--- | :------ | :---- |
+| `bootDisk.source.oci.image` | Cond. | string | — | OCI containerDisk reference. Exactly one boot source; XOR with `http`. |
+| `bootDisk.source.http.url` | Cond. | string | — | HTTP(S) disk URL. Requires `persist.volumeSet`. |
+| `bootDisk.source.http.checksum` | — | string | — | `sha256:<hex>` / `sha512:<hex>`. |
+| `bootDisk.persist.volumeSet` | ✓ | string | — | `cpln://volumeset/<name>`. The boot disk is always a per‑replica PVC. |
+| `bootDisk.bus` | — | enum | `virtio` | `virtio` / `sata` / `scsi`. |
+| `bootDisk.bootOrder` | — | int | `1` | 1–16. |
+| `cpu.sockets` | — | int | — | 1–32. Cores derive from container `cpu`. |
+| `cpu.threads` | — | int | — | 1–8. |
+| `firmware.bootloader` | — | enum | `efi` | `efi` / `bios`. |
+| `firmware.uuid` | — | string | generated | Fixed SMBIOS UUID (v4). |
+| `firmware.serial` | — | string | — | SMBIOS serial. |
+| `firmware.smbios.*` | — | string | — | `manufacturer`, `product`, `version`, `sku`, `family`. |
+| `guestOS` | — | enum | `linux` | `linux` / `windows`. |
+| `networks[0].name` | — | string | `default` | Single interface; masquerade only. |
+| `cloudInit.userData` | — | string | — | Inline cloud-init (≤16 KiB). XOR with the other `userData*`. |
+| `cloudInit.userDataBase64` | — | string | — | Base64 cloud-init. |
+| `cloudInit.userDataSecret` | — | secret link | — | Secret with `userdata` / `user-data`. |
+| `cloudInit.sshPublicKeySecrets` | — | secret link[] | — | Up to 8. |
+| `accessCredentials[].sshPublicKeySecret` | Cond. | secret link | — | Required when an `accessCredentials` entry is present. |
+| `accessCredentials[].users` | Cond. | string[] | — | Required per entry. 1–16 guest users. |
+| `accessCredentials[].deliveryMethod` | — | enum | `qemuGuestAgent` | `qemuGuestAgent` / `configDrive`. |
+| `runStrategy` | — | enum | `Always` | `Always` / `RerunOnFailure` / `Manual` / `Halted`. |
+| `clock.timezone` | — | string | `UTC` | e.g. `America/New_York`. |
+| `hostname` | — | string | — | `[a-z0-9-]`, ≤63. |
+| `subdomain` | — | string | — | `[a-z0-9-]`, ≤63. |
+
+## Related
+
+- [Publishing & converting VM images](/guides/vm-images)
+- [Run VM workloads on your own mk8s cluster](/mk8s/add-ons/kubevirt)
+- [Volume sets](/reference/volumeset)
+- [Workload firewall](/reference/workload/firewall)
+- [Workload identity](/reference/identity)
+- [Custom metrics](/reference/workload/custom-metrics)


### PR DESCRIPTION
Adds documentation for the new VM workload type.

- **reference/workload/vm.mdx** — VM workload reference: overview, lifecycle/disruption (no live migration yet), the container entry, boot disk (OCI/HTTP sources), persistence with volume sets, networking & ports, RDP via `cpln port-forward`, cloud-init injection, SSH access, scaling, and a full settings reference.
- **guides/vm-images.mdx** — publishing boot images: OCI containerDisks, HTTP(S) import, and format conversion (CDI converts vmdk/vhd/etc. on import; pre-conversion is optional).
- **mk8s/add-ons/kubevirt.mdx** — enabling VM workloads on an mk8s cluster (kubevirt add-on, VM node pool label/taint, hardware virtualization, storage).
- **reference/workload/types.mdx**, **concepts/workload.mdx** — add VM to the workload types, linking to the reference.
- **docs.json** — register the new pages in navigation.
