### PR TITLE
Add Node-Local DNS add-on documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -341,6 +341,7 @@
               "mk8s/add-ons/local_path_storage",
               "mk8s/add-ons/logs",
               "mk8s/add-ons/metrics",
+              "mk8s/add-ons/node_local_dns",
               "mk8s/add-ons/registry_mirror",
               "mk8s/add-ons/sysbox",
               "mk8s/add-ons/dashboard"

--- a/mk8s/add-ons/kubevirt.mdx
+++ b/mk8s/add-ons/kubevirt.mdx
@@ -95,7 +95,7 @@ The add-on also configures the KubeVirt CR automatically — the `DataVolumes`, 
 
 ## DNS
 
-VM guests reach in-cluster services through a platform DNS forwarder. The [`nodeLocalDns`](/mk8s/add-ons) add-on (a per-node CoreDNS cache) is recommended alongside KubeVirt for reliable VM DNS. It is not strictly required — VM cloud-init falls back to TCP DNS (`options use-vc`) — but enabling it avoids edge cases.
+VM guests reach in-cluster services through a platform DNS forwarder. The [`nodeLocalDns`](/mk8s/add-ons/node_local_dns) add-on (a per-node CoreDNS cache) is recommended alongside KubeVirt for reliable VM DNS. It is not strictly required — VM cloud-init falls back to TCP DNS (`options use-vc`) — but enabling it avoids edge cases.
 
 ## Verify
 
@@ -209,7 +209,7 @@ When a guest will not boot far enough to accept SSH or RDP — a kernel panic, a
 
   **Cause:** VM guests resolve in-cluster names through a platform DNS forwarder; large answers can be truncated over UDP on some guests.
 
-  **Fix:** Enable the [`nodeLocalDns`](/mk8s/add-ons) add-on (recommended alongside KubeVirt). On Linux guests you can also force TCP DNS by adding `options use-vc` to `/etc/resolv.conf` from [cloud-init](/reference/workload/vm#cloud-init--platform-injection).
+  **Fix:** Enable the [`nodeLocalDns`](/mk8s/add-ons/node_local_dns) add-on (recommended alongside KubeVirt). On Linux guests you can also force TCP DNS by adding `options use-vc` to `/etc/resolv.conf` from [cloud-init](/reference/workload/vm#cloud-init--platform-injection).
 </Accordion>
 </AccordionGroup>
 

--- a/mk8s/add-ons/node_local_dns.mdx
+++ b/mk8s/add-ons/node_local_dns.mdx
@@ -1,0 +1,82 @@
+---
+title: Node-Local DNS
+description: Run a per-node DNS cache on a Managed Kubernetes (mk8s) cluster to lower DNS latency, reduce load on cluster DNS, and avoid UDP conntrack races.
+keywords: ['mk8s', 'node-local dns', 'nodelocaldns', 'dns cache', 'coredns', 'kube-dns', 'dns latency', 'conntrack', 'kubevirt', 'vm dns']
+---
+
+## Overview
+
+The Node-Local DNS add-on runs a small DNS cache on every node in the cluster as a DaemonSet. Pods send their DNS queries to the local cache on the node instead of reaching the central cluster DNS service over the network, which:
+
+- **Lowers DNS latency** — most lookups are answered from the on-node cache.
+- **Reduces load on cluster DNS** — only cache misses are forwarded to the cluster DNS service.
+- **Avoids UDP `conntrack` races** — a well-known source of intermittent 5-second DNS timeouts in Kubernetes.
+
+The cache listens on the standard link-local address (`169.254.20.10`), caches in-cluster (`cluster.local`) and reverse-lookup zones, and forwards everything else to the cluster DNS service. It also exposes Prometheus metrics, which the [Metrics](/mk8s/add-ons/metrics) add-on collects when enabled.
+
+This add-on is **recommended alongside the [KubeVirt](/mk8s/add-ons/kubevirt) add-on**, where reliable in-cluster name resolution for VM guests matters most.
+
+## Supported Providers
+
+- All providers are supported
+
+## How to Enable
+
+The Node-Local DNS add-on can be enabled during cluster creation or at any time thereafter. It takes no configuration — enabling it is a simple toggle.
+
+### At Cluster Creation
+
+- **Through Cluster Manifest**: Add the following snippet to your cluster manifest when creating the cluster:
+
+  ```yaml YAML
+  spec:
+    ...
+    addOns:
+      nodeLocalDns: {}
+    ...
+  ```
+
+- **Using the Console**: If you're creating the cluster through the console, navigate to `Add-ons`, find the `Node-Local DNS` add-on in the list of available add-ons, and toggle it on.
+
+### After Cluster Creation
+
+If the Node-Local DNS add-on was not enabled during cluster creation, you can still enable it using either of the following methods:
+
+#### Using Manifest
+
+To enable the Node-Local DNS add-on after cluster creation, add the following to your cluster's YAML manifest:
+
+- **Direct Edit & Apply**: Navigate to your cluster in the Console, and use the `Edit & Apply` option.
+- **CLI Application**: Apply the entire manifest using the `cpln apply >_` command or through the `cpln` [CLI](/cli-reference/overview).
+
+  ```yaml YAML
+  spec:
+    ...
+    addOns:
+      nodeLocalDns: {}
+    ...
+  ```
+
+#### Using the UI
+
+1. **Navigate to the Control Plane Console**: Open [Control Plane Console](https://console.cpln.io/console/).
+2. **Select Your Kubernetes Cluster**: In the Control Plane Console, go to `Kubernetes` in the left sidebar, and click on the cluster you wish to configure.
+3. **Enable the Add-on**: Choose `Add-ons`, find the `Node-Local DNS` add-on in the list, and toggle it on.
+
+<Note>
+Once the add-on reconciles, the per-node cache is rolled out as a DaemonSet across the cluster's nodes. No changes to your workloads are required — pods automatically use the local cache for DNS resolution.
+</Note>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="KubeVirt (VM Workloads)" href="/mk8s/add-ons/kubevirt" icon="server">
+    Recommended companion add-on for VM DNS
+  </Card>
+  <Card title="Metrics" href="/mk8s/add-ons/metrics" icon="chart-line">
+    Collect the cache's Prometheus metrics
+  </Card>
+  <Card title="mk8s Overview" href="/mk8s/overview" icon="server">
+    Managed Kubernetes basics
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Adds documentation for the new **Node-Local DNS** mk8s add-on (shipped in the June 2026 platform release). This add-on had no published page.

The new page `mk8s/add-ons/node_local_dns.mdx` follows the existing add-on page pattern and was written against the source of truth:
- `go-libs/schema/mk8s/models.go` / `go-libs/schema/mk8sAddons/models.go` (`NodeLocalDnsAddonConfig` is empty — a no-config toggle, `addOns.nodeLocalDns: {}`)
- `mk8s/actuator/src/addons/node-local-dns/index.ts` (per-node CoreDNS cache as a DaemonSet at `169.254.20.10`; caches in-cluster/reverse zones; forwards misses to cluster DNS; exposes Prometheus metrics; required by the KubeVirt add-on)

## Changes
- New page `mk8s/add-ons/node_local_dns.mdx` — overview (lower DNS latency, less cluster-DNS load, avoids UDP conntrack races), supported providers, and how to enable (manifest + console).
- Added `mk8s/add-ons/node_local_dns` to the Add-ons nav in `docs.json`.
- Pointed the KubeVirt page's two `nodeLocalDns` references at the new page (were linking to the add-ons index).
