### PR TITLE
Add Sandbox Manager documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -121,6 +121,19 @@
             "pages": ["guides/overview"]
           },
           {
+            "group": "Sandbox",
+            "icon": "laptop-code",
+            "pages": [
+              "guides/sandbox/getting-started",
+              "guides/sandbox/toolbox-images",
+              "guides/sandbox/ui-reference",
+              "guides/sandbox/container-internals",
+              "guides/sandbox/terminal-tmux",
+              "guides/sandbox/sandbox-helper",
+              "guides/sandbox/multi-repo"
+            ]
+          },
+          {
             "group": "CLI Configuration",
             "icon": "terminal",
             "pages": ["guides/browser-less-cli-login"]

--- a/guides/sandbox/container-internals.mdx
+++ b/guides/sandbox/container-internals.mdx
@@ -1,0 +1,102 @@
+---
+title: "Container Internals"
+description: "How the sandbox container boots, exposes the browser IDE and terminal, and routes traffic through the gateway proxy."
+keywords: ['sandbox container', 'boot sequence', 'gateway proxy', 'port discovery', 'code-server', 'ttyd', 'SSH']
+---
+
+## Boot Sequence
+
+The container entrypoint starts the sandbox services in this order:
+
+1. Seed `/root` from defaults on first boot
+2. Create `/root/workspace` and symlink `/workspace`
+3. Raise inotify limits
+4. Start the gateway proxy (port 8888)
+5. Start `sshd`
+6. Run deferred install script (if present)
+7. Start code-server (port 8443)
+8. Start ttyd browser terminal (port 7681)
+9. Start port/resource monitor
+10. Snapshot installed packages for fork detection
+11. Mark the sandbox ready
+
+## Gateway Proxy
+
+Each sandbox runs a gateway proxy that routes browser IDE, terminal, and application traffic through a single public endpoint.
+
+| Path | Backend | Auth | Purpose |
+| :--- | :------ | :--- | :------ |
+| `/_ide/` | code-server (8443) | Password | VS Code in browser |
+| `/_term/` | ttyd (7681) | Password | Browser terminal |
+| `/_port/<N>/` | Any process (N) | Password | Proxy to detected local port |
+| `/_callback/<N>/` | Any process (N) | None | OAuth/webhook callbacks |
+| `/_status` | Gateway | None | JSON runtime status |
+| `/_ports` | Gateway | None | JSON discovered ports |
+| `/healthz` | Gateway | None | Readiness probe |
+| `/` | App process (APP_PORT) | None | Public application URL |
+
+The `/_ide/`, `/_term/`, and `/_port/` routes are password-protected via cookie session. The password is displayed in the connect panel.
+
+## Ports
+
+| Port | Visibility | Purpose |
+| :--- | :--------- | :------ |
+| 8888 | Public | Gateway endpoint |
+| APP_PORT (default 8080) | Local | User application |
+| 8443 | Local | code-server |
+| 7681 | Local | ttyd |
+| 22 | Private (port-forward only) | SSH |
+
+Reserved ports (22, 7681, 8443, 8888) cannot be used as the app port.
+
+## Port Discovery
+
+A background scanner checks for non-reserved TCP listeners every 10 seconds. Detected ports are available at `/_ports` and in the connect panel with auto-inferred labels (Vite, Next.js, Django, etc.).
+
+The primary app port is served at the root URL (`/`). Additional detected ports use prefix routing (`/_port/<N>/`).
+
+## IDE Backends
+
+### code-server
+
+Starts on `127.0.0.1:8443` with code-server auth disabled. The gateway handles browser authentication.
+
+### Browser Terminal
+
+ttyd starts on port 7681 with tmux for session persistence. See [Terminal & tmux](/guides/sandbox/terminal-tmux).
+
+### SSH Server
+
+`sshd` starts for desktop IDE connectivity. Interactive SSH sessions auto-attach to a persistent tmux session. The `cpln sandbox connect` command automates SSH access by injecting your public key, setting up port-forwarding, and launching your desktop IDE.
+
+## Persistent Workspace
+
+`/root` is mounted from a persistent [volumeset](/reference/volumeset). Everything under `/root` survives container restarts and suspend/resume:
+
+- `~/workspace/` — repositories and working files
+- `~/.bashrc`, `~/.gitconfig` — shell and tool config
+- `~/.config/` — code-server settings, extensions
+- `~/.npm-global/` — globally installed npm packages
+- `~/.local/` — pip user installs
+
+Deleting the sandbox deletes the volumeset and everything under `/root`.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="App port shows 'waiting' in sandbox status">
+    No process is listening on `APP_PORT`. Start your app from the IDE terminal. The gateway shows a waiting page until a process binds to the port.
+  </Accordion>
+  <Accordion title="IDE or terminal not starting">
+    Check the service logs inside the container:
+
+    ```bash theme={null}
+    cat /tmp/code-server.log
+    cat /tmp/ttyd.log
+    cat /tmp/ide-gateway.log
+    ```
+  </Accordion>
+  <Accordion title="Port detected but returns 502">
+    The service is detected but the gateway can't reach it. Verify the service binds to `0.0.0.0` or `127.0.0.1`, not a specific interface.
+  </Accordion>
+</AccordionGroup>

--- a/guides/sandbox/getting-started.mdx
+++ b/guides/sandbox/getting-started.mdx
@@ -1,0 +1,130 @@
+---
+title: "Getting Started with Sandbox"
+description: "Create a cloud development environment with a browser IDE, terminal, and persistent storage in under five minutes."
+keywords: ['sandbox', 'dev environment', 'cloud IDE', 'code-server', 'getting started', 'create sandbox', 'browser IDE']
+---
+
+## Prerequisites
+
+| Requirement | Purpose |
+| :---------- | :------ |
+| A Control Plane org | With at least one GVC |
+| Access to the CPLN Console | The Sandbox Manager runs as an embedded app in `console.cpln.io` |
+| `cpln` CLI (optional) | Required for `cpln sandbox connect` (desktop IDE and SSH access) |
+
+<Note>
+  VS Code Desktop and JetBrains Gateway are optional. The browser IDE (code-server) and terminal (ttyd) require zero local installs.
+</Note>
+
+## Open the Sandbox Manager
+
+The Sandbox Manager is embedded in the CPLN Console. Navigate to the **Sandbox** section for your org.
+
+## Create a Toolbox Image (Optional)
+
+Several sandbox templates are available to begin working immediately. These images include core runtimes and libraries for common development workflows. To customize a template or build from scratch:
+
+<Steps>
+  <Step title="Navigate to Images">
+    Click **Images** in the sidebar.
+  </Step>
+  <Step title="Start a new build">
+    Click **New Image**.
+  </Step>
+  <Step title="Choose a build mode">
+    - **From Template** — select runtimes, packages, and tools interactively
+    - **BYOI** — provide an existing OCI image reference
+  </Step>
+  <Step title="Build">
+    Click **Build** and wait for the build to complete.
+  </Step>
+</Steps>
+
+See [Building Toolbox Images](/guides/sandbox/toolbox-images) for details.
+
+## Create a Sandbox
+
+<Steps>
+  <Step title="Navigate to Instances">
+    Click **Instances** in the sidebar, then click **New Instance**.
+  </Step>
+  <Step title="Configure the sandbox">
+    - **Name** (optional) — unique environment name
+    - **Image** — select a sandbox image
+    - **Size** (Medium pre-selected) — CPU/memory profile
+    - **App Port** — port your app will listen on (default: 8080)
+    - **Identity** and **Secrets** — optional access to private infrastructure
+  </Step>
+  <Step title="Create">
+    Click **Create**. The sandbox provisions a persistent volume and workload, then becomes ready in ~60–90 seconds.
+  </Step>
+</Steps>
+
+<Tip>
+  Create a single-location [GVC](/reference/gvc) for your sandboxes. This reduces costs and provides the optimal developer experience.
+</Tip>
+
+## Connect Your IDE
+
+Once the instance shows **Ready**, use the connect panel or the CLI.
+
+### From the Web UI
+
+The connect panel shows direct links and the IDE password:
+
+| Feature | Access |
+| :------ | :----- |
+| Browser IDE (code-server) | `https://<endpoint>/_ide/` (password-protected) |
+| Browser terminal (ttyd) | `https://<endpoint>/_term/` (password-protected) |
+| Public app URL | `https://<endpoint>/` (shareable) |
+
+### From the CLI
+
+The `cpln sandbox connect` command sets up SSH tunnels for desktop IDE access. It automatically finds your sandbox by searching your accessible orgs and GVCs:
+
+```bash theme={null}
+# Open in VS Code (default)
+cpln sandbox connect <my-sandbox>
+
+# Open in Cursor
+cpln sandbox connect <my-sandbox> --ide cursor
+
+# Direct SSH session
+cpln sandbox connect <my-sandbox> --ide ssh
+
+# Open browser IDE
+cpln sandbox connect <my-sandbox> --ide browser
+```
+
+Specify org and GVC explicitly for faster lookup:
+
+```bash theme={null}
+cpln sandbox connect <my-sandbox> --org acme --gvc dev
+```
+
+## Start Coding
+
+Clone your repo and install dependencies from the IDE terminal. For private repos, authenticate git inside the environment:
+
+```bash theme={null}
+gh auth login          # GitHub
+glab auth login        # GitLab (if installed)
+```
+
+Credentials stored under `/root` survive suspend/resume because `/root` is backed by a persistent [volumeset](/reference/volumeset). They are removed when the environment is deleted.
+
+## Suspend and Resume
+
+Suspend to save costs when you're done for the day. Your full state is preserved.
+
+| Action | Effect | Cost |
+| :----- | :----- | :--- |
+| **Suspend** | Workload scaled to zero, volumeset retained | Storage only |
+| **Resume** | Workload scales back up, mounts existing volumeset | Compute + storage |
+| **Delete** | Workload and volumeset removed | None |
+
+Use the **Suspend** and **Resume** buttons in the Instances list or connect panel.
+
+<Warning>
+  Deleting an environment removes the workload and volumeset permanently, including cloned repos, credentials, IDE settings, and uncommitted changes. Use suspend to preserve state.
+</Warning>

--- a/guides/sandbox/multi-repo.mdx
+++ b/guides/sandbox/multi-repo.mdx
@@ -1,0 +1,39 @@
+---
+title: "Multi-Repo Workspaces"
+description: "Work with multiple repositories inside a single sandbox environment."
+keywords: ['sandbox multi-repo', 'multiple repositories', 'workspace', 'git clone', 'monorepo']
+---
+
+## Overview
+
+Sandboxes do not clone repositories at startup. Multi-repo workflows are handled inside the running sandbox using the browser IDE or terminal.
+
+## Recommended Flow
+
+```bash theme={null}
+cd /root/workspace
+gh auth login
+git clone https://github.com/acme/frontend
+git clone https://github.com/acme/api
+git clone https://github.com/acme/shared-lib
+```
+
+All repos live under `/root/workspace`, which is stored on a persistent [volumeset](/reference/volumeset). The workspace survives suspend/resume and is removed when the environment is deleted.
+
+## Private Repos
+
+Use provider-native tooling inside the environment:
+
+- **GitHub:** `gh auth login`
+- **GitLab:** `glab auth login` (if installed in the toolbox)
+- **SSH:** add keys under `/root/.ssh`
+
+Credentials stored under `/root` persist with the environment.
+
+## Running Multiple Services
+
+Start services from separate IDE terminals. The configured app port is served at the workload root URL. Additional local ports can be reached through the `/_port/<N>/` gateway route.
+
+<Tip>
+  Use `sandbox ports` to see all detected ports with their external URLs. Bind dev servers to `0.0.0.0` so the gateway can reach them.
+</Tip>

--- a/guides/sandbox/sandbox-helper.mdx
+++ b/guides/sandbox/sandbox-helper.mdx
@@ -1,0 +1,120 @@
+---
+title: "Sandbox Helper CLI"
+description: "Reference for the sandbox command available inside every sandbox — check status, discover ports, and diagnose runtime issues."
+keywords: ['sandbox command', 'sandbox status', 'sandbox ports', 'sandbox doctor', 'port discovery']
+---
+
+## Overview
+
+Every sandbox includes a `sandbox` command for inspecting runtime state, discovering ports, and diagnosing issues. No credentials required.
+
+## Commands
+
+| Command | Description |
+| :------ | :---------- |
+| `sandbox status` | Show runtime service status and resource usage |
+| `sandbox ports` | Show detected local ports and external URLs |
+| `sandbox url <port>` | Print the external URL for a specific port |
+| `sandbox app` | Show primary app port and common run hints |
+| `sandbox doctor` | Check installed runtimes and sandbox basics |
+
+## sandbox status
+
+```bash theme={null}
+sandbox status
+```
+
+```text Output theme={null}
+Sandbox: ready - Sandbox ready
+Primary app port: 8080
+Root URL: https://dev-alice-x7k2m.cpln.app/
+
+gateway:8888: ready - Gateway listening
+codeServer:8443: ready - code-server listening
+terminal:7681: ready - Terminal listening
+app:8080: waiting - No app listening on APP_PORT
+
+memory: 412MiB / 16GiB, peak 1.2GiB
+```
+
+The `app` service shows `waiting` until you start a process on `APP_PORT`. This is normal.
+
+## sandbox ports
+
+```bash theme={null}
+sandbox ports
+```
+
+```text Output theme={null}
+Sandbox ports
+
+8080  Primary app  root   https://dev-alice-x7k2m.cpln.app/
+3000  Next.js      prefix https://dev-alice-x7k2m.cpln.app/_port/3000/
+5173  Vite         prefix https://dev-alice-x7k2m.cpln.app/_port/5173/
+
+Tip: bind dev servers to 0.0.0.0 so the gateway can reach them.
+```
+
+A background scanner detects non-reserved TCP listeners every 10 seconds. Ports are auto-labeled based on process name and common conventions (Vite, Next.js, Django, Flask, Rails, etc.).
+
+<Tip>
+  Secondary ports use prefix routing (`/_port/3000/`). Most dev servers work without changes. Bind to `0.0.0.0` to ensure the gateway can reach them.
+</Tip>
+
+## sandbox app
+
+```bash theme={null}
+sandbox app
+```
+
+```text Output theme={null}
+Primary app port: 8080
+Root URL: https://dev-alice-x7k2m.cpln.app/
+
+Common run examples:
+  vite --host 0.0.0.0 --port 8080
+  next dev -H 0.0.0.0 -p 8080
+  python manage.py runserver 0.0.0.0:8080
+  rails server -b 0.0.0.0 -p 8080
+```
+
+## sandbox doctor
+
+```bash theme={null}
+sandbox doctor
+```
+
+```text Output theme={null}
+Sandbox doctor
+
+Runtime checks
+  git          git version 2.43.0
+  node         v20.18.0
+  npm          10.8.2
+  python       Python 3.12.7
+  go           go version go1.23.0 linux/amd64
+  code-server  4.96.4
+  gh           gh version 2.63.0
+
+Sandbox
+  status       ready
+  app port     8080
+  app url      https://dev-alice-x7k2m.cpln.app/
+  workspace    /root/workspace
+```
+
+Only installed tools are shown. Missing tools are silently omitted.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="sandbox: command not found">
+    The helper is installed during image build. Rebuild the toolbox image to get the latest version. As a workaround, check status files directly: `cat /tmp/devbox-status.json | jq .status`.
+  </Accordion>
+  <Accordion title="sandbox ports shows no ports">
+    The port scanner runs every 10 seconds. Wait a few seconds after starting a service, then retry. Verify your service is listening: `ss -tlnp | grep LISTEN`.
+  </Accordion>
+  <Accordion title="Port shows but URL returns 502">
+    Verify the service binds to `0.0.0.0` or `127.0.0.1`, not a specific interface. Check `sandbox status` for service states.
+  </Accordion>
+</AccordionGroup>

--- a/guides/sandbox/terminal-tmux.mdx
+++ b/guides/sandbox/terminal-tmux.mdx
@@ -1,0 +1,81 @@
+---
+title: "Terminal & tmux"
+description: "How tmux terminal sessions work inside sandboxes, including persistence, named sessions, and key bindings."
+keywords: ['sandbox terminal', 'tmux', 'persistent terminal', 'ttyd', 'ssh session', 'code-server terminal']
+---
+
+## How It Works
+
+Every sandbox runs [tmux](https://github.com/tmux/tmux) as an invisible session manager. Terminal sessions persist across disconnects — running processes, scroll history, and working directory survive browser refreshes, SSH reconnects, and IDE restarts.
+
+Three named sessions are created automatically:
+
+| Session | Created By | Attaches When |
+| :------ | :--------- | :------------ |
+| `vscode` | code-server settings | Opening a terminal in the browser IDE |
+| `term` | ttyd (browser terminal) | Opening `/_term/` in the browser |
+| `ssh` | `.bashrc` auto-attach | Connecting via SSH (VS Code Remote, Cursor, direct SSH) |
+
+Each session is independent. Work in the browser IDE terminal does not appear in the SSH session, and vice versa.
+
+## Session Persistence
+
+tmux sessions persist as long as the container is running.
+
+| Event | Sessions Preserved |
+| :---- | :----------------- |
+| Browser tab closed and reopened | Yes |
+| SSH disconnect and reconnect | Yes |
+| IDE restart | Yes |
+| Workload container restart | No |
+| Suspend and resume | No |
+
+<Note>
+  Files, git repos, and installed tools persist across suspend/resume because `/root` is backed by a [volumeset](/reference/volumeset). Only tmux sessions (running processes, shell history in memory) are lost.
+</Note>
+
+## Working with tmux
+
+The sandbox tmux configuration hides the status bar and unbinds the prefix key, so it stays invisible. You can still use tmux commands directly:
+
+```bash theme={null}
+# List all sessions
+tmux ls
+
+# Attach to a specific session
+tmux attach -t vscode
+
+# Create a new named session
+tmux new-session -s my-session
+
+# Kill a session
+tmux kill-session -t my-session
+```
+
+<Tip>
+  To enable standard tmux key bindings, add a prefix to `/root/.tmux.conf`:
+
+  ```bash theme={null}
+  echo "set -g prefix C-a" >> /root/.tmux.conf
+  tmux source-file /root/.tmux.conf
+  ```
+
+  This persists across container restarts.
+</Tip>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Terminal shows old output after reconnect">
+    This is expected. tmux preserves the scrollback buffer. Scroll down or press Enter to get to the current prompt.
+  </Accordion>
+  <Accordion title="Process still running after closing browser tab">
+    tmux keeps processes alive when you disconnect. To stop a process, reattach and terminate it, or kill the session: `tmux kill-session -t term`.
+  </Accordion>
+  <Accordion title="Clipboard not working in browser IDE">
+    Check browser permissions for the sandbox URL. The tmux config enables OSC 52 clipboard support.
+  </Accordion>
+  <Accordion title="Escape key has a delay in vim/neovim">
+    The sandbox tmux config sets `escape-time` to 0. Verify: `tmux show-option -g escape-time`. Reset if needed: `tmux set -g escape-time 0`.
+  </Accordion>
+</AccordionGroup>

--- a/guides/sandbox/toolbox-images.mdx
+++ b/guides/sandbox/toolbox-images.mdx
@@ -1,0 +1,108 @@
+---
+title: "Building Toolbox Images"
+description: "Build, customize, and manage sandbox images using templates, runtimes, packages, and AI coding tools."
+keywords: ['sandbox image', 'toolbox', 'build image', 'template', 'runtime', 'code-server', 'BYOI', 'fork image']
+---
+
+## What is a Toolbox
+
+A toolbox is a container image that provides the development stack: runtimes, package managers, IDEs, and utilities. Application code is **not** baked into the image — developers clone and manage repos inside the running sandbox.
+
+Every toolbox image includes the dev access layer:
+
+| Component | Purpose |
+| :-------- | :------ |
+| openssh-server | SSH for VS Code Remote, JetBrains Gateway |
+| code-server | VS Code in browser (port 8443) |
+| ttyd | Browser terminal (port 7681) |
+| Claude Code CLI | AI coding assistant |
+| gh CLI | GitHub operations |
+
+## Build Modes
+
+Build toolbox images from the **Images** page in the web UI.
+
+### Scratch
+
+Build an image interactively by selecting components:
+
+| Step | Description |
+| :--- | :---------- |
+| Template (optional) | Start from a pre-built template for faster builds |
+| Runtimes | Choose from 11 languages with version selection |
+| System Packages | Search/add from 7 categories or type custom apt package names |
+| Install Commands | Shell commands run during build |
+| AI Coding Tools | Claude Code, Codex CLI, Gemini CLI, Plandex, OpenCode, or custom |
+| VS Code Extensions | Extensions bundled into the image |
+
+### BYOI (Bring Your Own Image)
+
+Provide an existing OCI image reference. The dev access layer (SSH, code-server, ttyd, gateway) is layered on top automatically.
+
+## Templates
+
+Templates are pre-built toolbox images available as starting points. Selecting a template skips the base tool installation and only adds your customizations, making builds significantly faster.
+
+| Template | Description |
+| :------- | :---------- |
+| Blank | Ubuntu 24.04 + SSH + Claude Code |
+| Python API | Flask / FastAPI / Django |
+| Node.js Fullstack | React / Next.js / Express |
+| Go Microservice | Go APIs / gRPC services |
+| Java API | Spring Boot / Quarkus / Micronaut |
+| Rust | Systems / CLI tools / WebAssembly |
+| Data Science | pandas / ML workflows |
+| AI / Agents | Claude Code / LangChain / RAG |
+
+## Supported Runtimes
+
+| Runtime | Default Version | Install Method |
+| :------ | :-------------- | :------------- |
+| Python | 3.12 | Base image or apt |
+| Node.js | 20 | NodeSource apt repo |
+| Go | 1.23 | Binary tarball |
+| Rust | stable | rustup |
+| Java | 21 | Temurin JDK |
+| Ruby | system | apt |
+| .NET | 8.0 | apt |
+| PHP | system | apt + Composer |
+| Elixir | system | apt (Erlang + Elixir) |
+| Kotlin | latest | JetBrains release zip |
+| Swift | 5.9 | Swift.org tarball |
+
+## Image Forking
+
+When a developer installs packages inside a running sandbox, those changes can be detected and captured into a new image via the **Fork** feature.
+
+Fork detection compares the current state against snapshots taken at boot:
+
+| Package Manager | What's Detected |
+| :-------------- | :-------------- |
+| apt | New system packages |
+| pip | New Python packages (global) |
+| npm | New Node packages (global) |
+| VS Code extensions | Newly installed extensions |
+
+Click **Fork** on a running sandbox to see detected changes and build a new image that includes them.
+
+## Build Progress
+
+When you start a build, a modal shows live progress:
+
+1. **Creating** — preparing the build
+2. **Building** — executing the Dockerfile (installing runtimes, packages, tools)
+3. **Pushing** — uploading the image to the registry
+4. **Done** — image available for use
+
+Build logs stream in real time. If a build fails, the log shows which step failed and why.
+
+## Managing Images
+
+The **Images** page lists all toolbox images in your [org](/reference/org):
+
+| Action | Description |
+| :----- | :---------- |
+| Build | Create a new image from scratch or a template |
+| Clone | Copy an existing image config to a new image |
+| Set Default | Set as the default image for new sandboxes |
+| Delete | Remove the image from the registry |

--- a/guides/sandbox/ui-reference.mdx
+++ b/guides/sandbox/ui-reference.mdx
@@ -1,0 +1,145 @@
+---
+title: "Sandbox Web UI"
+description: "Reference for the Sandbox Manager web interface — dashboard, instances, images, and global settings."
+keywords: ['sandbox UI', 'sandbox manager', 'dashboard', 'instances', 'toolbox images', 'settings']
+---
+
+## Sidebar Navigation
+
+| Element | Description |
+| :------ | :---------- |
+| Overview | Organization health dashboard |
+| Instances | Sandbox instance management (create, suspend, resume, delete) |
+| Images | Toolbox image builder and manager |
+| Global Settings | Org-level configuration (Sandbox Profiles, Secrets & API Keys, Environment Variables, Defaults) |
+
+## Overview Dashboard
+
+At-a-glance view of organization health and sandbox status.
+
+### Health Cards
+
+| Card | Description |
+| :--- | :---------- |
+| Sandboxes | Count of running sandboxes |
+| Toolboxes | Count of configured toolbox images |
+| Volumesets | Count of persistent volumes |
+| Secrets | Count of org secrets |
+
+### Sandbox Table
+
+A full table of all sandboxes in the current GVC. Each row shows name, image, endpoint, readiness, size, and last modified date.
+
+### Sandbox Actions
+
+| Action | Description |
+| :----- | :---------- |
+| Connect | Open the connect panel |
+| Open IDE | Launch the browser IDE |
+| Open Terminal | Open a web terminal session |
+| Open App | Navigate to the application endpoint |
+| Suspend | Scale to zero while retaining the volumeset |
+| Resume | Scale back to one and remount the volumeset |
+| Delete | Delete the sandbox and its volumeset permanently |
+
+### Orphaned Volumesets
+
+Volumesets no longer attached to a sandbox are surfaced with age badges. A one-click restore action spins up a new sandbox from an orphaned volumeset.
+
+## Instances
+
+### Create Sandbox
+
+| Field | Required | Default | Description |
+| :---- | :------- | :------ | :---------- |
+| Name | No | `dev-{username}` | Sandbox name |
+| Image | Yes | org default | Toolbox image |
+| Size Profile | Yes | Medium | CPU/memory preset |
+| App Port | No | `8080` | Port your app listens on |
+| Identity | No | org default | Infrastructure identity |
+| Secrets | No | — | Secret-to-env-var mappings |
+| Environment Variables | No | — | Key-value pairs exposed inside the sandbox |
+
+### Connect Panel
+
+After selecting a sandbox, the connect panel displays IDE connection links, the IDE password, runtime diagnostics, and detected ports.
+
+## Images
+
+### Toolbox List
+
+| Column | Description |
+| :----- | :---------- |
+| Image Name | Image reference |
+| Runtimes | Configured language runtimes |
+| Mode | Build mode used (Scratch, BYOI) |
+| Created | Date the image was built |
+
+### Build Modes
+
+- **Scratch** — select runtimes, packages, AI tools, and extensions interactively
+- **BYOI** — provide an existing image. Dev tools are layered on top.
+
+### Build Modal
+
+An animated modal tracks build progress through four phases: Creating, Building, Pushing, Done.
+
+### Image Actions
+
+| Action | Description |
+| :----- | :---------- |
+| Clone | Create a copy with a new name |
+| Set Default | Set as the org default toolbox |
+| Delete | Remove the toolbox and delete the image |
+
+## Settings
+
+Organization-level configuration, accessible via the **Global Settings** submenu.
+
+### Sandbox Profiles
+
+CPU and memory presets that appear in the sandbox create form.
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| Name | string | Profile display name |
+| CPU | string | CPU allocation (e.g., `4`) |
+| Memory | string | Memory allocation (e.g., `16Gi`) |
+| Description | string | Human-readable description |
+| Default | radio | Pre-selected profile in the create form |
+
+### Secrets & API Keys
+
+Global secret mappings that bind a Control Plane [secret](/reference/secret) to an environment variable name.
+
+| Column | Description |
+| :----- | :---------- |
+| CPLN Secret | Name of the Control Plane secret |
+| Env Var Name | Environment variable exposed inside sandboxes |
+
+New secrets can be created inline from the settings page.
+
+### Environment Variables
+
+Default environment variables injected into every new sandbox.
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| Name | string | Variable name |
+| Value | string | Variable value |
+| Locked | toggle | Prevent developers from overriding |
+| Description | string | Human-readable description |
+
+### Defaults
+
+| Setting | Description |
+| :------ | :---------- |
+| Default Toolbox | Toolbox image used when none is specified |
+| Default Identity | [Identity](/reference/identity) attached to new sandboxes |
+| Identity Locked | Prevent developers from overriding the identity |
+| Default IDE | IDE used when none is specified |
+| IDE Locked | Prevent developers from overriding the IDE |
+
+<Warning>
+  Locked settings are enforced only in the UI. Users with direct CPLN API access can still override these values.
+</Warning>


### PR DESCRIPTION
## Summary

Adds 7 new documentation pages for the Sandbox Manager product under **How-to Guides > Sandbox**.

## Pages

| Page | Description |
|:---|:---|
| Getting Started | Quickstart — create sandbox, connect IDE, suspend/resume |
| Building Toolbox Images | Templates, runtimes, build modes, forking |
| Sandbox Web UI | Dashboard, instances, images, global settings |
| Container Internals | Boot sequence, gateway proxy, port discovery |
| Terminal & tmux | Session persistence, named sessions, configuration |
| Sandbox Helper CLI | In-container `sandbox` command — status, ports, doctor |
| Multi-Repo Workspaces | Cloning repos, private auth, running multiple services |

## Navigation

Added a **Sandbox** group with `laptop-code` icon under the How-to Guides tab in `docs.json`.

## Format

All pages use Mintlify MDX with:
- Frontmatter (title, description, keywords)
- `<Steps>`, `<Note>`, `<Tip>`, `<Warning>`, `<AccordionGroup>` components
- `theme={null}` on code blocks
- Cross-references to existing docs (`/reference/volumeset`, `/reference/gvc`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)