### PR TITLE
docs(cli): clarify npm install/upgrade and add Node/prefix troubleshooting

### DIFF
--- a/cli-reference/get-started/quickstart.mdx
+++ b/cli-reference/get-started/quickstart.mdx
@@ -12,12 +12,12 @@ Follow these steps to install, authenticate, and start using the Control Plane C
 
   <Tabs>
     <Tab title="npm">
-      Install via npm if you have Node.js **version 16** or later installed.
+      Install via npm if you have Node.js **version 18** or later installed.
       ```bash
       npm install -g @controlplane/cli
       ```
       <Note>
-      Requires [Node.js](https://nodejs.org/en/download/) version 16+.
+      Requires [Node.js](https://nodejs.org/en/download/) version 18+ (an active LTS release is recommended).
       </Note>
       For detailed instructions, see [Installation](/cli-reference/installation).
     </Tab>

--- a/cli-reference/using-cli/troubleshooting.mdx
+++ b/cli-reference/using-cli/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: Solutions to common Control Plane CLI issues.
-keywords: ['cli error', 'debug cli', 'verbose flag', 'cpln debug', 'auth error', 'connection error', 'cli not working', 'version mismatch', '401 unauthorized', 'proxy error', 'token expired']
+keywords: ['cli error', 'debug cli', 'verbose flag', 'cpln debug', 'auth error', 'connection error', 'cli not working', 'version mismatch', '401 unauthorized', 'proxy error', 'token expired', 'nvm', 'npm prefix', 'node version', 'homebrew node', 'uninstall cpln', 'up to date', 'global package']
 ---
 
 Quick solutions for common problems when using the Control Plane CLI.
@@ -85,46 +85,158 @@ Quick solutions for common problems when using the Control Plane CLI.
 </Accordion>
 
 <Accordion title="Permission denied when installing">
-  **Problem**: Installation fails with permission errors.
+  **Problem**: `npm install -g` fails with `EACCES` permission errors.
+
+  **Solution (recommended)**: Install Node through a version manager such as [nvm](https://github.com/nvm-sh/nvm), [fnm](https://github.com/Schniz/fnm), or [Volta](https://volta.sh/). These install Node and its global package directory inside your home folder, so global installs never need `sudo` and you avoid the permission problem entirely.
+
+  ```bash
+  # Example with nvm
+  nvm install --lts
+  nvm use --lts
+  npm install -g @controlplane/cli
+  ```
+
+  <Warning>
+  **Do not combine a custom `npm config set prefix` with a Node version manager.** nvm, fnm, and Volta manage the global prefix per Node version themselves. Setting your own `prefix` (the older "install without sudo" trick below) puts global packages in a *second* location that the version manager doesn't track — which leads to `cpln` installs that linger after uninstall and `npm` commands that silently target the wrong place. See the accordion **"The CLI lingers after uninstall, or npm targets the wrong location"** below.
+  </Warning>
+
+  <Accordion title="Legacy: custom prefix without sudo (only if you are NOT using nvm/fnm/Volta)">
+    Use `sudo` (not recommended) or configure a custom npm prefix:
+
+    ```bash
+    # Configure npm prefix
+    mkdir -p ~/.npm-global
+    npm config set prefix '~/.npm-global'
+    ```
+
+    Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
+    ```bash
+    export PATH=~/.npm-global/bin:$PATH
+    ```
+
+    Reload and reinstall:
+    ```bash
+    source ~/.bashrc  # or ~/.zshrc
+    npm install -g @controlplane/cli
+    ```
+
+    <Note>
+    If you later adopt nvm/fnm/Volta, undo this first: `npm config delete prefix`, then remove the `export PATH=~/.npm-global/bin:$PATH` line from your shell profile. Otherwise the two prefixes will conflict.
+    </Note>
+  </Accordion>
+
+  **Binary install alternative**: Move the binary to a user-writable directory instead of `/usr/local/bin`:
+
+  ```bash
+  mkdir -p ~/bin
+  mv cpln ~/bin/
+  ```
+
+  Add `~/bin` to your PATH in `~/.bashrc` or `~/.zshrc`:
+  ```bash
+  export PATH="$HOME/bin:$PATH"
+  ```
+</Accordion>
+
+<Accordion title="The CLI lingers after uninstall, or npm targets the wrong location">
+  **Problem**: One or more of the following:
+
+  - `npm uninstall -g @controlplane/cli` prints `up to date` (or `removed 0 packages`), yet `cpln` still runs.
+  - `npm update -g @controlplane/cli` reports success but `cpln --version` doesn't change.
+  - After installing, `cpln: command not found` in a new terminal even though the install succeeded.
+
+  **Cause**: You have more than one Node on your machine — commonly a [version manager](https://github.com/nvm-sh/nvm) (nvm/fnm/Volta), a [Homebrew](https://brew.sh/) Node, and/or a custom `~/.npm-global` prefix. `cpln` is a `#!/usr/bin/env node` script, so it runs under whichever `node` is **first on your PATH**, and `npm -g` reads/writes the **prefix of the specific `npm` you invoke**. When those disagree, `npm` manages one location while `cpln` actually lives in another — so uninstall and update appear to do nothing.
+
+  **Step 1 — See what you actually have.** Run every line; mismatches are the diagnosis:
+
+  ```bash
+  which -a node npm cpln          # every copy on PATH, in priority order
+  node -v                         # which node actually runs
+  npm -v
+  npm config get prefix           # where THIS npm installs global packages
+  readlink -f "$(command -v cpln)" # where the cpln on PATH physically lives
+  ```
+
+  If `npm config get prefix` does **not** contain the same directory as the resolved `cpln` path, that is exactly why uninstall/update is a no-op — `npm` is pointed at the wrong prefix.
+
+  **Step 2 — Remove every stale copy.** Uninstall from each prefix that has it, then delete any leftover symlink directly:
+
+  ```bash
+  # Run the uninstall once per Node/prefix that contains it.
+  npm uninstall -g @controlplane/cli
+
+  # If a cpln still resolves, remove the orphaned symlink + package by hand:
+  rm -f "$(command -v cpln)" "$(command -v docker-credential-cpln 2>/dev/null)"
+  hash -r                          # clear the shell's cached command paths (zsh/bash)
+  which -a cpln || echo "cpln fully removed"
+  ```
+
+  <Tip>
+  A custom-prefix install lives at `~/.npm-global/{bin,lib/node_modules}/@controlplane`. A Homebrew install lives under `/opt/homebrew/lib/node_modules` (Apple Silicon) or `/usr/local/lib/node_modules` (Intel). An nvm install lives under `~/.nvm/versions/node/<version>/lib/node_modules`.
+  </Tip>
+
+  **Step 3 — Reinstall into the prefix you intend to use.** Whatever `node` you want must be first on PATH *before* you install, so the install lands where you'll run it:
+
+  ```bash
+  nvm use --lts          # or: nvm use <version> — selects the node you want
+  npm install -g @controlplane/cli
+  cpln --version         # confirm it runs from the expected location
+  readlink -f "$(command -v cpln)"
+  ```
+</Accordion>
+
+<Accordion title="cpln disappears or reverts version after switching Node (nvm/fnm)">
+  **Problem**: `cpln` worked, then vanished or reverted to an old version after running `nvm use`, `nvm install`, or opening a new shell.
+
+  **Cause**: Version managers keep a **separate global package set per Node version**. Installing `@controlplane/cli` under Node 20 does not make it available under Node 22, and switching versions switches which `cpln` (if any) is on PATH.
 
   **Solutions**:
 
-  <Tabs>
-    <Tab title="npm">
-      Use `sudo` (not recommended) or configure npm to install globally without sudo:
+  1. Install the CLI under the Node version you actually use, then pin that version as the default so new shells use it:
+     ```bash
+     nvm alias default <version>     # e.g. nvm alias default 22
+     ```
 
-      ```bash
-      # Configure npm prefix
-      mkdir -p ~/.npm-global
-      npm config set prefix '~/.npm-global'
-      ```
+  2. When upgrading Node, carry your global packages forward:
+     ```bash
+     nvm install <new-version> --reinstall-packages-from=<old-version>
+     # or, after installing the new version:
+     nvm reinstall-packages <old-version>
+     ```
 
-      Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
-      ```bash
-      export PATH=~/.npm-global/bin:$PATH
-      ```
+  3. Verify after switching:
+     ```bash
+     node -v && cpln --version
+     ```
+</Accordion>
 
-      Reload and reinstall:
-      ```bash
-      source ~/.bashrc  # or ~/.zshrc
-      npm install -g @controlplane/cli
-      ```
-    </Tab>
+<Accordion title="A version manager is installed but Homebrew's Node keeps winning">
+  **Problem**: You installed nvm/fnm, but `which node` still points at `/opt/homebrew/bin/node` (or `/usr/local/bin/node`), so your version manager's Node — and the `cpln` installed under it — is ignored.
 
-    <Tab title="Binary">
-      Move the binary to a user-writable directory instead of `/usr/local/bin`:
+  **Cause**: PATH order. Your shell startup file loads the version manager, but a later line **re-prepends** Homebrew's `bin` to PATH (for example `export PATH="/opt/homebrew/bin:$PATH"`, or Homebrew's `shellenv`), so Homebrew's `node` ends up ahead of the version manager's.
 
-      ```bash
-      mkdir -p ~/bin
-      mv cpln ~/bin/
-      ```
+  **Solution**: Make the version manager activate **last** in your `~/.zshrc` / `~/.bashrc`, after any line that prepends Homebrew. With nvm, the robust form is to activate the default version and push its bin to the front of PATH at the end of the file:
 
-      Add `~/bin` to your PATH in `~/.bashrc` or `~/.zshrc`:
-      ```bash
-      export PATH="$HOME/bin:$PATH"
-      ```
-    </Tab>
-  </Tabs>
+  ```bash
+  # ... all other PATH exports, including Homebrew, above this ...
+
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  # Activate the default Node and ensure it wins over Homebrew on PATH.
+  # (nvm use swaps the version in place and will not re-front itself.)
+  command -v nvm >/dev/null && nvm use default --silent >/dev/null 2>&1
+  [ -n "$NVM_BIN" ] && export PATH="$NVM_BIN:$PATH"
+  ```
+
+  Open a new terminal and confirm:
+  ```bash
+  which node          # should be under ~/.nvm/versions/node/...
+  node -v
+  ```
+
+  <Note>
+  Keeping Homebrew's Node installed is fine — it just must not shadow the version you intend to use. If you don't need it, `brew uninstall node` (check first that no other Homebrew formula depends on it).
+  </Note>
 </Accordion>
 </AccordionGroup>
 

--- a/quickstart/quick-start-1-deploy-workload.mdx
+++ b/quickstart/quick-start-1-deploy-workload.mdx
@@ -134,7 +134,7 @@ Choose your preferred installation method:
 npm install -g @controlplane/cli
 ```
 
-<Note>Requires [Node.js](https://nodejs.org/en/download/) version 16+.</Note>
+<Note>Requires [Node.js](https://nodejs.org/en/download/) version 18+ (an active LTS release is recommended).</Note>
 
 For other installation options, see [Installation](/cli-reference/installation).
 

--- a/quickstart/quick-start-2-deploy-application.mdx
+++ b/quickstart/quick-start-2-deploy-application.mdx
@@ -31,7 +31,7 @@ The CLI is required to build and push images to your org's private registry at C
 npm install -g @controlplane/cli
 ```
 
-<Note>Requires [Node.js](https://nodejs.org/en/download/) version 16+.</Note>
+<Note>Requires [Node.js](https://nodejs.org/en/download/) version 18+ (an active LTS release is recommended).</Note>
 
 </Tab>
 <Tab title="Homebrew">


### PR DESCRIPTION
## What

Clarifies the npm install/upgrade guidance and adds troubleshooting for the multi-Node / multi-prefix problems that cause `cpln` to linger after uninstall or `npm` to silently target the wrong location.

## Why

The "Permission denied when installing" tip recommended `npm config set prefix ~/.npm-global` with no warning that it conflicts with nvm/fnm/Volta. That custom prefix is the leading cause of: `npm uninstall -g` printing `up to date` while `cpln` still runs, `npm update -g` being a no-op, and `cpln: command not found` in fresh shells.

## Changes

- **`cli-reference/using-cli/troubleshooting.mdx`**
  - Recommend a Node version manager (nvm/fnm/Volta) as the primary no-sudo install path.
  - Demote the custom-prefix trick to a "Legacy" accordion with undo steps + a warning against combining it with a version manager.
  - New accordions: *CLI lingers after uninstall / npm targets wrong location* (env-node + per-prefix-npm mechanism, diagnose-and-fix runbook); *cpln disappears after switching Node version*; *version manager shadowed by Homebrew node on PATH*.
- **Node minimum 16 → 18+** (active-LTS recommended) on non-generated pages: `cli-reference/get-started/quickstart.mdx`, `quickstart/quick-start-1-deploy-workload.mdx`, `quickstart/quick-start-2-deploy-application.mdx`. The package declares no `engines`, so this is editorial; Node 16 is EOL.

## Follow-up (not in this PR)

`cli-reference/installation.mdx` and `cli-reference/ci-cd-development/container-image.mdx` are generated by the `docs-cli-generator` sibling repo and must be updated there to (a) mirror the npm install/upgrade guidance and (b) apply the Node 16 → 18 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)