### PR TITLE
docs: document V2 agent reverse HTTP proxy BYOK and CLI config

### DIFF
--- a/byok/settings/agent.mdx
+++ b/byok/settings/agent.mdx
@@ -129,4 +129,5 @@ Configuration for Middlebox, required for the [Cloud Wormhole agent](/reference/
 | enabled    | boolean| Required. `true` or `false`                                                                   | 
 | ip         | string | Optional. For cloud platform that do not support UDP type Load Balancers                     |
 | port       | number | Optional. To change the default (51820) port.                                                |
+| ingressReplicas | number | Optional. Required for the agent [reverse HTTP proxy](/reference/agent#bi-directional-functionality). Set greater than `0` to enable inbound access from allowed agents. Defaults to `0`. |
 

--- a/reference/agent.mdx
+++ b/reference/agent.mdx
@@ -85,6 +85,19 @@ To allow an agent to proxy a request to the workload running on Control Plane, f
 4. Click `Add Agent` and select one or more agents. Click `OK`.
 5. Click `Update`. Once the deployment is complete, the agent will be allowed to proxy requests to this workload.
 
+Using the CLI, add the agent's link to the workload's internal firewall `inboundAllowWorkload` list:
+
+```yaml YAML
+spec:
+  firewallConfig:
+    internal:
+      inboundAllowType: workload-list
+      inboundAllowWorkload:
+        - //agent/AGENT_NAME
+```
+
+<Note>On [BYOK](/byok) locations, the agent reverse proxy also requires the middlebox add-on to have [`ingressReplicas`](/byok/settings/agent#middlebox) set greater than `0`. If it is `0`, the workload reports `Reverse proxy is not fully configured in this location`.</Note>
+
 ### Proxy Usage
 
 To route traffic through the proxy, configure the calling application to use the agent’s internal IP address and port `3128` as its HTTPS proxy. Obtain the agent’s internal IP address from the instance summary page for the cloud provider where the agent is deployed.
@@ -92,6 +105,8 @@ To route traffic through the proxy, configure the calling application to use the
 ```bash Curl example
 HTTPS_PROXY=http://AGENT_IP:3128 curl https://example-cpln-workload.cpln.app
 ```
+
+You can reach the workload through the proxy using any of its endpoints: its canonical endpoint (`<workload>-<gvc>.cpln.app`), any custom [domains](/reference/domain) that route to it, or its in-cluster name (`<workload>.<gvc>.cpln.local`).
 
 If you are not able to configure the application to use the proxy server, the global proxy server setting of the running environment can be configured.
 


### PR DESCRIPTION
Fills gaps in the V2 agent reverse HTTP proxy docs (the feature itself is covered under `reference/agent.mdx` → Bi-directional Functionality).

reference/agent.mdx:
- Adds the CLI/manifest form of the config (`firewallConfig.internal.inboundAllowWorkload: [ //agent/AGENT_NAME ]`) alongside the existing UI steps.
- Adds a BYOK requirement note: the middlebox add-on needs `ingressReplicas > 0`, including the workload error string, cross-linked to the BYOK setting.
- Lists the reachable endpoints through the proxy (canonical endpoint, custom domains, in-cluster `.cpln.local` name).

byok/settings/agent.mdx:
- Documents the middlebox `ingressReplicas` field (required > 0 for the reverse proxy).

Documents GitLab issue controlplane/controlplane#4443.