### PR TITLE
docs: update PrivateLink RDS guide for cpln-rds-producer changes

### DIFF
--- a/guides/native-networking/aws-privatelink/privatelink-rds-terraform.mdx
+++ b/guides/native-networking/aws-privatelink/privatelink-rds-terraform.mdx
@@ -38,7 +38,7 @@ Follow the steps below to provision (or integrate with existing) an [RDS](https:
 
 **Software Requirements:**
 - Install AWS [CLI](https://aws.amazon.com/cli/).
-- Install Terraform [CLI](https://developer.hashicorp.com/terraform).
+- Install Terraform [CLI](https://developer.hashicorp.com/terraform) version `1.11.1` or later.
 - [Git](https://git-scm.com/) (for cloning the repository).
 
 **AWS Account Requirements:**
@@ -55,6 +55,7 @@ Follow the steps below to provision (or integrate with existing) an [RDS](https:
     "password": "your_db_password"
     }
     ```
+- Your RDS instance's security group must allow inbound PostgreSQL traffic (port 5432) from the VPC CIDR, so the RDS Proxy created by the Terraform can reach the database.
 
 ### Step 1 - Clone Control Plane Terraform
 ```bash
@@ -86,14 +87,19 @@ terraform apply
 ```
 - The Terraform will automatically provision all necessary resources and output your PrivateLink endpoint service name.
 
+<Note>
+If `terraform apply` fails with `Cannot find version X for postgres`, AWS has retired that PostgreSQL minor version. Set the `rds_engine_version` variable to a currently offered version (list them with `aws rds describe-db-engine-versions --engine postgres --query 'DBEngineVersions[].EngineVersion'`).
+</Note>
+
 - For more information, refer to the [repository README](https://github.com/controlplane-com/cpln-rds-producer#control-plane-rds-producer-terraform-modules)
 
 ## Next Steps
 - Contact <a href="mailto:support@controlplane.com">support@controlplane.com</a> with your service name and region.
 - Control Plane will use this to create the consumer-side endpoint connection.
-- Once notified that the consumer endpoint has been created, go to your AWS Console:
-    - Navigate to `VPC` and to `Endpoint Services`.
-    - Click on your PrivateLink service.
-    - Under Pending endpoint connections, select the pending request.
-    - Click the `Actions` dropdown and accept endpoint connection request.
+- No manual acceptance is required: the endpoint service is created with automatic acceptance enabled and only allows connections from Control Plane's AWS account (the `allowed_principal_arn` variable).
 - Proceed to follow the [Native Networking Setup](/guides/native-networking/native-networking-setup) in Control Plane.
+
+## Connecting to the Database
+- **TLS is required.** The RDS Proxy is configured with `require_tls`, so clients must connect with SSL enabled (e.g., `sslmode=require` for PostgreSQL clients).
+- Authenticate using the database username and password stored in the Secrets Manager Secret.
+- Connect to the PrivateLink endpoint on port `5432`.


### PR DESCRIPTION
- Terraform minimum version is now 1.11.1
- Existing-infrastructure mode: the RDS security group must allow 5432 from the VPC CIDR so the proxy can reach the database
- Note on AWS retiring PostgreSQL minor versions (rds_engine_version)
- Remove manual endpoint-acceptance steps: the endpoint service uses automatic acceptance restricted to Control Plane's principal
- Add client connection section (TLS required, secret credentials, 5432)