### PR TITLE
docs: document internal domains and required client certificates

### DIFF
--- a/guides/configure-domain.mdx
+++ b/guides/configure-domain.mdx
@@ -94,10 +94,11 @@ spec:
 
 #### APEX Verification and Subdomain Based Routing
 
-Configure a domain for APEX verification and subdomain-based routing.
+Configure an apex domain for subdomain-based routing, where each workload in the GVC is served at `<workload>.example.com`.
 
-- Substitute `example.com` with your domain, `GVC_NAME`, and `TLS_SECRET`.
-- Notice that the `dnsMode` is set to `cname` and a TLS secret is required.
+- Substitute `example.com` with your domain and `GVC_NAME`.
+- `dnsMode` is `cname` and `gvcLink` selects the GVC.
+- With `certChallengeType: dns01`, Control Plane issues a wildcard certificate — no TLS secret is required.
 
 ```yaml YAML
 kind: domain
@@ -106,6 +107,22 @@ description: example.com
 tags: {}
 spec:
   dnsMode: cname
+  certChallengeType: dns01
+  gvcLink: //gvc/GVC_NAME
+```
+
+After the domain is created, view its `status.dnsConfig` (for example, `cpln domain get example.com -o yaml`) and create the records it lists: one `CNAME` per workload (`<workload>.example.com` → `<gvcAlias>.cpln.app`) plus the `_acme-challenge` CNAME used to issue the certificate.
+
+To supply your own certificate instead, use `certChallengeType: http01` and configure a `tls.serverCertificate.secretLink` on each TLS port:
+
+```yaml YAML
+kind: domain
+name: example.com
+description: example.com
+tags: {}
+spec:
+  dnsMode: cname
+  certChallengeType: http01
   gvcLink: //gvc/GVC_NAME
   ports:
     - number: 443

--- a/llms.txt
+++ b/llms.txt
@@ -365,7 +365,7 @@ cpln logs '{gvc="GVC", workload="WL"}' --org ORG --tail
 - [Agent](https://docs.controlplane.com/reference/agent): Wormhole agents for secure connectivity to private networks, VPCs, and on-prem resources
 - [Audit Context](https://docs.controlplane.com/reference/auditctx): Audit context configuration for scoping audit trail queries
 - [Cloud Account](https://docs.controlplane.com/reference/cloudaccount): Cloud provider account mappings that work with identities to enable credential-free cloud resource access via Universal Cloud Identity
-- [Domain](https://docs.controlplane.com/reference/domain): Custom domain configuration with TLS, geo-routing, path-based and subdomain-based DNS modes
+- [Domain](https://docs.controlplane.com/reference/domain): Custom domain configuration with TLS, geo-routing, path-based and subdomain-based DNS modes, required client certificates (mTLS), and private .internal domains
 - [Group](https://docs.controlplane.com/reference/group): User and service account membership collections for access control
 - [GVC](https://docs.controlplane.com/reference/gvc): GVC configuration including locations, pull secrets, environment variables, tracing, and load balancing
 - [Identity](https://docs.controlplane.com/reference/identity): GVC-scoped workload identities for credential-free cloud provider access via Universal Cloud Identity

--- a/reference/domain.mdx
+++ b/reference/domain.mdx
@@ -245,7 +245,7 @@ Instead of specifying routes based on a path prefix, paths can be specified usin
 
 Subdomain-based routing maps a domain to all workloads within a [GVC](/reference/gvc).
 
-This is accomplished by adding **NS** records to DNS which delegate DNS to Control Plane for this domain **only** and configuring the domain with `dnsMode: ns`.
+This works in either [DNS mode](#dns-modes). In **NS mode** (`dnsMode: ns`), add **NS** records that delegate DNS to Control Plane for this domain **only**, and Control Plane creates every subdomain record automatically. In **CNAME mode** (`dnsMode: cname` with a `gvcLink`), you create one **CNAME** record per workload — see [Subdomain-Based Routing in CNAME Mode](#cname-mode-dnsmode-cname).
 
 Advantages of using subdomain-based routing:
 
@@ -272,7 +272,14 @@ In CNAME mode, Control Plane will configure workloads to accept traffic for the 
 - `certChallengeType: http01`: Uses HTTP-01 challenge for certificate validation
 - `certChallengeType: dns01`: Uses DNS-01 challenge for certificate validation
 
-<Note>When using CNAME mode with subdomain-based routing (`gvcLink`), a custom server certificate must be configured for all ports that enable TLS.</Note>
+**Subdomain-Based Routing in CNAME Mode**
+
+When a `gvcLink` is configured, each workload in the GVC is served at `<workload>.<domain>`. Create one **CNAME** record per workload pointing `<workload>.<domain>` to `<gvcAlias>.cpln.app`. The exact records to create are listed in the domain's [`status.dnsConfig`](#dns-configuration-records).
+
+Certificate handling depends on `certChallengeType`:
+
+- `dns01`: Control Plane issues a **wildcard** certificate covering all subdomains. Also create the `_acme-challenge` CNAME record shown in `status.dnsConfig` to delegate the challenge to Control Plane.
+- `http01` (or unset): Control Plane does not issue a certificate for subdomain-based routing — configure a [custom server certificate](#custom-server-certificate) on every port that enables TLS.
 
 **Constraints:**
 
@@ -297,7 +304,7 @@ The `certChallengeType` property controls both the certificate validation method
 - An apex domain (e.g., **example.com**) can serve requests to workloads using
   either [path-based](#path-based-routing) or [subdomain-based](#subdomain-based-routing) routing.
 
-- If subdomain-based routing is desired, a [custom server certificate](#custom-server-certificate) must be configured.
+- If subdomain-based routing is desired, set `certChallengeType: dns01` for a Control Plane-managed wildcard certificate, or configure a [custom server certificate](#custom-server-certificate) and use `http01`.
 
 - If your DNS provider does not allow apex domains to point to a CNAME record, a service such as [CloudFront](https://docs.aws.amazon.com/cloudfront/index.html) or [Cloudflare](https://cloudflare.com) must be used to proxy the apex domain to Control Plane.
 
@@ -684,7 +691,7 @@ If you prefer to use a different certificate authority, you can configure a [cus
 - **CNAME domains**: Control Plane uses the Let's Encrypt [HTTP-01](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) verification process.
   This involves serving a specific HTTP resource to prove domain ownership at `http://${domain}/.well-known/acme-challenge/`, allowing Let's Encrypt to issue a certificate.
   Control Plane configures the domain with a redirect to our HTTP-01 solver, and then the certificate is issued by Let's Encrypt.
-  Wildcard certificates cannot be created using the HTTP-01 verification process, so CNAME domains should not be attached to a GVC unless a custom server certificate is used.
+  Wildcard certificates cannot be created using the HTTP-01 verification process. To attach a CNAME domain to a GVC for [subdomain-based routing](#subdomain-based-routing) (`gvcLink`) with a Control Plane-managed certificate, set `certChallengeType: dns01` so a wildcard certificate is issued via [DNS-01](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) — this requires adding the `_acme-challenge` CNAME record shown in `status.dnsConfig`. Otherwise, configure a custom server certificate.
 
 <Note>
   If you choose to use a custom server certificate, ensure you monitor its expiration and renew it as necessary to avoid service

--- a/reference/domain.mdx
+++ b/reference/domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Domain
 description: "Domain configuration for workloads with TLS certificates, geo-routing, path-based routing, and DNS verification modes (CNAME and NS delegation)."
-keywords: ['apex domain', 'subdomain', 'dns01', 'http01', 'fqdn', 'host header', 'wildcard cert', 'path route', 'subdomain route', 'cors', 'custom cert']
+keywords: ['apex domain', 'subdomain', 'dns01', 'http01', 'fqdn', 'host header', 'wildcard cert', 'path route', 'subdomain route', 'cors', 'custom cert', 'mtls', 'client certificate', 'internal domain', 'private domain']
 ---
 
 ## Domain Overview
@@ -319,6 +319,37 @@ These DNS providers **do not** allow apex domains to have a CNAME record:
 
 </Tip>
 
+## Internal Domains
+
+A domain whose name ends in `.internal` (for example, `example.internal`) is a private domain. Control Plane configures its workloads to accept and route traffic for the domain but does **not** manage or publish any public DNS for it — you are responsible for resolving the domain in your own environment.
+
+**Resolution:** Point your own (private or split-horizon) DNS at the Control Plane endpoint with a CNAME record. On [BYOK](/byok) locations, the CNAME can resolve to a private address if you prefer to keep traffic off the public internet.
+
+**Constraints:**
+
+- Only CNAME mode is supported (`dnsMode: cname`, which is also the default).
+- Subdomain-based routing (`gvcLink`) is not supported. Route to workloads using [path-based](#path-based-routing) or [regex-based](#regex-based-routing) routes.
+- `certChallengeType` is not supported. Control Plane cannot issue a certificate for a private domain, so you must supply your own via `tls.serverCertificate.secretLink` on every port that enables TLS.
+- An apex `.internal` domain and all of its subdomains can be used by only one Org.
+
+**Example:**
+
+```yaml YAML
+kind: domain
+name: example.internal
+description: example.internal
+spec:
+  dnsMode: cname
+  ports:
+    - number: 443
+      tls:
+        serverCertificate:
+          secretLink: //secret/TLS_SECRET
+      routes:
+        - prefix: /
+          workloadLink: //gvc/GVC_NAME/workload/WORKLOAD_NAME
+```
+
 ## Port Configuration
 
 In the Console UI, the port configuration section is available when editing a domain in `Advanced Mode`.
@@ -391,6 +422,8 @@ The `x-forwarded-client-cert` (XFCC) HTTP header will contain the client certifi
 The certificate authority PEM, stored as a [secret](/reference/secret) of type `keypair`, can be associated with the domain through the `secretLink` property and used to verify the authority of the client certificate. The secret must contain a client certificate authority certificate in PEM format used to verify requests that include client certificates. The key subject must match the domain and the key usage properties must be configured for client certificate authorization.
 
 If a certificate authority PEM is not associated with a domain, no verification is performed.
+
+By default, supplying a client certificate is optional — a request without one is still served, and any certificate presented is forwarded in the XFCC header. To **require** a valid client certificate, set the [`cpln/clientCertificateValidation`](#special-tags) tag to `enabled` on the domain. Control Plane then verifies each client certificate against the certificate authority configured in `clientCertificate.secretLink` and rejects any connection that does not present a valid, trusted certificate. A `clientCertificate.secretLink` must be configured for this to take effect.
 
 CRL lists are not verified, but they can be checked by the [workload](/concepts/workload) by keeping a list of allowed or revoked client certificate hashes. When a request is received by the [workload](/concepts/workload), the hash field in the XFCC header can be checked against the allowed or revoked list and an allow or deny decision can be made.
 
@@ -666,6 +699,7 @@ Control Plane supports special tags prefixed with `cpln/` that modify domain beh
 | :-- | :---- | :---------- |
 | `cpln/skipDNSCheck` | `true` | Skip DNS validation checks during domain configuration. Useful when DNS propagation is delayed or when using external DNS management. |
 | `cpln/wildcard` | `true` | Enable wildcard certificate for custom ingress domains. Only applicable for domains with custom ingress enabled. |
+| `cpln/clientCertificateValidation` | `enabled` | Require a valid client certificate (mTLS) on the domain. Connections must present a certificate that is verified against the CA in `tls.clientCertificate.secretLink`; requests without a valid, trusted certificate are rejected. When unset, client certificates are optional and accepted without verification. |
 
 ## CLI
 


### PR DESCRIPTION
Documents two domain features in `reference/domain.mdx`:

- **Internal domains** (`.internal`): new section covering private domains — CP does not publish public DNS, you resolve via your own private/split-horizon DNS (private address on BYOK), CNAME-only, no `gvcLink`, customer-supplied `serverCertificate` required, single-Org apex+subdomains. Includes an example manifest.
- **Required client certificate**: documents the `cpln/clientCertificateValidation: enabled` tag (require + verify against the configured CA, mTLS) in the Client Certificate section and the Special Tags table.

Also updates page keywords and the `llms.txt` domain index line.

Documents GitLab issues controlplane/controlplane#4444 and controlplane/controlplane#4454.

> [!NOTE]
> Stacked on #196 — that PR should merge first. Until then this PR's diff also includes #196's commit.