### PR TITLE
docs: BYOK VM mesh setting, VNC console, and troubleshooting

### DIFF
--- a/byok/settings/actuator.mdx
+++ b/byok/settings/actuator.mdx
@@ -85,6 +85,34 @@ Here is an example of how the configuration should look:
 
 ```
 
+### MESH_DISABLE_IP_AUTOALLOCATE
+
+Stamps the mTLS [ServiceEntries](/reference/workload/security) the actuator generates with `networking.istio.io/enable-autoallocate-ip=false`. Defaults to `false` (off); enable it **per location**, only where it is needed.
+
+#### When to use it
+
+Enable this when a workload — most commonly a [VM workload](/reference/workload/vm) such as a Windows guest — connects to **another workload over the internal mesh endpoint** and the connection is unreliable over **raw TCP** (databases, RDP, or any non-HTTP protocol).
+
+- **Symptom:** HTTP requests to the internal endpoint succeed, but plain TCP connections reset intermittently (roughly half the time).
+- **Cause:** Istio's DNS proxy auto-allocates a virtual IP for each ServiceEntry. In the per-port mesh clusters Control Plane generates, that auto-allocated IP can resolve to an endpoint that is not actually serving, so the TCP connection is reset. HTTP survives because it is re-routed by its `Host` header; raw TCP has no such fallback.
+- **Fix:** Setting this to `true` removes the auto-allocated IP, leaving only the real workload endpoint, so raw TCP lands on a live target.
+
+#### How to configure
+
+Add the environment variable to the actuator settings — either through the [CPLN Platform Add-on](/mk8s/add-ons/byok) configuration or by editing the `cpln-byok-current` ConfigMap directly if you run your own Kubernetes:
+
+```json
+{
+  "actuator": {
+    "env": {
+      "MESH_DISABLE_IP_AUTOALLOCATE": "true"
+    }
+  }
+}
+```
+
+After the actuator picks up the change, redeploy or reconcile the affected workload so its ServiceEntry is re-stamped, then re-establish any existing TCP connections.
+
 ### LABEL_NODES
 
 Controls whether the actuator automatically manages node labels and workload node selectors to enable isolation between core platform components and user workloads across multiple nodepools.

--- a/mk8s/add-ons/kubevirt.mdx
+++ b/mk8s/add-ons/kubevirt.mdx
@@ -104,6 +104,115 @@ After the add-on reconciles and a VM node is ready:
 - The cluster's [location](/reference/location) reports `vm` under its workload-type capabilities.
 - A [VM workload](/reference/workload/vm) targeting this location schedules, imports its boot disk (watch `Importing boot disk: NN%` in the deployment status), and boots.
 
+## Console access
+
+For day-to-day access, use the platform paths documented on the [VM workload](/reference/workload/vm) page — they work the same on your own cluster and require no `kubectl`:
+
+- **SSH (Linux):** `cpln workload connect` / `cpln workload exec`.
+- **RDP (Windows) or any TCP service:** [`cpln port-forward`](/guides/cli/cpln-port-forward) to the guest port, then connect to `localhost`.
+
+When a guest will not boot far enough to accept SSH or RDP — a kernel panic, a UEFI failure, or a stalled first boot — you need the raw graphical console. On a cluster you operate (mk8s or [BYOK](/mk8s/generic)) you have direct access, so use KubeVirt's [`virtctl`](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/) against the cluster:
+
+<Steps>
+<Step title="Find the VM instance and its namespace">
+  VM instances are labelled with their workload name and run in the [GVC](/reference/gvc) namespace:
+
+  ```bash
+  kubectl get vmi -A -l cpln/workload=<workload-name>
+  ```
+</Step>
+
+<Step title="Open the VNC console">
+  Point `virtctl` at the instance (use the `NAME` and `NAMESPACE` from the previous step). `virtctl` launches your local VNC viewer:
+
+  ```bash
+  virtctl vnc <vmi-name> -n <gvc-namespace> --kubeconfig <cluster-kubeconfig>
+  ```
+
+  If you have no local VNC client, run with `--proxy-only`; `virtctl` prints a local `127.0.0.1:<port>` address you can point any VNC client at.
+</Step>
+</Steps>
+
+<Note>
+`virtctl` must match the cluster's KubeVirt version, and your kubeconfig user needs access to the `virtualmachineinstances/vnc` subresource. The serial console (boot log, login banner) is also available as `virtctl console <vmi-name> -n <gvc-namespace>`.
+</Note>
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="A VM workload never starts and no instance appears">
+  **Symptom:** The workload deploys but stays not-ready, and `kubectl get vmi -A -l cpln/workload=<workload-name>` returns nothing — or the VM instance is stuck `Pending`/`Scheduling`. The [location](/reference/location) may not report `vm` in its capabilities.
+
+  **Cause:** No VM-capable node, or KubeVirt's components have nowhere to run. VMs and the KubeVirt control plane are scoped to nodes labelled `cpln.io/nodeType: vm`.
+
+  **Fix:** Confirm at least one ready, labelled node exists:
+
+  ```bash
+  kubectl get nodes -l cpln.io/nodeType=vm
+  ```
+
+  If the list is empty, add the label (and the matching taint) to a node pool on KVM-capable instances as shown in [How to enable](#how-to-enable), and verify the `kubevirt` add-on has reconciled.
+</Accordion>
+
+<Accordion title="Boot disk import is stuck">
+  **Symptom:** The deployment status sits at `Importing boot disk: NN%` and never reaches running.
+
+  **Cause:** CDI imports the boot disk into a PVC before the VM can boot. Imports stall when there is no working default `StorageClass`, or when the default StorageClass is **block-mode** and CDI has no filesystem-mode scratch space.
+
+  **Fix:** Ensure a default `StorageClass` exists. If it is block-mode, set `scratchSpaceStorageClass` to a filesystem-mode class:
+
+  ```yaml YAML
+  addOns:
+    kubevirt:
+      scratchSpaceStorageClass: my-filesystem-sc
+  ```
+
+  Inspect the importer pod for the underlying error:
+
+  ```bash
+  kubectl logs -n <gvc-namespace> -l app=containerized-data-importer
+  ```
+</Accordion>
+
+<Accordion title="Windows VM fails to boot (UEFI)">
+  **Symptom:** The VM never reaches the OS; the VNC/serial console shows a UEFI error such as `failed to load Boot0001 ... from PciRoot(0x0)`.
+
+  **Cause:** Control Plane runs these VMs with non-persistent EFI NVRAM, so the firmware boots with an empty variable store. The image must place the Windows boot manager at the UEFI fallback path (`\EFI\BOOT\BOOTX64.EFI`); without it the firmware has nothing to boot. Enabling Secure Boot causes the same class of failure because it requires persistent NVRAM.
+
+  **Fix:** Rebuild the Windows image with the fallback bootloader (see [Publishing & converting VM images](/guides/vm-images)). Do **not** set `firmware.secureBoot` — it is [not yet available](/reference/workload/vm#scaling--lifecycle) for this reason.
+</Accordion>
+
+<Accordion title="Raw TCP to another workload over the mesh resets (HTTP works)">
+  **Symptom:** A VM (often Windows) reaches another workload's internal endpoint fine over HTTP, but a plain TCP protocol (SQL, RDP, custom TCP) connects only intermittently and otherwise resets.
+
+  **Cause:** Istio's DNS proxy auto-allocates a virtual IP per ServiceEntry that can resolve to a non-serving endpoint; HTTP re-routes by `Host` header, raw TCP does not.
+
+  **Fix:** Enable the [`MESH_DISABLE_IP_AUTOALLOCATE`](/byok/settings/actuator#mesh_disable_ip_autoallocate) actuator setting for that location, then reconcile the workload and re-establish the connection.
+</Accordion>
+
+<Accordion title="Can't connect to the VM from my machine">
+  **Symptom:** SSH or RDP to the VM times out from outside the cluster.
+
+  **Cause:** A VM has no public endpoint by default; its `ports` only govern in-cluster service-mesh traffic.
+
+  **Fix:** Reach the guest with [`cpln port-forward`](/guides/cli/cpln-port-forward) — it tunnels directly to a replica and the target port does **not** need to be listed in the workload's `ports`:
+
+  ```bash
+  cpln port-forward <workload-name> 13389:3389 --gvc <gvc> --location <location>
+  ```
+
+  Then connect your client to `localhost:13389`. For public HTTP access, attach a [domain](/reference/domain) instead.
+</Accordion>
+
+<Accordion title="VM can't resolve cpln.local or reach other workloads">
+  **Symptom:** Inside the guest, `*.cpln.local` names or cross-location peers fail to resolve.
+
+  **Cause:** VM guests resolve in-cluster names through a platform DNS forwarder; large answers can be truncated over UDP on some guests.
+
+  **Fix:** Enable the [`nodeLocalDns`](/mk8s/add-ons) add-on (recommended alongside KubeVirt). On Linux guests you can also force TCP DNS by adding `options use-vc` to `/etc/resolv.conf` from [cloud-init](/reference/workload/vm#cloud-init--platform-injection).
+</Accordion>
+</AccordionGroup>
+
 ## Next steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
Adds operator-facing docs for running VM workloads (including Windows) on BYOK / mk8s.

## Changes

**`byok/settings/actuator.mdx`** — documents the new `MESH_DISABLE_IP_AUTOALLOCATE` actuator setting:
- When to use it: a workload (commonly a Windows VM) reaching another workload over the internal mesh endpoint where **HTTP works but raw TCP resets ~half the time**.
- Symptom / cause (Istio auto-allocated VIP → non-serving endpoint) / fix, with the `actuator.env` config example. Default off, enable per-location.

**`mk8s/add-ons/kubevirt.mdx`** — two new sections on the "run VMs on your own cluster" page:
- **Console access** — platform paths first (`cpln workload connect`, `cpln port-forward`), then raw **VNC via `virtctl`** (with serial-console and `--proxy-only` variants) for guests that won't boot far enough for SSH/RDP.
- **Troubleshooting** — an `AccordionGroup` (symptom / cause / fix, with searchable error text): no instance / unlabeled node, stuck boot-disk import, Windows UEFI `failed to load Boot0001` failure, raw-TCP mesh resets, can't connect from outside, and in-guest DNS resolution.

All cross-links verified against existing pages; anchors match Mintlify slugs. No new pages, so `llms.txt`/`docs.json` need no changes.