### PR TITLE
Document WORKLOAD_DNS_CONFIG_OPTIONS actuator setting

### DIFF
--- a/byok/settings/actuator.mdx
+++ b/byok/settings/actuator.mdx
@@ -184,3 +184,38 @@ taints:
 labels:
   cpln.io/nodeType: core
 ```
+
+### WORKLOAD_DNS_CONFIG_OPTIONS
+
+Overrides the pod `dnsConfig.options` the actuator applies to standard, stateful, cron, and serverless workload pods in this location. Value is a JSON array of `{name, value?}` objects, matching Kubernetes' [PodDNSConfigOption](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config) shape.
+
+Defaults to:
+
+```json
+[
+  { "name": "ndots", "value": "2" },
+  { "name": "single-request-reopen" },
+  { "name": "timeout", "value": "2" },
+  { "name": "attempts", "value": "3" }
+]
+```
+
+These defaults reduce transient `getaddrinfo` resolution failures. Set the value to `[]` to disable pod DNS options entirely.
+
+<Note>
+Changing this setting does not force a fleet-wide pod restart. The new options take effect the next time each workload is otherwise updated (its next deploy).
+</Note>
+
+#### How to configure
+
+Add the environment variable to the actuator settings — either through the [CPLN Platform Add-on](/mk8s/add-ons/byok) configuration or by editing the `cpln-byok-current` ConfigMap directly if you run your own Kubernetes:
+
+```json
+{
+  "actuator": {
+    "env": {
+      "WORKLOAD_DNS_CONFIG_OPTIONS": "[{\"name\":\"ndots\",\"value\":\"2\"}]"
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary
- Adds a new environment-variable section to the Actuator Settings page for `WORKLOAD_DNS_CONFIG_OPTIONS`, shipped in the July 2026 release.
- Lets operators of custom (BYOK) locations override the default pod DNS resolver options the actuator applies to standard, stateful, cron, and serverless workload pods.

## Test plan
- [ ] Preview renders correctly (code blocks, `<Note>` callout)
- [ ] Links to `/mk8s/add-ons/byok` resolve