### PR TITLE
docs: document GVC aliasWorkloadLink alias endpoint health awareness

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -367,7 +367,7 @@ cpln logs '{gvc="GVC", workload="WL"}' --org ORG --tail
 - [Cloud Account](https://docs.controlplane.com/reference/cloudaccount): Cloud provider account mappings that work with identities to enable credential-free cloud resource access via Universal Cloud Identity
 - [Domain](https://docs.controlplane.com/reference/domain): Custom domain configuration with TLS, geo-routing, path-based and subdomain-based DNS modes
 - [Group](https://docs.controlplane.com/reference/group): User and service account membership collections for access control
-- [GVC](https://docs.controlplane.com/reference/gvc): GVC configuration including locations, pull secrets, environment variables, tracing, and load balancing
+- [GVC](https://docs.controlplane.com/reference/gvc): GVC configuration including locations, location routing options, alias endpoint health awareness (aliasWorkloadLink), pull secrets, environment variables, tracing, and load balancing
 - [Identity](https://docs.controlplane.com/reference/identity): GVC-scoped workload identities for credential-free cloud provider access via Universal Cloud Identity
 - [Image](https://docs.controlplane.com/reference/image): Container image registry, formats, and private/public image references
 - [IP Set](https://docs.controlplane.com/reference/ipset): Reserve static public IP addresses per GVC location for workloads (via direct load balancer) and GVC dedicated load balancers

--- a/reference/gvc.mdx
+++ b/reference/gvc.mdx
@@ -1,7 +1,7 @@
 ---
 title: GVC (Global Virtual Cloud)
 description: "GVC configuration reference with YAML examples. Covers locations, pull secrets, domain assignment, environment variables, tracing, and load balancing."
-keywords: ['gvc spec', 'gvc manifest', 'env vars', 'tracing config', 'opentelemetry', 'lb config', 'pull secret', 'location routing', 'load balancer config', 'domain links']
+keywords: ['gvc spec', 'gvc manifest', 'env vars', 'tracing config', 'opentelemetry', 'lb config', 'pull secret', 'location routing', 'load balancer config', 'domain links', 'alias endpoint', 'aliasWorkloadLink']
 ---
 
 ## Overview
@@ -152,6 +152,27 @@ spec:
 ```
 
 This configuration makes `aws-us-east-1` appear 10ms closer and `aws-us-west-2` appear 10ms farther, shifting more traffic toward the east coast location.
+
+## Alias Endpoint Health Awareness
+
+Every GVC has a global alias endpoint, `${alias}.cpln.app`, that DNS geo-routes to the nearest healthy location serving the GVC. By default this DNS record resolves directly to each location that is configured for the GVC and is health-checked with a basic TCP probe. This TCP probe will succeed even when no workload in the GVC is actually able to serve traffic in that location, so the DNS can advertise locations that are unable to serve requests.
+
+Set `spec.aliasWorkloadLink` to a workload in this GVC to make the alias inherit that workload's health and routing instead. When set, `${alias}.cpln.app` is published as a CNAME to the referenced workload's canonical endpoint, so the alias inherits the workload's HTTP readiness probes and per-location geo failover. A location then only receives alias traffic while the workload is actually healthy there.
+
+### Configuration
+
+```yaml
+spec:
+  aliasWorkloadLink: //workload/api-gateway
+```
+
+### Behavior
+
+- **When set**: `${alias}.cpln.app` is a CNAME to the referenced workload's canonical endpoint and follows that workload's HTTP health checks and location routing.
+- **When unset**: the alias resolves to cluster ingress endpoints with a TCP-only health check and no application-level health awareness.
+- The referenced workload must be in the same GVC.
+
+<Note>`aliasWorkloadLink` has no effect if the referenced workload does not exist, or while it is globally suspended (`defaultOptions.suspend` or `defaultOptions.autoscaling.maxScale` set to `0`); in these cases the alias falls back to ingress resolution. Per-location suspends are ignored.</Note>
 
 ## Load Balancer Configuration
 


### PR DESCRIPTION
Adds a reference section for `spec.aliasWorkloadLink` to `reference/gvc.mdx`.

- Explains the GVC alias endpoint (`${alias}.cpln.app`) and its default TCP-only ingress health check.
- Documents how `aliasWorkloadLink` makes the alias a CNAME to a workload's canonical endpoint, inheriting its HTTP health probes and per-location geo failover.
- Includes config example, behavior list, and fallback cases (workload missing or globally suspended).
- Updates page keywords and the `llms.txt` GVC index entry.