### PR TITLE
docs: document the etcd storage fix across twenty template pages

### DIFF
--- a/template-catalog/templates/cdc-pipeline.mdx
+++ b/template-catalog/templates/cdc-pipeline.mdx
@@ -145,9 +145,13 @@ debezium-server:
 
 | Component | Template Version | Software Version |
 |-----------|-----------------|-----------------|
-| PostgreSQL HA | 2.2.0 | PostgreSQL 17 (Patroni) |
-| Kafka | 4.0.0 | Apache Kafka 3.9.1 (KRaft) |
-| Debezium Server | 1.1.0 | Debezium 3.0 |
+| PostgreSQL HA | 2.4.2 | PostgreSQL 17 (Patroni) |
+| Kafka | 4.0.1 | Apache Kafka 3.9.1 (KRaft) |
+| Debezium Server | 1.1.1 | Debezium 3.0 |
+
+<Warning>
+**Versions `1.0.0` and `1.0.1` did not compact the etcd cluster inside the bundled PostgreSQL HA store**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. This template bundles PostgreSQL HA unconditionally, with no toggle to opt out, so **every install on `1.0.0` or `1.0.1` is affected**; see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.2` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
 
 ### Using External PostgreSQL or Kafka
 

--- a/template-catalog/templates/chatwoot.mdx
+++ b/template-catalog/templates/chatwoot.mdx
@@ -447,6 +447,10 @@ Enable exactly one of `postgresHA` (default) or `postgres` — the chart refuses
 In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it seeds the database on first boot and is not updated by later value edits.
 
 <Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
+<Warning>
 Choose the database mode **before** installing — it cannot be switched later. Flipping `postgresHA.enabled` / `postgres.enabled` on a live release points Chatwoot at a different, empty database (a separate volume set, and a different PostgreSQL major version), so the app re-runs onboarding and your existing conversations are orphaned rather than migrated.
 </Warning>
 

--- a/template-catalog/templates/etcd-multi-location.mdx
+++ b/template-catalog/templates/etcd-multi-location.mdx
@@ -1,7 +1,7 @@
 ---
 title: etcd Multi-Location
 description: Deploy etcd Multi-Location on Control Plane using the Template Catalog. Covers configuration, volumes, quorum sizing, and a stretched key-value cluster with exactly one member per location.
-keywords: ['kv store', 'cross-region coordination', 'raft consensus', 'leader election', 'distributed lock', 'consul alternative', 'zookeeper alternative', 'geo-distributed', 'etcdctl', 'service discovery', 'config store', 'failover']
+keywords: ['kv store', 'cross-region coordination', 'raft consensus', 'leader election', 'distributed lock', 'consul alternative', 'zookeeper alternative', 'geo-distributed', 'etcdctl', 'service discovery', 'config store', 'failover', 'auto-compaction', 'backend quota', 'nospace alarm']
 ---
 
 ## Overview
@@ -81,6 +81,11 @@ resources:
 tuning:
   heartbeatIntervalMs: 250 # ~0.5-1.5x the worst round trip between locations
   electionTimeoutMs: 5000 # must be >= 10x heartbeatIntervalMs; maximum 50000
+  # etcd keeps every superseded revision until told otherwise, so compaction is
+  # required rather than optional and cannot be switched off here.
+  autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+  autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h); revision takes a count
+  quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
 
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
@@ -140,7 +145,42 @@ The defaults detect a dead leader in about 5 seconds across an AWS us-east ↔ e
 
 - `volumeset.capacity` — Persistent volume size in GiB per member for the raft write-ahead log and snapshots (minimum 10).
 
-Auto-compaction is enabled by design (periodic, every hour) and is not configurable. The first compaction happens an hour after a member starts, and a restart resets that clock. Without it, a continuously written cluster grows revisions until it reaches etcd's 2 GiB backend quota and goes read-only. Compaction reclaims pages for reuse rather than shrinking the file, so the reported `dbSize` plateaus instead of dropping — only `etcdctl defrag` returns space to the filesystem.
+### Compaction and Backend Growth
+
+etcd never discards a superseded revision on its own. Every write creates a new revision and the old one is kept until a **compaction** removes it, so the backend grows with **time alone** whenever a client writes on a timer — Patroni, for example, renews its leader lease roughly every 10 seconds, which produces new revisions whether or not any application data changes. Measured on an otherwise idle cluster: about **151,000 revisions and 19 MB per day**, which reaches etcd's default 2 GiB backend quota in roughly **110 days**.
+
+When the quota is reached, etcd raises a cluster-wide `NOSPACE` alarm and **every member goes read-only** until an operator intervenes. Auto-compaction is what prevents that. It has always been enabled in this template; since version `1.0.2` it is also configurable, alongside the backend quota:
+
+```yaml
+tuning:
+  autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+  autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h); revision takes a count
+  quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
+```
+
+- `tuning.autoCompactionMode` — How `autoCompactionRetention` is read. `periodic` treats it as a time window; `revision` treats it as a number of revisions to keep. There is no "off" — an unrecognized mode is rejected at render time.
+- `tuning.autoCompactionRetention` — How much history is kept before old revisions are discarded. The default `1h` keeps the backend flat and is the value this template is tested at. Raising it to `24h` or more buys a longer history window at the cost of a larger backend.
+- `tuning.quotaBackendBytes` — Backend size ceiling in bytes. `0` (the default) means the flag is not passed at all and etcd applies its own 2 GiB limit. Leave it at `0` unless the keyspace genuinely outgrows that; 8 GiB (`8589934592`) is etcd's own suggested maximum, above which it warns at startup.
+
+<Warning>
+**In `periodic` mode a retention value without a unit means hours.** etcd reads a bare `30` as thirty *hours*, not thirty minutes. This template rejects an unsuffixed value at render time rather than letting it become a silently wrong window — write `30m`, `1h` or `24h`.
+</Warning>
+
+<Warning>
+**`quotaBackendBytes` takes a plain byte count, not a size suffix.** etcd itself refuses `--quota-backend-bytes 2Gi` at boot and the cluster would crash-loop, so a `2Gi`-style value is rejected at render time instead. Write `2147483648`.
+</Warning>
+
+Compaction is deliberately not switchable off: a retention of `0`, an unrecognized mode and a negative quota (which etcd reads as "no quota at all") are each rejected at render time. Each one produces a chart that installs cleanly and fails weeks later.
+
+<Note>
+**Compaction frees pages for reuse inside the backend file; it does not shrink the file.** The reported `dbSize` therefore plateaus rather than dropping, while `dbSizeInUse` falls back to the size of the live keyspace. That is the expected behavior and is sufficient to stay under the quota, because reclaimed pages are reused for new writes. Only `etcdctl defrag` returns space to the filesystem, and this template does not automate it — defragmentation blocks the member it runs on.
+
+Testing measured the mechanism directly on a shortened retention window: the compacted revision advanced from 1 to 4001, `dbSizeInUse` collapsed from 5.76 MB to 20,480 bytes while `dbSize` stayed at about 5.8 MB, and reads of pre-compaction revisions then failed with `required revision has been compacted`. On this template's own three-location run at the default `1h`, compaction fired at the one-hour mark, freed 569 KB, and `dbSize` stayed flat afterwards under load. The multi-day `dbSize` plateau is **derived from that mechanism rather than observed** over days.
+</Note>
+
+<Note>
+`etcdctl endpoint status` reports `QUOTA | 0 B` when `quotaBackendBytes` is `0`, because that column reflects the flag rather than the effective limit. The effective quota in that case is still etcd's 2 GiB default, which etcd logs at startup as `enabled backend quota with default value`.
+</Note>
 
 ### Internal Access
 
@@ -251,11 +291,35 @@ Never suspend a location for this workload. Suspending and resuming a location p
 Never set `recovery.forceNewClusterInLocation` to more than one location, and never leave it set. Two members both forcing a new cluster produce two divergent single-member clusters that cannot be merged.
 </Warning>
 
+## If the Backend Quota Fills
+
+Every version of this template compacts, so a default install does not accumulate revisions in the first place. A backend can still reach the quota if the keyspace itself is genuinely large, or if `autoCompactionRetention` has been raised far enough that the retained history outgrows 2 GiB.
+
+<Warning>
+**Turning compaction on, or tightening it, cannot rescue a cluster that has already filled its backend.** Compaction stops further growth; it never shrinks an existing backend file. Once etcd has raised a `NOSPACE` alarm, writes stay rejected until an operator compacts, defragments each member and disarms the alarm — a `helm upgrade` does none of that.
+</Warning>
+
+The symptom usually surfaces in the client rather than in etcd. A Patroni replica that cannot renew its lease exits *cleanly*, so it restart-loops with `exitCode: 0` and `reason: Completed` and a climbing restart count — which reads as healthy and gets misdiagnosed as a database fault. Check etcd first.
+
+Both inspection commands are read-only and safe to run on a live cluster:
+
+```bash
+cpln workload exec RELEASE_NAME-etcd --gvc GVC_NAME --container etcd -- etcdctl endpoint status --cluster -w table
+cpln workload exec RELEASE_NAME-etcd --gvc GVC_NAME --container etcd -- etcdctl alarm list
+```
+
+Add `--location LOCATION` to target a specific location's member; without it the CLI picks one for you and names it in its output. `endpoint status --cluster` reports every member from whichever one you reach.
+
+A `DB SIZE` close to 2.1 GB on every member, plus `NOSPACE` in the alarm list, confirms it. A healthy cluster prints nothing at all for `alarm list`. Recovery from there — compacting to a revision, defragmenting each member, then disarming the alarm — is an operator procedure this template deliberately does not perform, because each step is disruptive and the order matters. Follow etcd's [maintenance guide](https://etcd.io/docs/v3.6/op-guide/maintenance/) and plan it as a maintenance window.
+
 ## External References
 
 <CardGroup cols={2}>
     <Card title="etcd Documentation" icon="book" href="https://etcd.io/docs/v3.6/">
     Official etcd documentation
+    </Card>
+    <Card title="Maintenance and Compaction" icon="broom" href="https://etcd.io/docs/v3.6/op-guide/maintenance/">
+    Compaction, defragmentation, and clearing a NOSPACE alarm
     </Card>
     <Card title="Tuning for Latency" icon="gauge" href="https://etcd.io/docs/v3.6/tuning/">
     Heartbeat and election timeout guidance for cross-region clusters

--- a/template-catalog/templates/etcd.mdx
+++ b/template-catalog/templates/etcd.mdx
@@ -1,12 +1,12 @@
 ---
 title: etcd
 description: Deploy etcd on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and distributed key-value store cluster setup with peer discovery.
-keywords: ['kv store', 'service discovery', 'config store', 'consul alternative', 'zookeeper alternative', 'k8s backend', 'distributed lock', 'raft consensus', 'leader election', 'coordination service']
+keywords: ['kv store', 'service discovery', 'config store', 'consul alternative', 'zookeeper alternative', 'k8s backend', 'distributed lock', 'raft consensus', 'leader election', 'coordination service', 'auto-compaction', 'nospace alarm', 'backend quota', 'etcdctl']
 ---
 
 ## Overview
 
-etcd is a distributed, reliable key-value store designed for the most critical data of a distributed system. It provides consistent coordination, service discovery, and configuration management across distributed systems, making it a common foundation for cluster health and orchestration. This template deploys an etcd cluster as a stateful workload with configurable replica count and persistent storage.
+etcd is a distributed, reliable key-value store designed for the most critical data of a distributed system. It provides consistent coordination, service discovery, and configuration management across distributed systems, making it a common foundation for cluster health and orchestration. This template deploys an etcd cluster as a stateful workload with configurable replica count, persistent storage, and auto-compaction configured so the backend does not grow without bound.
 
 ### What Gets Created
 
@@ -58,6 +58,13 @@ resources:
 
 multiZone: false
 
+# etcd keeps every superseded revision until told otherwise, so compaction is
+# required rather than optional and cannot be switched off here.
+tuning:
+  autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+  autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h); revision takes a count
+  quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
+
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
 
@@ -83,6 +90,43 @@ The replica count must always be an odd number. etcd uses the Raft consensus alg
 
 - `volumeset.capacity` — Persistent volume size in GiB for etcd data (minimum 10).
 
+### Compaction and Backend Growth
+
+etcd never discards a superseded revision on its own. Every write creates a new revision and the old one is kept until a **compaction** removes it, so the backend grows with **time alone** whenever a client writes on a timer — Patroni, for example, renews its leader lease roughly every 10 seconds, which produces new revisions whether or not any application data changes. Measured on an otherwise idle cluster: about **151,000 revisions and 19 MB per day**, which reaches etcd's default 2 GiB backend quota in roughly **110 days**.
+
+When the quota is reached, etcd raises a cluster-wide `NOSPACE` alarm and **every member goes read-only** until an operator intervenes. Auto-compaction is what prevents that, and this template configures it by default.
+
+```yaml
+tuning:
+  autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+  autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h); revision takes a count
+  quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
+```
+
+- `tuning.autoCompactionMode` — How `autoCompactionRetention` is read. `periodic` treats it as a time window; `revision` treats it as a number of revisions to keep. There is no "off" — an unrecognized mode is rejected at render time.
+- `tuning.autoCompactionRetention` — How much history is kept before old revisions are discarded. The default `1h` keeps the backend flat. Raising it to `24h` or more buys a longer history window at the cost of a larger backend.
+- `tuning.quotaBackendBytes` — Backend size ceiling in bytes. `0` (the default) means the flag is not passed at all and etcd applies its own 2 GiB limit. Leave it at `0` unless the keyspace genuinely outgrows that; 8 GiB (`8589934592`) is etcd's own suggested maximum, above which it warns at startup.
+
+<Warning>
+**In `periodic` mode a retention value without a unit means hours.** etcd reads a bare `30` as thirty *hours*, not thirty minutes. This template rejects an unsuffixed value at render time rather than letting it become a silently wrong window — write `30m`, `1h` or `24h`.
+</Warning>
+
+<Warning>
+**`quotaBackendBytes` takes a plain byte count, not a size suffix.** etcd itself refuses `--quota-backend-bytes 2Gi` at boot and the cluster would crash-loop, so a `2Gi`-style value is rejected at render time instead. Write `2147483648`.
+</Warning>
+
+Compaction is deliberately not switchable off: a retention of `0`, an unrecognized mode and a negative quota (which etcd reads as "no quota at all") are each rejected at render time. Each one produces a chart that installs cleanly and fails weeks later.
+
+<Note>
+**Compaction frees pages for reuse inside the backend file; it does not shrink the file.** The reported `dbSize` therefore plateaus rather than dropping, while `dbSizeInUse` falls back to the size of the live keyspace. That is the expected behavior and is sufficient to stay under the quota, because reclaimed pages are reused for new writes. Only `etcdctl defrag` returns space to the filesystem, and this template does not automate it — defragmentation blocks the member it runs on.
+
+Testing measured the mechanism directly on a shortened retention window: the compacted revision advanced from 1 to 4001, `dbSizeInUse` collapsed from 5.76 MB to 20,480 bytes while `dbSize` stayed at about 5.8 MB, and reads of pre-compaction revisions then failed with `required revision has been compacted`. The multi-day `dbSize` plateau is **derived from that mechanism rather than observed** over days.
+</Note>
+
+<Note>
+`etcdctl endpoint status` reports `QUOTA | 0 B` when `quotaBackendBytes` is `0`, because that column reflects the flag rather than the effective limit. The effective quota in that case is still etcd's 2 GiB default, which etcd logs at startup as `enabled backend quota with default value`.
+</Note>
+
 ### Multi-Zone
 
 - `multiZone` — When `true`, distributes replicas equally across available zones for higher availability.
@@ -101,11 +145,33 @@ The `internal_access` section controls which workloads can reach the etcd cluste
 | `same-org` | Allow access from all workloads in the same organization |
 | `workload-list` | Allow access only from specific workloads listed in `workloads` |
 
+## If the Backend Quota Is Already Full
+
+Auto-compaction is configured from template version `1.4.2` onward. Earlier versions passed no compaction flags at all, so a cluster installed from one of them retains every revision it has ever written and grows until it hits the quota.
+
+<Warning>
+**Upgrading turns compaction on, but it cannot rescue a cluster that has already filled its backend.** Compaction stops further growth; it never shrinks an existing backend file. Once etcd has raised a `NOSPACE` alarm, writes stay rejected until an operator compacts, defragments each member and disarms the alarm — an upgrade does none of that.
+</Warning>
+
+The symptom usually surfaces in the client rather than in etcd. A Patroni replica that cannot renew its lease exits *cleanly*, so it restart-loops with `exitCode: 0` and `reason: Completed` and a climbing restart count — which reads as healthy and gets misdiagnosed as a database fault. Check etcd first.
+
+Both inspection commands are read-only and safe to run on a live cluster:
+
+```bash
+cpln workload exec RELEASE_NAME-etcd --gvc GVC_NAME --container etcd -- etcdctl endpoint status --cluster -w table
+cpln workload exec RELEASE_NAME-etcd --gvc GVC_NAME --container etcd -- etcdctl alarm list
+```
+
+A `DB SIZE` close to 2.1 GB on every member, plus `NOSPACE` in the alarm list, confirms it. A healthy cluster prints nothing at all for `alarm list`. Recovery from there — compacting to a revision, defragmenting each member, then disarming the alarm — is an operator procedure this template deliberately does not perform, because each step is disruptive and the order matters. Follow etcd's [maintenance guide](https://etcd.io/docs/v3.6/op-guide/maintenance/) and plan it as a maintenance window.
+
 ## External References
 
 <CardGroup cols={2}>
     <Card title="etcd Documentation" icon="book" href="https://etcd.io/docs/v3.6/">
     Official etcd documentation
+    </Card>
+    <Card title="Maintenance and Compaction" icon="broom" href="https://etcd.io/docs/v3.6/op-guide/maintenance/">
+    Compaction, defragmentation, and clearing a NOSPACE alarm
     </Card>
     <Card title="Hardware Recommendations" icon="server" href="https://etcd.io/docs/v3.6/op-guide/hardware/">
     etcd hardware and resource sizing guidelines

--- a/template-catalog/templates/glitchtip.mdx
+++ b/template-catalog/templates/glitchtip.mdx
@@ -262,6 +262,10 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). GlitchTip is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Onboarding Users
 
 Registration is closed by default (`registration.enabled: false`) — an override of GlitchTip's upstream open-signup default. With registration closed, **invites only work for accounts that already exist**: create teammate accounts first through the Django admin at `https://<canonical>.cpln.app/admin/` (log in with the superuser account), then invite them to your organization. Invite, alert, and password-reset emails require `email.secretName` to be set. To allow open self-signup instead, set `registration.enabled: true`.

--- a/template-catalog/templates/grafana-multi-location.mdx
+++ b/template-catalog/templates/grafana-multi-location.mdx
@@ -287,6 +287,16 @@ internalAccess:
 # Grafana has no read/write splitting, so EVERY query goes to the primary —
 # put it where most of your users are.
 postgresML:
+  # The stretched etcd cluster behind Patroni. Compaction is on by default and
+  # should stay on: without it etcd's backend grows with time alone — Patroni
+  # renews its lease every ~10s and every renewal is a revision — until it hits
+  # the quota and etcd goes READ-ONLY, taking the database's failover with it.
+  etcd:
+    tuning:
+      autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+      autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h)
+      quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
+
   postgres:
     # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL.
     # A `dictionary` secret holding exactly `username`, `password` and
@@ -476,6 +486,10 @@ The `postgresML` block configures the bundled [`postgres-multi-location`](/templ
 <Warning>
 Grafana has **no read/write splitting** — every query, including every dashboard load, goes to the single primary. Testing confirms the shape directly: with seven Grafana instances running, all application connections were on the primary and both standbys carried none. Every location except the primary's therefore pays one cross-region round trip per query, so set `primaryLocation` where most of your users are.
 </Warning>
+
+#### etcd History Compaction
+
+`postgresML.etcd.tuning.autoCompactionMode`, `postgresML.etcd.tuning.autoCompactionRetention` and `postgresML.etcd.tuning.quotaBackendBytes` control how much revision history the database's consensus store keeps and how large its backend may grow. Compaction has been enabled in every version of the bundled etcd chart; since template version `1.1.1` the values are also configurable here. The defaults — `periodic`, `1h` and `0` (etcd's own 2 GiB limit) — are the right settings for a Patroni consensus store and should be left alone: an etcd cluster that fills its backend goes read-only, which takes the database's failover with it. See [Compaction and Backend Growth](/template-catalog/templates/etcd-multi-location#compaction-and-backend-growth) for the mechanism and the accepted value formats.
 
 ### Alerting-HA Coordination
 

--- a/template-catalog/templates/grafana.mdx
+++ b/template-catalog/templates/grafana.mdx
@@ -348,6 +348,10 @@ Firewall changes applied by an upgrade take up to about 30 seconds to propagate.
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Grafana is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode. In HA mode `postgresHA.proxy.enabled` must stay `true` — that HAProxy endpoint is Grafana's stable database address, and disabling it is rejected at render.
 
+<Warning>
+**Template versions before `1.2.1` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.2.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ### High Availability
 
 Grafana holds no local state, so scaling the app tier is a matter of raising `replicas`. Alert evaluation is the one thing that must be coordinated: without coordination every replica would evaluate the same rule and send its own notification.

--- a/template-catalog/templates/keycloak.mdx
+++ b/template-catalog/templates/keycloak.mdx
@@ -192,6 +192,10 @@ Exactly one of the two stores must be enabled — the chart enforces this at ren
 - `postgresHA.postgres.*` / `postgres.config.*` — Database credentials and database name. **Change the password before installing.**
 - `postgresHA.volumeset.capacity` / `postgres.volumeset.capacity` — Initial volume size in GiB (minimum 10, per replica for the HA store).
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ### Access
 
 - `publicAccess.enabled` — Exposes Keycloak over HTTPS at the automatically assigned canonical `*.cpln.app` endpoint. Keep it enabled for browser-based SSO — end-user browsers must reach Keycloak's login endpoints. Disable it only for pure service-to-service deployments; internal access keeps working.

--- a/template-catalog/templates/listmonk.mdx
+++ b/template-catalog/templates/listmonk.mdx
@@ -184,6 +184,10 @@ Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA)
 
 The database holds everything except uploaded media: lists, subscribers, campaigns, templates, users, and all of the settings you configure in the admin UI.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, which is off by default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |

--- a/template-catalog/templates/metabase.mdx
+++ b/template-catalog/templates/metabase.mdx
@@ -217,6 +217,10 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Metabase is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |

--- a/template-catalog/templates/n8n.mdx
+++ b/template-catalog/templates/n8n.mdx
@@ -219,6 +219,10 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). n8n is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |

--- a/template-catalog/templates/nocodb.mdx
+++ b/template-catalog/templates/nocodb.mdx
@@ -435,6 +435,10 @@ Enable exactly one of `postgres` (single instance, default) or `postgresHA` (hig
 
 NocoDB connects to the single instance directly, or to the HAProxy leader endpoint in HA mode, and creates its own meta tables and one schema per base on first boot. `postgres.resources` / `postgresHA.resources` and the `volumeset.capacity` values (GiB, minimum 10, per replica in HA mode) size the backing store. `postgresHA.replicas` sets the number of Patroni replicas.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, which is off by default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |

--- a/template-catalog/templates/polaris.mdx
+++ b/template-catalog/templates/polaris.mdx
@@ -266,6 +266,10 @@ Switch by setting `postgres.enabled: false` and `postgresHA.enabled: true`. Pola
 
 Each Polaris replica opens up to 20 JDBC connections, plus the bootstrap workload — about 21 of PostgreSQL's default 100 at `replicas: 1`, and about 61 at `replicas: 3`.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available metastore**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA metastore are affected (`postgresHA.enabled`, which is off by default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Building a Lakehouse
 
 Storage, catalog, and engine are three separate templates. This is the whole path, verified end to end.

--- a/template-catalog/templates/postgres-highly-available.mdx
+++ b/template-catalog/templates/postgres-highly-available.mdx
@@ -93,6 +93,13 @@ etcd:
     cpu: 500m
     memory: 512Mi
   multiZone: false
+  tuning:
+    # Passed through to the bundled etcd. Without compaction its backend grows
+    # with time alone — Patroni renews its lease every ~10s and every renewal is
+    # a revision — until it hits the quota and etcd goes READ-ONLY.
+    autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+    autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h); revision takes a count
+    quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
   internal_access:
@@ -192,6 +199,16 @@ These values are only applied on first startup when the data directory is empty.
 - `etcd.multiZone` — Spread etcd replicas across availability zones.
 - `etcd.volumeset.capacity` — Initial volume size for etcd data in GiB.
 - `etcd.internal_access.type` — Controls which workloads can reach the etcd cluster.
+
+#### etcd History Compaction
+
+`etcd.tuning.autoCompactionMode`, `etcd.tuning.autoCompactionRetention` and `etcd.tuning.quotaBackendBytes` control how much revision history the bundled etcd cluster keeps and how large its backend may grow. The defaults — `periodic`, `1h` and `0` (etcd's own 2 GiB limit) — are the right settings for a Patroni consensus store and should be left alone. The [etcd template](/template-catalog/templates/etcd#compaction-and-backend-growth) documents the mechanism, the accepted value formats, and the read-only commands for inspecting a cluster.
+
+<Warning>
+**Template versions before `2.4.2` did not compact the bundled etcd cluster.** Patroni renews its leader lease about every 10 seconds and every renewal creates a revision, so etcd grows with time alone — roughly 19 MB per day on an idle cluster — and reaches its 2 GiB backend quota in about 110 days. etcd then goes read-only across the whole cluster, and the PostgreSQL replicas restart-loop with `exitCode: 0` and `reason: Completed`, which reads as healthy and is easily mistaken for a database fault. Upgrade to `2.4.2` or later to turn compaction on.
+
+Upgrading prevents further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade — see [If the Backend Quota Is Already Full](/template-catalog/templates/etcd#if-the-backend-quota-is-already-full).
+</Warning>
 
 ### HAProxy (Strongly Recommended)
 

--- a/template-catalog/templates/postgres-multi-location.mdx
+++ b/template-catalog/templates/postgres-multi-location.mdx
@@ -254,6 +254,12 @@ etcd:
   tuning:
     heartbeatIntervalMs: 250
     electionTimeoutMs: 5000
+    # History compaction. Without it etcd's backend grows with time alone —
+    # Patroni renews its lease every ~10s and every renewal is a revision —
+    # until it hits the quota and etcd goes READ-ONLY.
+    autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+    autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h)
+    quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
   volumeset:
     capacity: 10
   internalAccess:
@@ -355,6 +361,14 @@ PgBouncer multiplexes application connections into a smaller pool of real databa
 - `pgbouncer.maxClientConn` — Client connections accepted per PgBouncer replica (default `1000`).
 - `pgbouncer.maxDbConnections` — Hard cap on total PostgreSQL connections, so scaling PgBouncer out cannot exhaust the primary.
 - `pgbouncer.minReplicas` / `pgbouncer.maxReplicas` — Autoscaling bounds, **per location**.
+
+### etcd Consensus Store
+
+The `etcd` block is passed straight through to the bundled [`etcd-multi-location`](/template-catalog/templates/etcd-multi-location) chart, which is where its image, resources, storage, access and emergency recovery settings are documented.
+
+`etcd.tuning.autoCompactionMode`, `etcd.tuning.autoCompactionRetention` and `etcd.tuning.quotaBackendBytes` control how much revision history etcd keeps and how large its backend may grow. Compaction has been enabled in every version of the bundled chart; since template version `1.0.3` the values are also configurable here. The defaults — `periodic`, `1h` and `0` (etcd's own 2 GiB limit) — are the right settings for a Patroni consensus store and should be left alone. See [Compaction and Backend Growth](/template-catalog/templates/etcd-multi-location#compaction-and-backend-growth) for the mechanism and the accepted value formats.
+
+`etcd.tuning.heartbeatIntervalMs` and `etcd.tuning.electionTimeoutMs` are the raft timers, tuned for cross-region round trips; raise both in proportion if your locations are more than about 250 ms apart.
 
 ## Connecting
 

--- a/template-catalog/templates/temporal.mdx
+++ b/template-catalog/templates/temporal.mdx
@@ -202,6 +202,10 @@ Both workloads are internal-only — there is no public-access option in this te
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Temporal is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |

--- a/template-catalog/templates/timescaledb-highly-available.mdx
+++ b/template-catalog/templates/timescaledb-highly-available.mdx
@@ -98,6 +98,13 @@ etcd:
     cpu: 500m
     memory: 512Mi
   multiZone: false
+  tuning:
+    # Passed through to the bundled etcd. Without compaction its backend grows
+    # with time alone — Patroni renews its lease every ~10s and every renewal is
+    # a revision — until it hits the quota and etcd goes READ-ONLY.
+    autoCompactionMode: periodic # periodic (retention is a duration) or revision (a revision count)
+    autoCompactionRetention: 1h # periodic needs an explicit unit (1h, 30m, 24h); revision takes a count
+    quotaBackendBytes: 0 # backend size limit in bytes; 0 = etcd's own default of 2 GiB
   volumeset:
     capacity: 10
   internal_access:
@@ -192,6 +199,16 @@ These values are only applied on first startup when the data directory is empty.
 <Note>
 etcd is a hard dependency. If the etcd members are unhealthy, Patroni loses its consensus store and the cluster goes read-only. If writes start failing, check the `RELEASE_NAME-etcd` workload first.
 </Note>
+
+#### etcd History Compaction
+
+`etcd.tuning.autoCompactionMode`, `etcd.tuning.autoCompactionRetention` and `etcd.tuning.quotaBackendBytes` control how much revision history the bundled etcd cluster keeps and how large its backend may grow. The defaults — `periodic`, `1h` and `0` (etcd's own 2 GiB limit) — are the right settings for a Patroni consensus store and should be left alone. The [etcd template](/template-catalog/templates/etcd#compaction-and-backend-growth) documents the mechanism, the accepted value formats, and the read-only commands for inspecting a cluster.
+
+<Warning>
+**Template version `1.0.0` did not compact the bundled etcd cluster.** Patroni renews its leader lease about every 10 seconds and every renewal creates a revision, so etcd grows with time alone — roughly 19 MB per day on an idle cluster — and reaches its 2 GiB backend quota in about 110 days. etcd then goes read-only across the whole cluster, and the TimescaleDB replicas restart-loop with `exitCode: 0` and `reason: Completed`, which reads as healthy and is easily mistaken for a database fault. Upgrade to `1.0.1` or later to turn compaction on.
+
+Upgrading prevents further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade — see [If the Backend Quota Is Already Full](/template-catalog/templates/etcd#if-the-backend-quota-is-already-full).
+</Warning>
 
 ### HAProxy Leader Endpoint
 

--- a/template-catalog/templates/twenty.mdx
+++ b/template-catalog/templates/twenty.mdx
@@ -408,6 +408,10 @@ Enable exactly one of `postgres` (single instance, default) or `postgresHA` (hig
 
 Twenty connects to the single instance directly, or to the HAProxy leader endpoint in HA mode, and creates the `uuid-ossp` and `unaccent` extensions itself on first boot. `postgres.resources` / `postgresHA.resources` and the `volumeset.capacity` values (GiB, minimum 10, per replica in HA mode) size the backing store.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, which is off by default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |

--- a/template-catalog/templates/umami.mdx
+++ b/template-catalog/templates/umami.mdx
@@ -170,6 +170,10 @@ Both default to `""` (standard paths). Custom paths take effect once a replica h
 
 Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.config.password` / `postgresHA.postgres.password`).
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, which is off by default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |

--- a/template-catalog/templates/unleash.mdx
+++ b/template-catalog/templates/unleash.mdx
@@ -215,6 +215,10 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Unleash is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
+<Warning>
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+</Warning>
+
 ## Connecting
 
 | What | Value |


### PR DESCRIPTION
Documents the etcd storage fix across **20 template pages**.

## The defect

etcd never compacts its history unless told to. Patroni renews its leader lease every ~10 s, so the backend grows **with time alone** — about 19 MB/day on an idle cluster, reaching the 2 GiB quota in roughly 110 days. One field cluster got there in ~10 weeks. At that point etcd raises `NOSPACE`, goes read-only, and Patroni replicas restart-loop with `exitCode: 0` / `reason: Completed` — which reads as healthy and gets misdiagnosed as an application fault.

## Six pages — full treatment

`etcd`, `etcd-multi-location`, `postgres-highly-available`, `timescaledb-highly-available`, `postgres-multi-location`, `grafana-multi-location`.

The two etcd pages get the mechanism, the three new knobs, the symptom signature, and the specifics that bite: a **bare integer retention means hours** (`30` is thirty hours), `--quota-backend-bytes 2Gi` is **rejected by etcd at boot**, and compaction reclaims pages for reuse rather than shrinking the file — so `dbSize` plateaus instead of dropping, and only `defrag` returns space to the filesystem.

A stale claim was corrected: `etcd-multi-location` previously said compaction "is not configurable", true of 1.0.1 and false as of 1.0.2. An unsupported "a restart resets that clock" sentence went with it.

The four consumer pages get a short pointer, correctly split: `postgres-highly-available` and `timescaledb-highly-available` **carried the defect**; `postgres-multi-location` and `grafana-multi-location` **never did**, because `etcd-multi-location` always compacted. Implying otherwise would send users hunting a problem they never had.

## Fourteen pages — brief note

`cdc-pipeline`, `chatwoot`, `glitchtip`, `grafana`, `keycloak`, `listmonk`, `metabase`, `n8n`, `nocodb`, `polaris`, `temporal`, `twenty`, `umami`, `unleash` — each bundles `postgres-highly-available` and reached the defect transitively (templates #415).

The affected-scope sentence is **not uniform**, and that is the point:

- **`cdc-pipeline`** bundles PostgreSQL HA with no `condition:` — **every** install of 1.0.0/1.0.1 is affected, so it carries no "only if you enabled HA" clause.
- **Eight default `postgresHA.enabled: true`** (chatwoot, glitchtip, grafana, keycloak, metabase, n8n, temporal, unleash) — a user who never touched a toggle got HA anyway, so these say "the default here".
- **Five default it off** (listmonk, nocodb, polaris, twenty, umami) — these say "off by default here".

Verified independently against each template's shipped `values.yaml`, for the affected prior versions as well as the fixed ones.

## Derived vs measured

The multi-day `dbSize` plateau is marked **derived**. What was measured is compaction firing: `compact-revision` advancing 1 → 4001, `dbSizeInUse` collapsing 5.76 MB → 20,480 B at constant `dbSize`, and historical reads returning `required revision has been compacted`.

## Also

`cdc-pipeline`'s Component Versions table claimed pg-ha 2.2.0, Kafka 4.0.0 and Debezium 1.1.0 — corrected to the shipped 2.4.2 / 4.0.1 / 1.1.1, since it sat directly above the new note and contradicted it.

Anchors were verified against served HTML rather than assumed: these are the only links to an h4 anchor in the catalog, so the slug behaviour was checked against the live site.

`dbeaver` is deliberately excluded and will get its own PR.