### PR TITLE
Document VM env injection and volume field changes

### DIFF
--- a/reference/workload/vm.mdx
+++ b/reference/workload/vm.mdx
@@ -107,6 +107,7 @@ A VM workload reuses the [container](/reference/workload/containers) object for 
 - **`metrics`** enables Prometheus scraping of a guest endpoint (see [Custom metrics](/reference/workload/custom-metrics)).
 - **`readinessProbe` / `livenessProbe`** support `tcpSocket` and `httpGet` only (`exec` and `grpc` are rejected).
 - **`volumes`** attach data disks to the VM (see [Persistence](#persistence-with-volume-sets)).
+- **`env`** is injected into the guest OS (see [Environment variables](#environment-variables)).
 - **Not valid for VMs:** `image`, `command`, `args`, `workingDir`, `lifecycle`, and the singular `port`. The guest OS owns process lifecycle.
 
 CPU topology (how those cores are presented) can optionally be shaped with `spec.vm.cpu.sockets` (1–32) and `spec.vm.cpu.threads` (1–8). By default the core count is derived from `containers[0].cpu`.
@@ -198,11 +199,10 @@ containers:
       - uri: cpln://volumeset/my-vm-data
         name: data
         bus: virtio
-        serial: DATA001
 ```
 
 <Warning>
-For VMs, a data volume is presented to the guest as a **raw block device** (e.g. `/dev/vdb`), **not** auto‑mounted at a path. This is different from container workloads, where a volume's `path` mounts it into the filesystem. The guest is responsible for partitioning, formatting, and mounting the device — typically once, then persisted on the device itself. Use the `serial` field to find the device reliably at `/dev/disk/by-id/...` and mount it from cloud-init.
+For VMs, a data volume is presented to the guest as a **raw block device** (e.g. `/dev/vdb`), **not** auto‑mounted at a path. This is different from container workloads, where a volume's `path` mounts it into the filesystem. The guest is responsible for partitioning, formatting, and mounting the device — typically once, then persisted on the device itself. The disk's serial is set to its volume `name`, so you can find it reliably at `/dev/disk/by-id/*<name>*` and mount it from cloud-init.
 </Warning>
 
 Data‑disk volume fields:
@@ -210,11 +210,9 @@ Data‑disk volume fields:
 | Field | Default | Notes |
 | :---- | :------ | :---- |
 | `uri` | — | `cpln://volumeset/<name>` for a data disk, or `cpln://secret/<name>` to surface a [secret](/reference/secret) as a disk. |
-| `name` | — | Required. Device name inside the guest. |
-| `bus` | `virtio` | `virtio`, `sata`, or `scsi`. |
-| `serial` | — | Disk serial, surfaced to the guest for stable `by-id` lookup. |
-| `cdrom` | `false` | Attach as a read‑only CD‑ROM (useful for ISO/secret payloads). |
-| `bootOrder` | — | Optional boot priority if the disk is bootable. |
+| `name` | — | Required. Device name inside the guest; also used as the disk serial for stable `by-id` lookup. |
+| `bus` | `virtio` | `virtio`, `sata`, or `scsi`. A `cpln://secret/` volume on `sata` or `scsi` is presented as a read‑only CD‑ROM (`/dev/sr0`); on `virtio` it's a block device. |
+| `bootOrder` | — | Optional boot priority if the disk is bootable. Not valid for secret volumes — a secret is not bootable. |
 
 Example: format and mount a data disk on first boot, idempotently, from cloud-init:
 
@@ -224,7 +222,7 @@ cloudInit:
     #cloud-config
     runcmd:
       - |
-        DEV=/dev/disk/by-id/*DATA001*
+        DEV=/dev/disk/by-id/*data*
         if ! blkid $DEV; then mkfs.ext4 -L data $DEV; fi
         mkdir -p /mnt/data
         echo 'LABEL=data /mnt/data ext4 defaults,nofail 0 2' >> /etc/fstab
@@ -232,6 +230,21 @@ cloudInit:
 ```
 
 Volume set [considerations](/reference/workload/types#considerations-when-using-persistent-storage) apply: they are GVC‑scoped, a volume set is used by at most one workload (unless [shared](/reference/volumeset#shared-file-system)), and the URI must begin with `cpln://volumeset/`.
+
+## Environment variables
+
+`containers[0].env` is delivered into the guest OS. A VM has no container process to set variables on, so Control Plane writes them through the guest's init system at boot:
+
+- **Linux** (cloud-init): to `/etc/cpln/environment` (reference it from a systemd unit with `EnvironmentFile=`), appended to `/etc/environment` for login shells, and exported from `/etc/profile.d/cpln-env.sh`.
+- **Windows** (cloudbase-init): set machine‑wide, so services and new sessions inherit them.
+
+Control Plane also provides `CPLN_GVC`, `CPLN_LOCATION`, `CPLN_ORG`, `CPLN_PROVIDER`, and `CPLN_WORKLOAD`.
+
+Values that reference a [secret](/reference/secret) (`cpln://secret/<name>` or `cpln://secret/<name>.<key>`) are resolved to the secret's value, provided the workload identity has access to it. Manifest references (`cpln://reference/...`) are not supported for VMs — there is no pod for the guest to read them from. Multi‑line values are skipped; deliver those as a [secret](/reference/secret) disk instead.
+
+<Note>
+Env is baked into the guest at boot, so changes take effect when the VM next rolls to a new version and reboots — not live.
+</Note>
 
 ## Networking & ports
 


### PR DESCRIPTION
Updates `reference/workload/vm.mdx` to reflect recent VM workload improvements.

### Environment variables
- New **Environment variables** section + container-entry bullet documenting that `containers[0].env` is injected into the guest:
  - Linux (cloud-init): `/etc/cpln/environment` (systemd `EnvironmentFile=`), `/etc/environment`, `/etc/profile.d/cpln-env.sh`
  - Windows (cloudbase-init): set machine-wide
  - Platform defaults (`CPLN_GVC`/`CPLN_LOCATION`/`CPLN_ORG`/`CPLN_PROVIDER`/`CPLN_WORKLOAD`), secret resolution (auth-gated), `cpln://reference` unsupported, multi-line skipped, and the "baked at boot, not live" caveat.

### Volume fields
- Removed the `cdrom` and `serial` rows from the data-disk table — both are now derived:
  - `cdrom` is **inferred from bus**: a `cpln://secret/` volume on `sata`/`scsi` → read-only CD-ROM; on `virtio` → block device.
  - `serial` is **derived from the volume `name`** (updated the raw-block-device note and the `by-id` example accordingly).
- `bootOrder` now noted as **not valid for secret volumes** (a secret is not bootable).