### PR TITLE
docs: document CNAME-mode subdomain routing and dns01 wildcard certs

### DIFF
--- a/guides/configure-domain.mdx
+++ b/guides/configure-domain.mdx
@@ -94,10 +94,11 @@ spec:
 
 #### APEX Verification and Subdomain Based Routing
 
-Configure a domain for APEX verification and subdomain-based routing.
+Configure an apex domain for subdomain-based routing, where each workload in the GVC is served at `<workload>.example.com`.
 
-- Substitute `example.com` with your domain, `GVC_NAME`, and `TLS_SECRET`.
-- Notice that the `dnsMode` is set to `cname` and a TLS secret is required.
+- Substitute `example.com` with your domain and `GVC_NAME`.
+- `dnsMode` is `cname` and `gvcLink` selects the GVC.
+- With `certChallengeType: dns01`, Control Plane issues a wildcard certificate — no TLS secret is required.
 
 ```yaml YAML
 kind: domain
@@ -106,6 +107,22 @@ description: example.com
 tags: {}
 spec:
   dnsMode: cname
+  certChallengeType: dns01
+  gvcLink: //gvc/GVC_NAME
+```
+
+After the domain is created, view its `status.dnsConfig` (for example, `cpln domain get example.com -o yaml`) and create the records it lists: one `CNAME` per workload (`<workload>.example.com` → `<gvcAlias>.cpln.app`) plus the `_acme-challenge` CNAME used to issue the certificate.
+
+To supply your own certificate instead, use `certChallengeType: http01` and configure a `tls.serverCertificate.secretLink` on each TLS port:
+
+```yaml YAML
+kind: domain
+name: example.com
+description: example.com
+tags: {}
+spec:
+  dnsMode: cname
+  certChallengeType: http01
   gvcLink: //gvc/GVC_NAME
   ports:
     - number: 443

--- a/reference/domain.mdx
+++ b/reference/domain.mdx
@@ -245,7 +245,7 @@ Instead of specifying routes based on a path prefix, paths can be specified usin
 
 Subdomain-based routing maps a domain to all workloads within a [GVC](/reference/gvc).
 
-This is accomplished by adding **NS** records to DNS which delegate DNS to Control Plane for this domain **only** and configuring the domain with `dnsMode: ns`.
+This works in either [DNS mode](#dns-modes). In **NS mode** (`dnsMode: ns`), add **NS** records that delegate DNS to Control Plane for this domain **only**, and Control Plane creates every subdomain record automatically. In **CNAME mode** (`dnsMode: cname` with a `gvcLink`), you create one **CNAME** record per workload — see [Subdomain-Based Routing in CNAME Mode](#cname-mode-dnsmode-cname).
 
 Advantages of using subdomain-based routing:
 
@@ -272,7 +272,14 @@ In CNAME mode, Control Plane will configure workloads to accept traffic for the 
 - `certChallengeType: http01`: Uses HTTP-01 challenge for certificate validation
 - `certChallengeType: dns01`: Uses DNS-01 challenge for certificate validation
 
-<Note>When using CNAME mode with subdomain-based routing (`gvcLink`), a custom server certificate must be configured for all ports that enable TLS.</Note>
+**Subdomain-Based Routing in CNAME Mode**
+
+When a `gvcLink` is configured, each workload in the GVC is served at `<workload>.<domain>`. Create one **CNAME** record per workload pointing `<workload>.<domain>` to `<gvcAlias>.cpln.app`. The exact records to create are listed in the domain's [`status.dnsConfig`](#dns-configuration-records).
+
+Certificate handling depends on `certChallengeType`:
+
+- `dns01`: Control Plane issues a **wildcard** certificate covering all subdomains. Also create the `_acme-challenge` CNAME record shown in `status.dnsConfig` to delegate the challenge to Control Plane.
+- `http01` (or unset): Control Plane does not issue a certificate for subdomain-based routing — configure a [custom server certificate](#custom-server-certificate) on every port that enables TLS.
 
 **Constraints:**
 
@@ -297,7 +304,7 @@ The `certChallengeType` property controls both the certificate validation method
 - An apex domain (e.g., **example.com**) can serve requests to workloads using
   either [path-based](#path-based-routing) or [subdomain-based](#subdomain-based-routing) routing.
 
-- If subdomain-based routing is desired, a [custom server certificate](#custom-server-certificate) must be configured.
+- If subdomain-based routing is desired, set `certChallengeType: dns01` for a Control Plane-managed wildcard certificate, or configure a [custom server certificate](#custom-server-certificate) and use `http01`.
 
 - If your DNS provider does not allow apex domains to point to a CNAME record, a service such as [CloudFront](https://docs.aws.amazon.com/cloudfront/index.html) or [Cloudflare](https://cloudflare.com) must be used to proxy the apex domain to Control Plane.
 
@@ -684,7 +691,7 @@ If you prefer to use a different certificate authority, you can configure a [cus
 - **CNAME domains**: Control Plane uses the Let's Encrypt [HTTP-01](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) verification process.
   This involves serving a specific HTTP resource to prove domain ownership at `http://${domain}/.well-known/acme-challenge/`, allowing Let's Encrypt to issue a certificate.
   Control Plane configures the domain with a redirect to our HTTP-01 solver, and then the certificate is issued by Let's Encrypt.
-  Wildcard certificates cannot be created using the HTTP-01 verification process, so CNAME domains should not be attached to a GVC unless a custom server certificate is used.
+  Wildcard certificates cannot be created using the HTTP-01 verification process. To attach a CNAME domain to a GVC for [subdomain-based routing](#subdomain-based-routing) (`gvcLink`) with a Control Plane-managed certificate, set `certChallengeType: dns01` so a wildcard certificate is issued via [DNS-01](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) — this requires adding the `_acme-challenge` CNAME record shown in `status.dnsConfig`. Otherwise, configure a custom server certificate.
 
 <Note>
   If you choose to use a custom server certificate, ensure you monitor its expiration and renew it as necessary to avoid service


### PR DESCRIPTION
Documents subdomain-based routing for CNAME-mode domains (apex + `gvcLink`) and corrects the now-inaccurate "custom server certificate always required" statements.

reference/domain.mdx:
- Subdomain-Based Routing now covers both NS (CP-managed records) and CNAME (per-workload CNAMEs) modes.
- CNAME Mode documents the per-workload `<workload>.<domain>` → `<gvcAlias>.cpln.app` records (surfaced in `status.dnsConfig`) and the cert rule: `dns01` → CP wildcard cert (+ `_acme-challenge` CNAME); `http01`/unset → custom server cert.
- Corrected the Apex Domain Considerations and Certificate Management paragraphs accordingly.

guides/configure-domain.mdx:
- APEX subdomain-routing example leads with `dns01` (no TLS secret) and points to `status.dnsConfig`; keeps `http01` + server-cert as the alternative.

Documents the feature from GitLab issue controlplane/controlplane#4112.