### PR TITLE
docs: sync the -ml placeholder rename that missed PR 258

### DIFF
--- a/template-catalog/templates/grafana-multi-location.mdx
+++ b/template-catalog/templates/grafana-multi-location.mdx
@@ -29,11 +29,11 @@ With N locations you survive `floor((N-1)/2)` losses, so an even count buys noth
 ### What Gets Created
 
 - **GVC** — A new GVC pinned to the configured locations. This template always creates it.
-- **Standard Grafana UI Workload** — `{release}-grafana-ml`, `replicas` instances **per location**, serving the UI and HTTP API on port `3000`. Public by default. Alert rule execution is disabled here.
-- **Standard Alert Evaluator Workload** — `{release}-grafana-ml-alerting`, the same image with **exactly one replica**, running only in `alerting.location` and never reachable from the internet. Optional — set `alerting.location: ""` to omit it entirely.
+- **Standard Grafana UI Workload** — `{release}-grafana`, `replicas` instances **per location**, serving the UI and HTTP API on port `3000`. Public by default. Alert rule execution is disabled here.
+- **Standard Alert Evaluator Workload** — `{release}-grafana-alerting`, the same image with **exactly one replica**, running only in `alerting.location` and never reachable from the internet. Optional — set `alerting.location: ""` to omit it entirely.
 - **App Database Workloads** — The `postgres-multi-location` subchart: a stateful Patroni PostgreSQL workload with one primary and asynchronous replicas, a stateful etcd workload for consensus, and an HAProxy leader-routing tier in every location.
-- **Volume Sets** — `{release}-postgres-ml-vs` for the PostgreSQL data directory and the etcd cluster's own volume set. Grafana has none.
-- **Secrets** — The subchart's startup scripts, and — only when `datasources.definitions` is set — `{release}-grafana-ml-datasources`, the rendered datasource provisioning file mounted by both Grafana workloads. The admin password, encryption key and database credentials are **prerequisite secrets you create yourself**; the chart references them by name and never creates, modifies or deletes them.
+- **Volume Sets** — `{release}-postgres-vs` for the PostgreSQL data directory and the etcd cluster's own volume set. Grafana has none.
+- **Secrets** — The subchart's startup scripts, and — only when `datasources.definitions` is set — `{release}-grafana-datasources`, the rendered datasource provisioning file mounted by both Grafana workloads. The admin password, encryption key and database credentials are **prerequisite secrets you create yourself**; the chart references them by name and never creates, modifies or deletes them.
 - **Identity & Policy** — One identity shared by both Grafana workloads, with `reveal` on exactly the secrets they mount and nothing else.
 
 <Note>
@@ -54,7 +54,7 @@ The GVC named in `global.gvc.name` **must not already exist**. Helm adopts a GVC
 
     ```bash
     printf '%s' "$(openssl rand -hex 24)" \
-      | cpln secret create-opaque --name my-grafana-ml-admin-password --encoding plain -f -
+      | cpln secret create-opaque --name my-grafana-admin-password --encoding plain -f -
     ```
 
     Set `admin.passwordSecretName` to the name you used.
@@ -64,7 +64,7 @@ The GVC named in `global.gvc.name` **must not already exist**. Helm adopts a GVC
 
     ```bash
     printf '%s' "$(openssl rand -hex 32)" \
-      | cpln secret create-opaque --name my-grafana-ml-secret-key --encoding plain -f -
+      | cpln secret create-opaque --name my-grafana-secret-key --encoding plain -f -
     ```
 
     Set `admin.secretKeySecretName` to the name you used.
@@ -73,7 +73,7 @@ The GVC named in `global.gvc.name` **must not already exist**. Helm adopts a GVC
     A [dictionary secret](/guides/create-secret/dictionary) holding exactly `username`, `password` and `database`:
 
     ```bash
-    cpln secret create-dictionary --name my-grafana-ml-db-credentials \
+    cpln secret create-dictionary --name my-grafana-db-credentials \
       --entry username=grafana \
       --entry password="$(openssl rand -hex 24)" \
       --entry database=grafana
@@ -83,7 +83,7 @@ The GVC named in `global.gvc.name` **must not already exist**. Helm adopts a GVC
   </Step>
   <Step title="Read a secret back later">
     ```bash
-    cpln secret reveal my-grafana-ml-db-credentials -o json
+    cpln secret reveal my-grafana-db-credentials -o json
     ```
 
     Without `-o json` the command prints a table containing no secret data.
@@ -91,7 +91,7 @@ The GVC named in `global.gvc.name` **must not already exist**. Helm adopts a GVC
 </Steps>
 
 <Warning>
-**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still reports success while the affected workload sits at zero replicas waiting on a secret reference that never resolves, which looks like a broken install. Create all three first, and confirm with `cpln workload get-deployments {release}-grafana-ml --gvc {gvc}` rather than trusting the Helm output.
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still reports success while the affected workload sits at zero replicas waiting on a secret reference that never resolves, which looks like a broken install. Create all three first, and confirm with `cpln workload get-deployments {release}-grafana --gvc {gvc}` rather than trusting the Helm output.
 </Warning>
 
 Optional features each need something created **before** you install:
@@ -193,11 +193,11 @@ admin:
   # The password applies only when the admin account is FIRST created; on later
   # boots Grafana ignores it (change it in the UI instead).
   applyPassword: true # set false after your first login to stop referencing the password secret
-  passwordSecretName: my-grafana-ml-admin-password # opaque secret holding the first-boot admin password
+  passwordSecretName: my-grafana-admin-password # opaque secret holding the first-boot admin password
   # DIFFERENT LIFECYCLE — permanent. Read on EVERY boot by EVERY instance to
   # decrypt datasource credentials stored in the shared database: never delete
   # it, never rotate it.
-  secretKeySecretName: my-grafana-ml-secret-key # opaque secret holding the encryption key
+  secretKeySecretName: my-grafana-secret-key # opaque secret holding the encryption key
 
 # ─── Datasources as Code (optional) ───────────────────────────────────────────
 # Grafana datasource provisioning entries, passed through verbatim. Every
@@ -222,7 +222,7 @@ datasources:
   # pre-created dictionary secret and write $KEY above. Every $KEY needs an entry
   # here, and the secrets MUST EXIST BEFORE INSTALL.
   credentialSecrets: []
-  # - name: my-grafana-ml-ds-credentials
+  # - name: my-grafana-ds-credentials
   #   keys: [PG_PASSWORD]
 
 # ─── SMTP for Alert Emails (optional) ─────────────────────────────────────────
@@ -262,7 +262,7 @@ postgresML:
     # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL.
     # A `dictionary` secret holding exactly `username`, `password` and
     # `database`. If it does not exist the deployment wedges waiting on it.
-    credentialsSecretName: my-grafana-ml-db-credentials
+    credentialsSecretName: my-grafana-db-credentials
 
   # Preferred location for the database primary. Keep it aligned with
   # alerting.location so the hot path has no cross-region hop.
@@ -299,19 +299,19 @@ postgresML:
       intervalSeconds: 21600
     provider: aws # options: aws, gcp, minio
     aws:
-      bucket: my-grafana-ml-bucket
+      bucket: my-grafana-bucket
       region: us-east-1
       cloudAccountName: my-s3-cloud-account
-      policyName: my-grafana-ml-backup-policy
+      policyName: my-grafana-backup-policy
       prefix: grafana/backups
     gcp:
-      bucket: my-grafana-ml-bucket
+      bucket: my-grafana-bucket
       cloudAccountName: my-gcs-cloud-account
       prefix: grafana/backups
     minio:
       endpoint: http://my-minio-workload:9000
-      bucket: my-grafana-ml-bucket
-      credentialsSecretName: my-grafana-ml-minio-credentials
+      bucket: my-grafana-bucket
+      credentialsSecretName: my-grafana-minio-credentials
       prefix: grafana/backups
 ```
 
@@ -370,7 +370,7 @@ datasources:
       secureJsonData:
         password: $PG_PASSWORD
   credentialSecrets:
-    - name: my-grafana-ml-ds-credentials
+    - name: my-grafana-ds-credentials
       keys: [PG_PASSWORD]
 ```
 
@@ -430,7 +430,7 @@ Four consequences worth knowing before you rely on it:
 - **Silences do not propagate between instances.** Without gossip, a silence created against the UI tier is not guaranteed to be honored by the evaluator, so create silences against the evaluator directly:
 
   ```bash
-  curl http://RELEASE_NAME-grafana-ml-alerting.GVC_NAME.cpln.local:3000/api/alertmanager/grafana/api/v2/silences
+  curl http://RELEASE_NAME-grafana-alerting.GVC_NAME.cpln.local:3000/api/alertmanager/grafana/api/v2/silences
   ```
 
 <Warning>
@@ -464,16 +464,16 @@ Substitute your release name and the GVC name from `global.gvc.name`.
 
 | What | Where |
 |---|---|
-| Grafana UI / API (public) | `status.canonicalEndpoint` of `{release}-grafana-ml` — `cpln workload get RELEASE_NAME-grafana-ml --gvc GVC_NAME -o yaml` |
-| Grafana UI / API (internal) | `RELEASE_NAME-grafana-ml.GVC_NAME.cpln.local:3000` |
-| Alert evaluator (internal, own location only) | `RELEASE_NAME-grafana-ml-alerting.GVC_NAME.cpln.local:3000` |
-| App database (always the current primary) | `RELEASE_NAME-postgres-ml-proxy.GVC_NAME.cpln.local:5432` |
+| Grafana UI / API (public) | `status.canonicalEndpoint` of `{release}-grafana` — `cpln workload get RELEASE_NAME-grafana --gvc GVC_NAME -o yaml` |
+| Grafana UI / API (internal) | `RELEASE_NAME-grafana.GVC_NAME.cpln.local:3000` |
+| Alert evaluator (internal, own location only) | `RELEASE_NAME-grafana-alerting.GVC_NAME.cpln.local:3000` |
+| App database (always the current primary) | `RELEASE_NAME-postgres-proxy.GVC_NAME.cpln.local:5432` |
 | Admin login | `admin.user`, with the password in the secret named by `admin.passwordSecretName` — `cpln secret reveal SECRET_NAME -o json` |
 
 Health and readiness are served at `/api/health`, which reports the Grafana version and the app-database status. The [Grafana HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/) is available on the same endpoint for scripted dashboard, datasource and alert-rule management.
 
 <Note>
-An in-GVC request to `RELEASE_NAME-grafana-ml.GVC_NAME.cpln.local:3000` is always served by an instance in the **caller's own** location. That is why a single write-then-read from one client proves nothing about cross-location state.
+An in-GVC request to `RELEASE_NAME-grafana.GVC_NAME.cpln.local:3000` is always served by an instance in the **caller's own** location. That is why a single write-then-read from one client proves nothing about cross-location state.
 </Note>
 
 ## Availability and Planned Outages
@@ -573,7 +573,7 @@ The backup path has been exercised against **AWS S3** and **MinIO**, and a **wal
         Create a [dictionary secret](/guides/create-secret/dictionary) and set `postgresML.backup.minio.credentialsSecretName` to its name, then set `postgresML.backup.minio.prefix` to the folder path:
 
         ```bash
-        cpln secret create-dictionary --name my-grafana-ml-minio-credentials \
+        cpln secret create-dictionary --name my-grafana-minio-credentials \
           --entry accessKey=MINIO_ACCESS_KEY \
           --entry secretKey=MINIO_SECRET_KEY
         ```

--- a/template-catalog/templates/postgres-multi-location.mdx
+++ b/template-catalog/templates/postgres-multi-location.mdx
@@ -29,13 +29,13 @@ With N locations you survive `floor((N-1)/2)` losses, so an even count buys noth
 ### What Gets Created
 
 - **GVC** — A new GVC pinned to the configured locations. This template always creates it.
-- **Stateful Patroni PostgreSQL Workload** — `{release}-postgres-ml`, running PostgreSQL 17 with Patroni. Each configured location runs `replicas` members, every member gets its own volume, and every member is individually addressable. PostgreSQL listens on `5432` and the Patroni REST API on `8008`.
+- **Stateful Patroni PostgreSQL Workload** — `{release}-postgres`, running PostgreSQL 17 with Patroni. Each configured location runs `replicas` members, every member gets its own volume, and every member is individually addressable. PostgreSQL listens on `5432` and the Patroni REST API on `8008`.
 - **Stateful etcd Workload** — `{release}-etcd`, the bundled `etcd-multi-location` chart providing consensus, one member per location.
-- **HAProxy Leader-Routing Workload** *(optional, enabled by default)* — `{release}-postgres-ml-proxy`, one tier per location, each routing to the single current primary.
-- **PgBouncer Workload** *(optional)* — `{release}-postgres-ml-pgbouncer`, a connection pooler, one tier per location, pooling into that location's HAProxy.
-- **Cron Backup Workload** *(optional)* — `{release}-postgres-ml-backup`, a scheduled `pg_dumpall` to object storage, running in exactly one location.
+- **HAProxy Leader-Routing Workload** *(optional, enabled by default)* — `{release}-postgres-proxy`, one tier per location, each routing to the single current primary.
+- **PgBouncer Workload** *(optional)* — `{release}-postgres-pgbouncer`, a connection pooler, one tier per location, pooling into that location's HAProxy.
+- **Cron Backup Workload** *(optional)* — `{release}-postgres-backup`, a scheduled `pg_dumpall` to object storage, running in exactly one location.
 - **WAL-G Sidecar** *(optional)* — A sidecar on every Patroni member; only the member holding the leader lock archives WAL and pushes base backups.
-- **Volume Sets** — `{release}-postgres-ml-vs` for the PostgreSQL data directory (`ext4`, final snapshot with 7-day retention), plus the etcd cluster's own volume set.
+- **Volume Sets** — `{release}-postgres-vs` for the PostgreSQL data directory (`ext4`, final snapshot with 7-day retention), plus the etcd cluster's own volume set.
 - **Secrets** — Opaque secrets holding the Patroni startup script, the HAProxy startup script, and the WAL-G backup script. The **database credentials secret is not created by this template** — see [Prerequisites](#prerequisites).
 - **Identity & Policy** — An identity per workload group with `reveal` on exactly the secrets in play, plus a bucket-scoped cloud binding when backups are enabled.
 
@@ -56,7 +56,7 @@ PostgreSQL credentials are supplied through a [dictionary secret](/guides/create
     The secret must hold exactly three keys — `username`, `password` and `database`:
 
     ```bash
-    cpln secret create-dictionary --name my-postgres-ml-credentials \
+    cpln secret create-dictionary --name my-postgres-credentials \
       --entry username=postgres \
       --entry password="$(openssl rand -hex 24)" \
       --entry database=mydb
@@ -69,7 +69,7 @@ PostgreSQL credentials are supplied through a [dictionary secret](/guides/create
   </Step>
   <Step title="Read the credentials back later">
     ```bash
-    cpln secret reveal my-postgres-ml-credentials
+    cpln secret reveal my-postgres-credentials
     ```
   </Step>
 </Steps>
@@ -138,7 +138,7 @@ postgres:
   # A `dictionary` secret holding exactly three keys: `username`, `password` and
   # `database`. If it does not exist at install time the deployment WEDGES
   # waiting on it and looks broken.
-  credentialsSecretName: my-postgres-ml-credentials
+  credentialsSecretName: my-postgres-credentials
 
 # Preferred location for the primary. CHANGING THIS ON A LIVE CLUSTER MOVES THE
 # LEADER: the value is baked into the startup script, so editing it restarts every
@@ -211,23 +211,23 @@ backup:
   provider: aws # options: aws, gcp, minio
 
   aws:
-    bucket: my-postgres-ml-bucket
+    bucket: my-postgres-bucket
     region: us-east-1
     cloudAccountName: my-s3-cloud-account
-    policyName: my-postgres-ml-backup-policy # bucket-scoped IAM policy
+    policyName: my-postgres-backup-policy # bucket-scoped IAM policy
     prefix: postgres/backups # folder within the bucket
 
   gcp:
-    bucket: my-postgres-ml-bucket
+    bucket: my-postgres-bucket
     cloudAccountName: my-gcs-cloud-account
     prefix: postgres/backups # folder within the bucket
 
   minio: # a self-hosted MinIO workload, or any S3-compatible endpoint
     endpoint: http://my-minio-workload:9000 # e.g. http://WORKLOAD_NAME:9000 in the same GVC
-    bucket: my-postgres-ml-bucket
+    bucket: my-postgres-bucket
     # REQUIRED PREREQUISITE SECRET when provider is `minio` — a `dictionary`
     # secret holding `accessKey` and `secretKey`.
-    credentialsSecretName: my-postgres-ml-minio-credentials
+    credentialsSecretName: my-postgres-minio-credentials
     prefix: postgres/backups # folder within the bucket
 
 # ─── etcd (subchart: etcd-multi-location) ─────────────────────────────────────
@@ -336,9 +336,9 @@ Everything is internal to Control Plane. Substitute your release name and the GV
 
 | What | Where |
 |---|---|
-| PostgreSQL, pooled (when PgBouncer is enabled) | `RELEASE_NAME-postgres-ml-pgbouncer.GVC_NAME.cpln.local:5432` |
-| PostgreSQL, current primary (recommended otherwise) | `RELEASE_NAME-postgres-ml-proxy.GVC_NAME.cpln.local:5432` |
-| PostgreSQL, one specific member | `replica-INDEX.RELEASE_NAME-postgres-ml.LOCATION.GVC_NAME.cpln.local:5432` |
+| PostgreSQL, pooled (when PgBouncer is enabled) | `RELEASE_NAME-postgres-pgbouncer.GVC_NAME.cpln.local:5432` |
+| PostgreSQL, current primary (recommended otherwise) | `RELEASE_NAME-postgres-proxy.GVC_NAME.cpln.local:5432` |
+| PostgreSQL, one specific member | `replica-INDEX.RELEASE_NAME-postgres.LOCATION.GVC_NAME.cpln.local:5432` |
 | Patroni REST API | Port `8008` on the same per-member names (`/primary`, `/replica`, `/health`) |
 | HAProxy health and stats | `:8404/healthz` and `:8405/stats` on the proxy workload |
 | Credentials | The dictionary secret named by `postgres.credentialsSecretName` |
@@ -379,16 +379,16 @@ Replication is **asynchronous**. A promoted replica applies everything it has re
 
 ## Operating the Cluster
 
-Members are named `{workload}-{location}-{index}`, for example `my-db-postgres-ml-aws-us-east-1-0`. `patronictl` reads the config the startup script writes to `/tmp/patroni_config.yml`:
+Members are named `{workload}-{location}-{index}`, for example `my-db-postgres-aws-us-east-1-0`. `patronictl` reads the config the startup script writes to `/tmp/patroni_config.yml`:
 
 ```bash
 # Every member, its location, role and replication lag
-cpln workload exec RELEASE_NAME-postgres-ml --gvc GVC_NAME --container patroni-postgres \
+cpln workload exec RELEASE_NAME-postgres --gvc GVC_NAME --container patroni-postgres \
   -- patronictl -c /tmp/patroni_config.yml list
 
 # Move a live primary to another location — a planned, near-zero-downtime handover
-cpln workload exec RELEASE_NAME-postgres-ml --gvc GVC_NAME --container patroni-postgres \
-  -- patronictl -c /tmp/patroni_config.yml switchover --candidate RELEASE_NAME-postgres-ml-LOCATION-0 --force
+cpln workload exec RELEASE_NAME-postgres --gvc GVC_NAME --container patroni-postgres \
+  -- patronictl -c /tmp/patroni_config.yml switchover --candidate RELEASE_NAME-postgres-LOCATION-0 --force
 ```
 
 Consensus-level settings (`ttl`, `loop_wait`, `retry_timeout`, `maximum_lag_on_failover`, failsafe mode) are written once, when the cluster is first initialized, and are not values knobs. Change them on a live cluster with `patronictl edit-config`.
@@ -474,7 +474,7 @@ No Cloud Account is needed — credentials are supplied as a secret.
 3. Create a dictionary secret holding the MinIO credentials and set `backup.minio.credentialsSecretName` to its name. For the `minio` template these are its `admin.username` and `admin.password`:
 
 ```bash
-cpln secret create-dictionary --name my-postgres-ml-minio-credentials \
+cpln secret create-dictionary --name my-postgres-minio-credentials \
   --entry accessKey=MINIO_ACCESS_KEY \
   --entry secretKey=MINIO_SECRET_KEY
 ```
@@ -498,7 +498,7 @@ export PGPASSWORD="PASSWORD"
 aws s3 cp "s3://BUCKET_NAME/PREFIX/BACKUP_FILE.sql.gz" - \
   | gunzip \
   | psql \
-      --host=RELEASE_NAME-postgres-ml-proxy.GVC_NAME.cpln.local \
+      --host=RELEASE_NAME-postgres-proxy.GVC_NAME.cpln.local \
       --port=5432 \
       --username=USERNAME \
       --dbname=postgres


### PR DESCRIPTION
The maintainer hit this installing from the published chart: the docs' `cpln secret create-*` commands and YAML blocks still name `my-grafana-ml-admin-password`, `my-postgres-ml-credentials` and friends, while the shipped templates now use `my-grafana-admin-password`, `my-postgres-credentials`.

**Cause:** this commit was pushed to `docs-cycle-2026-08-multiloc` *after* PR 258 had already merged, so it was left orphaned on the branch. I reported it as "PR 258 updated" without checking the PR was still open.

**Effect:** anyone following the docs creates secrets under names the chart does not reference, so the deployment waits on secrets that do not exist — the wedge the Prerequisites section explicitly warns about.

48 replacements across the two pages: the prerequisite `create-opaque` / `create-dictionary` commands, the Configuration YAML blocks, the Connecting tables and the `cpln workload exec` examples.

Verified against the **published** chart rather than the repo: the `my-grafana-*` placeholder set in `oci://ghcr.io/controlplane-com/templates/grafana-multi-location:1.0.0` is now byte-identical to the set on the page. No `-ml` remains on either page, and `mintlify broken-links` reports only the pre-existing unrelated `headlamp` break.