### PR TITLE
updated trivy docs

### DIFF
--- a/template-catalog/templates/cpln-trivy.mdx
+++ b/template-catalog/templates/cpln-trivy.mdx
@@ -27,7 +27,7 @@ Only images without an existing `cpln/trivy-scan` tag are scanned. To re-scan an
 - **Cron Daemon Workload** — Trivy daemon with trivy-api sidecar, runs on a cron schedule.
 - **Serverless Web-Server Workload** — Report storage and serving, autoscales from 1–3 replicas.
 - **Identity & Policy** — Identity bound to each workload with access to the configured storage cloud account and the service account secret.
-- **Secret** — Opaque secret storing the service account key used to authenticate Trivy against the Control Plane image registry.
+- **Secret** — CPLN secret storing the service account key *(created automatically when using `trivyAuth.type: inline`; skipped when referencing an existing secret)*.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -37,7 +37,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ### Service Account
 
-Trivy authenticates against the Control Plane image registry using a service account key.
+Trivy authenticates against the Control Plane image registry using a service account key. Set `serviceAccountName` to the name of your service account, then choose one of the two auth methods below.
 
 <Steps>
   <Step title="Create or select a service account">
@@ -46,12 +46,30 @@ Trivy authenticates against the Control Plane image registry using a service acc
   <Step title="Generate a key">
     Generate a key for the service account and copy the key value.
   </Step>
-  <Step title="Set the key in values.yaml">
-    Set `trivyPassword` to the key value. The template stores it as an opaque secret named by `trivyPasswordSecretName` (default: `trivy-password`).
+  <Step title="Configure auth in values.yaml">
+    Choose how to provide the key:
+
+    **Inline** (`trivyAuth.type: inline`) — Paste the key directly. The template creates a CPLN secret automatically:
+    ```yaml
+    trivyAuth:
+      type: inline
+      serviceAccountKey: "your-service-account-key"
+    ```
+
+    **Existing Secret** (`trivyAuth.type: existingSecret`) — Reference a pre-existing CPLN **dictionary** secret by name and key. The template grants the workload identity `reveal` access automatically:
+    ```yaml
+    trivyAuth:
+      type: existingSecret
+      existingSecret:
+        name: my-registry-credentials  # CPLN dictionary secret name
+        key: SERVICE_ACCOUNT_KEY       # Key within the dictionary secret
+    ```
   </Step>
 </Steps>
 
 ### Storage
+
+Choose a storage backend — either AWS S3 or Azure File Share. Set `storage.type` to the appropriate value and configure only that section.
 
 <Tabs>
   <Tab title="AWS S3">
@@ -60,7 +78,31 @@ Trivy authenticates against the Control Plane image registry using a service acc
         Create an S3 bucket in your AWS account to store scan reports. Set `storage.s3.bucket` and `storage.s3.region`.
       </Step>
       <Step title="Register a Cloud Account">
-        If you do not have one, [create an AWS Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) in Control Plane with `AmazonS3FullAccess` permissions. Set `storage.s3.cloudAccountName` to its name.
+        If you do not have one, [create an AWS Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) in Control Plane. Set `storage.s3.cloudAccountName` to its name.
+      </Step>
+      <Step title="Create an IAM policy">
+        Create an IAM policy scoped to your bucket (replace `YOUR_BUCKET_NAME`) and set `storage.s3.policyName` to its name:
+
+        ```json
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:GetObject",
+                        "s3:PutObject",
+                        "s3:DeleteObject",
+                        "s3:ListBucket"
+                    ],
+                    "Resource": [
+                        "arn:aws:s3:::YOUR_BUCKET_NAME",
+                        "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+                    ]
+                }
+            ]
+        }
+        ```
       </Step>
     </Steps>
   </Tab>
@@ -117,6 +159,7 @@ storage:
     cloudAccountName: my-aws-cloud-account
     bucket: trivy-reports-bucket
     region: us-east-1
+    policyName: my-trivy-s3-policy  # IAM policy scoped to the bucket (see Prerequisites)
 
   azureFileshare:
     cloudAccountName: my-azure-cloud-account
@@ -127,9 +170,16 @@ storage:
 # Bearer token shared between the daemon and web-server. Change before deploying to production.
 postToken: changeme
 
-# Service account key used by Trivy to authenticate against the Control Plane image registry
-trivyPassword: my-service-account-key
-trivyPasswordSecretName: trivy-password
+# Authentication for Trivy to pull images from the Control Plane image registry.
+# type: "inline"         — paste the key here; template creates the CPLN secret automatically
+# type: "existingSecret" — reference a pre-existing CPLN dictionary secret
+trivyAuth:
+  type: inline
+  serviceAccountKey: my-service-account-key
+
+  existingSecret:
+    name: trivy-credentials  # CPLN dictionary secret name
+    key: serviceAccountKey   # Key within the dictionary secret
 
 # Control Plane service account that Trivy uses to pull images
 serviceAccountName: trivy-service-account
@@ -175,13 +225,16 @@ webServer:
 | `storage.s3.cloudAccountName` | — | AWS Cloud Account name registered in Control Plane |
 | `storage.s3.bucket` | — | S3 bucket name |
 | `storage.s3.region` | — | AWS region (e.g. `us-east-1`) |
+| `storage.s3.policyName` | — | Name of the IAM policy scoped to the bucket |
 | `storage.azureFileshare.cloudAccountName` | — | Azure Cloud Account name registered in Control Plane |
 | `storage.azureFileshare.accountName` | — | Azure storage account name |
 | `storage.azureFileshare.fileShare` | — | Azure file share name |
 | `storage.azureFileshare.scope` | — | Full Azure resource scope for role assignment |
 | `postToken` | `changeme` | Shared bearer token between daemon and web-server |
-| `trivyPassword` | — | Service account key for Trivy registry authentication |
-| `trivyPasswordSecretName` | `trivy-password` | Name of the Control Plane secret storing the key |
+| `trivyAuth.type` | `inline` | Auth method: `inline` or `existingSecret` |
+| `trivyAuth.serviceAccountKey` | — | Service account key value *(required when type is `inline`)* |
+| `trivyAuth.existingSecret.name` | — | CPLN dictionary secret name *(required when type is `existingSecret`)* |
+| `trivyAuth.existingSecret.key` | — | Key within the dictionary secret *(required when type is `existingSecret`)* |
 | `serviceAccountName` | `cpln-trivy-service-account` | Service account Trivy uses to pull images |
 | `schedule` | `*/59 * * * *` | Cron schedule for the scanning daemon |
 | `daemon.resources.cpu` | `1` | CPU for the daemon container |


### PR DESCRIPTION
updated trivy docs to reflect recent changes in template including s3 using least privilege permissions with custom policy and rework secrets with either inline or referencing an existing secret