### PR TITLE
docs: tier-1 security updates for dbeaver 1.3.0 and tyk 1.3.0

### DIFF
--- a/template-catalog/templates/dbeaver.mdx
+++ b/template-catalog/templates/dbeaver.mdx
@@ -17,7 +17,7 @@ The admin account is bootstrapped from an [opaque secret](/guides/create-secret/
 ### What Gets Created
 
 - **Stateful CloudBeaver Workload** (`RELEASE_NAME-dbeaver`) — a single CloudBeaver instance serving the web UI and API on port `8978`.
-- **Volume Set** (`RELEASE_NAME-dbeaver-vs`) — a 10 GiB `ext4` volume mounted at `/opt/cloudbeaver/workspace`, holding the server configuration, saved connections, and user accounts. Daily snapshots with 7-day retention.
+- **Volume Set** (`RELEASE_NAME-dbeaver-vs`) — a 10 GiB `ext4` volume mounted at `/opt/cloudbeaver/workspace`, holding the server configuration, saved connections, and user accounts. A final snapshot is taken when the volume set is deleted and kept for 7 days; there are no scheduled snapshots.
 - **Identity & Policy** — an identity bound to the workload and a policy granting it `reveal` on exactly the admin-password secret you created, and nothing else.
 - **No template-created secret** — the only credential lives in the prerequisite secret you own.
 
@@ -31,7 +31,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 <Steps>
   <Step title="Create the admin password secret">
-    Choose your own strong password (CloudBeaver requires at least 8 characters) and store it as the secret's payload:
+    Choose your own strong password — use at least 8 characters — and store it as the secret's payload:
 
     ```bash
     printf '%s' 'YOUR-STRONG-PASSWORD' | cpln secret create-opaque --name my-dbeaver-admin-password --encoding plain -f -
@@ -141,7 +141,7 @@ To change the password, use the CloudBeaver UI (**Administration → Users**), o
 | `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads` |
 
 <Note>
-**An access change takes up to a couple of minutes to take effect.** Firewall changes propagate asynchronously: enabling public access was measured at 107 seconds from upgrade to the first `200`, and disabling it at about 120 seconds, passing through `503` and `504` on the way. Re-poll before concluding the knob did nothing.
+**An access change takes up to a couple of minutes to take effect.** Firewall changes propagate asynchronously: enabling public access was measured at 107 seconds from upgrade to the first `200`, passing through `504` on the way, and disabling it at about 120 seconds, passing through `503` and `504` before settling on `403`. Re-poll before concluding the knob did nothing.
 
 A request blocked by `internalAccess.type: none` **hangs until your client times out** rather than being refused — the TCP connection is accepted by the local sidecar and no bytes are ever returned. "Connected, but no response" is what a correctly closed internal firewall looks like here.
 </Note>
@@ -174,13 +174,13 @@ Add database connections from the UI after logging in, pointing them at in-GVC h
 ## Upgrading From 1.2.1 or Earlier
 
 <Warning>
-**After upgrading, the console is no longer reachable from the internet, and your existing admin password keeps working.** Both are expected. Plan the upgrade rather than discovering it.
+**After upgrading, the console is no longer reachable from the internet, and your existing admin login is unchanged — both the name and the password stay whatever the workspace was first bootstrapped with.** In particular, keep logging in as your old admin name (`adminusername` if you never changed it); the new `cbadmin` default never applies to an existing workspace. Both behaviors are expected. Plan the upgrade rather than discovering it.
 </Warning>
 
 | Behavior | 1.2.1 and earlier | 1.3.0 |
 |---|---|---|
 | Admin password | `admin.password` value, defaulting to `Password123` | `admin.passwordSecretName`, naming an opaque secret you create |
-| Admin login name | `admin.name`, defaulting to `adminusername` | `admin.name`, defaulting to `cbadmin` — still a plain value |
+| Admin login name | `admin.name`, defaulting to `adminusername` | `admin.name`, defaulting to `cbadmin` — still a plain value, and the new default applies to new installs only; an existing workspace keeps the name it was bootstrapped with |
 | Public access | Hardcoded `0.0.0.0/0` inbound, no knob | `publicAccess.enabled`, defaulting to `false` |
 | Internal access | Hardcoded `none` | `internalAccess.type`, defaulting to `same-gvc` |
 | Chart-created secret | A secret holding the admin name and password | None — the chart creates no secret |
@@ -200,21 +200,22 @@ What to do before upgrading:
   <Step title="Decide whether you still want public access">
     If you were relying on the internet-facing URL, set `publicAccess.enabled: true` explicitly. If you were not, do nothing and the console becomes internal-only. Either way, allow a couple of minutes for the firewall change to propagate.
   </Step>
-  <Step title="Expect your old password to keep working">
-    The account already exists in the workspace database, so the upgrade does not re-bootstrap it — see [Admin Credentials](#admin-credentials). If the password you were using is one you would rather not keep, change it in the CloudBeaver UI after the upgrade.
+  <Step title="Expect your old login name and password to keep working">
+    The account already exists in the workspace database, so the upgrade does not re-bootstrap it — neither `admin.name` nor the password secret is applied to a workspace that is already initialized (see [Admin Credentials](#admin-credentials)). Keep signing in with the name and password the workspace was bootstrapped with — typically `adminusername`, not the new `cbadmin` default. If either is one you would rather not keep, change it in the CloudBeaver UI after the upgrade.
   </Step>
 </Steps>
 
 ## Important Notes
 
 - **Create the admin-password secret before installing.** A missing secret does not fail the install — `cpln helm install` reports success and the workload then sits at zero replicas waiting on it, with no container logs to diagnose from.
-- **The admin password is read only when the workspace is first initialized.** Rotating the secret afterwards changes what the container sees and changes nothing about who can log in. Change it in the CloudBeaver UI instead.
+- **The admin name and password are read only when the workspace is first initialized.** Rotating the secret or changing `admin.name` afterwards changes what the container sees and changes nothing about who can log in. Change the password in the CloudBeaver UI instead.
 - **Anyone who can read this workload's logs can authenticate as the admin**, because CloudBeaver logs the submitted password hash and its API accepts that hash as a credential.
 - **`publicAccess.enabled: true` puts a database administration console on the public internet.** Anyone who reaches it needs only the admin password to query every connected database. Prefer leaving it off and reaching the UI from inside the GVC.
 - **Egress is closed and there is no knob for it** — only databases inside the same GVC can be connected. Managed services such as RDS, Cloud SQL, and Atlas are unreachable.
 - **Access changes take up to a couple of minutes to propagate.** A `publicAccess` or `internalAccess` change that appears to do nothing has usually just not settled yet.
 - **The first `helm upgrade` after an install restarts the workload**, taking the UI down for roughly 30 to 60 seconds even when nothing about the values changed. This template runs a single replica, so there is no other instance to serve during the restart. Later no-op upgrades do not restart it.
 - **Saved connections and users live on the volume set** and survive redeploys and upgrades. `cpln helm uninstall` deletes the volume set, taking every saved connection with it.
+- **There is no scheduled-backup feature.** The volume set takes no scheduled snapshots — the only one is the final snapshot taken when it is deleted, kept for 7 days. Export anything you cannot lose from the CloudBeaver UI before uninstalling.
 - **The prerequisite secret is not owned by the release** — it survives `cpln helm uninstall` and must be deleted manually if you no longer need it.
 
 ## External References

--- a/template-catalog/templates/dbeaver.mdx
+++ b/template-catalog/templates/dbeaver.mdx
@@ -1,27 +1,58 @@
 ---
 title: DBeaver
-description: Deploy DBeaver on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and web-based database administration with CloudBeaver.
-keywords: ['cloudbeaver', 'sql client', 'db gui', 'sql workbench', 'datagrip alternative', 'pgadmin alternative', 'web sql ide', 'multi-db client', 'browser db tool', 'phpmyadmin alternative']
+description: Deploy DBeaver CloudBeaver on Control Plane using the Template Catalog. A browser-based SQL client and database administration console with a persistent workspace, an admin password held in a prerequisite secret, and no public access by default.
+keywords: ['cloudbeaver', 'sql client', 'db gui', 'sql workbench', 'datagrip alternative', 'pgadmin alternative', 'web sql ide', 'multi-db client', 'browser db tool', 'phpmyadmin alternative', 'prerequisite secret', 'admin password rotation']
 ---
 
 ## Overview
 
-DBeaver is a web-based database administration tool that provides a modern interface for managing multiple database connections. This template deploys the self-hosted [CloudBeaver](https://github.com/dbeaver/cloudbeaver) web application — the browser-based edition of DBeaver — with automatic admin user creation, giving you immediate access to a full-featured SQL editor, connection manager, and data browser for a wide range of database systems including PostgreSQL, MySQL, MariaDB, MongoDB, Redis, SQLite, Oracle, SQL Server, and more.
+DBeaver is a web-based database administration tool that provides a modern interface for managing multiple database connections. This template deploys the self-hosted [CloudBeaver](https://github.com/dbeaver/cloudbeaver) web application — the browser-based edition of DBeaver — giving you a full-featured SQL editor, connection manager, and data browser for PostgreSQL, MySQL, MariaDB, MongoDB, Redis, SQLite, Oracle, SQL Server, and more.
+
+The admin account is bootstrapped from an [opaque secret](/guides/create-secret/opaque) you create before installing, and the console is reachable only from inside the GVC unless you deliberately publish it.
+
+<Warning>
+**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped a working admin password (`Password123`) as a `values.yaml` default and hardcoded the workload's inbound firewall to `0.0.0.0/0` with no way to turn it off, so a default install published a database administration console to the internet behind a password published in a public repository. In 1.3.0 the password moved to a prerequisite secret and public access became an opt-in knob that defaults to off — **which changes the behavior of an existing install when you upgrade.**
+</Warning>
 
 ### What Gets Created
 
-- **Workload** — A DBeaver web application container with persistent storage and an admin user pre-configured on startup.
-- **Volume Set** — Persistent storage for workspace data, connections, and settings.
-- **Secret** — An opaque secret storing the admin username and password, injected into the container at startup.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to the admin credentials secret.
+- **Stateful CloudBeaver Workload** (`RELEASE_NAME-dbeaver`) — a single CloudBeaver instance serving the web UI and API on port `8978`.
+- **Volume Set** (`RELEASE_NAME-dbeaver-vs`) — a 10 GiB `ext4` volume mounted at `/opt/cloudbeaver/workspace`, holding the server configuration, saved connections, and user accounts. Daily snapshots with 7-day retention.
+- **Identity & Policy** — an identity bound to the workload and a policy granting it `reveal` on exactly the admin-password secret you created, and nothing else.
+- **No template-created secret** — the only credential lives in the prerequisite secret you own.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Prerequisites
+
+**One [opaque secret](/guides/create-secret/opaque) must exist before you install.** The admin password guards a database administration console, and whoever holds it can query every database that console is connected to — so it is never a Helm value and never lands in the release.
+
+<Steps>
+  <Step title="Create the admin password secret">
+    Choose your own strong password (CloudBeaver requires at least 8 characters) and store it as the secret's payload:
+
+    ```bash
+    printf '%s' 'YOUR-STRONG-PASSWORD' | cpln secret create-opaque --name my-dbeaver-admin-password --encoding plain -f -
+    ```
+
+    Set `admin.passwordSecretName` to the name you used. The default in `values.yaml` is `my-dbeaver-admin-password`.
+  </Step>
+  <Step title="Pick an admin login name">
+    Set `admin.name` to the login name you want. It is not sensitive and stays a plain value; the default is `cbadmin`.
+  </Step>
+</Steps>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, all four resources are created, and the workload then never starts — it sits at zero replicas with the message `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` There are no container logs to diagnose from, because the container never ran. Create the secret first, and after installing confirm with `cpln workload get-deployments RELEASE_NAME-dbeaver --gvc GVC_NAME` rather than trusting the Helm output.
+</Warning>
+
+Nothing else is required for a default install.
+
 ## Installation
 
-This template has no external prerequisites. To install, follow the instructions for your preferred method:
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -52,9 +83,26 @@ The default `values.yaml` for this template:
 ```yaml
 image: dbeaver/cloudbeaver:25.2.0
 
+# ─── Admin Login (prerequisite secret) ────────────────────────────────────────
+# The admin password guards the CloudBeaver web login, and whoever holds it can
+# reach every database this console is connected to — so it never transits
+# values or the Helm release. Create the opaque secret (encoding: plain) BEFORE
+# install; see README Prerequisites.
 admin:
-  name: adminusername
-  password: Password123
+  name: cbadmin # admin login name (not sensitive)
+  passwordSecretName: my-dbeaver-admin-password # opaque secret holding the admin password; must EXIST BEFORE INSTALL
+
+# ─── Access ───────────────────────────────────────────────────────────────────
+publicAccess:
+  # false = not reachable from the internet. Setting this true publishes a
+  # database administration console, and its login form, to the whole internet.
+  enabled: false
+
+internalAccess:
+  type: same-gvc # options: none, same-gvc, same-org, workload-list
+  workloads: [] # used with workload-list
+  # workloads:
+  #   - //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
 resources:
   cpu: 500m
@@ -66,25 +114,120 @@ volumeset:
 
 ### Admin Credentials
 
-- `admin.name` — Username for the admin account created on first startup.
-- `admin.password` — Password for the admin account. **Change this before deploying.**
+- `admin.name` — the admin login name, created when the workspace is first initialized. Not sensitive, so it stays a plain value. Default `cbadmin`.
+- `admin.passwordSecretName` — the name of the opaque secret holding the admin password. The chart references it as `cpln://secret/NAME.payload`, so the password itself never appears in the workload spec or the Helm release.
 
-These values are stored as a Control Plane secret and injected into the container at startup. No manual user creation is required — log in with these credentials immediately after deployment.
+<Warning>
+**The admin password cannot be rotated by changing the secret.** Both credentials are consumed only when an empty workspace is initialized on the volume set. On every later boot CloudBeaver reads the account it already stored in its workspace database and ignores the environment. This was measured: after rewriting the secret's payload and restarting the workload, the container held the **new** value while the **old password still logged in** and the new one was rejected with `Invalid user credentials`.
+
+To change the password, use the CloudBeaver UI (**Administration → Users**), or uninstall — which deletes the volume set and every saved connection with it — and reinstall.
+</Warning>
+
+<Warning>
+**CloudBeaver logs the submitted password hash, and its API accepts that hash in place of the password.** At the image's default log level, login requests appear in `cpln logs` with the credential included, and replaying that value against the API authenticates successfully — so anyone who can read this workload's logs can log in as the admin. This is upstream CloudBeaver behavior, not something the chart configures; the move to a prerequisite secret does not close it. Treat log access to this workload as equivalent to admin access to every database it is connected to.
+</Warning>
+
+### Access
+
+- `publicAccess.enabled` — when `true`, the workload's external inbound firewall opens to `0.0.0.0/0` and Control Plane assigns a `*.cpln.app` canonical endpoint. **Defaults to `false`.** With it off, requests to the canonical endpoint return `403 RBAC: access denied`.
+- `internalAccess.type` — which workloads inside Control Plane may reach the console. **Defaults to `same-gvc`.**
+- `internalAccess.workloads` — list of workload links, used only when `type` is `workload-list`.
+
+| Type | Description |
+|------|-------------|
+| `none` | No internal access allowed |
+| `same-gvc` | Allow access from all workloads in the same GVC |
+| `same-org` | Allow access from all workloads in the same organization |
+| `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads` |
+
+<Note>
+**An access change takes up to a couple of minutes to take effect.** Firewall changes propagate asynchronously: enabling public access was measured at 107 seconds from upgrade to the first `200`, and disabling it at about 120 seconds, passing through `503` and `504` on the way. Re-poll before concluding the knob did nothing.
+
+A request blocked by `internalAccess.type: none` **hangs until your client times out** rather than being refused — the TCP connection is accepted by the local sidecar and no bytes are ever returned. "Connected, but no response" is what a correctly closed internal firewall looks like here.
+</Note>
+
+### Outbound Connectivity
+
+The workload ships with an empty outbound firewall (`outboundAllowCIDR: []`), and there is no value to change it.
+
+<Warning>
+**CloudBeaver can only reach databases inside its own GVC.** Outbound TLS connections to the public internet do not complete — measured as a connection reset during the TLS handshake (`curl` exit code 35) from the CloudBeaver container, while a control workload in the same GVC with open egress reached the same hosts normally. In practice this means **managed databases such as Amazon RDS, Google Cloud SQL, and MongoDB Atlas cannot be connected**. Point connections at in-GVC hosts over internal DNS instead, e.g. `my-postgres.GVC_NAME.cpln.local:5432`.
+
+Note that DNS still resolves and a bare TCP connect can appear to succeed, because the sidecar accepts the socket before the connection is reset — do not infer working egress from either.
+</Warning>
 
 ### Resources and Storage
 
 - `resources.cpu` / `resources.memory` — CPU and memory allocated to the CloudBeaver workload.
-- `volumeset.capacity` — Persistent volume size in GiB for workspace data, connections, and settings (minimum 10).
+- `volumeset.capacity` — persistent volume size in GiB for workspace data, saved connections, and user accounts (minimum 10).
 
-### Accessing CloudBeaver
+## Connecting
 
-Once deployed, open the workload's endpoint in your browser and log in with the admin credentials configured in your values file.
+| Path | Address | Notes |
+|------|---------|-------|
+| Public UI | `https://CANONICAL_ENDPOINT` | Only when `publicAccess.enabled` is `true`. Read the endpoint from `status.canonicalEndpoint` in `cpln workload get RELEASE_NAME-dbeaver --gvc GVC_NAME -o yaml`. |
+| Internal UI and API | `http://RELEASE_NAME-dbeaver.GVC_NAME.cpln.local:8978` | Subject to `internalAccess.type`. |
+| Admin credentials | `admin.name` from your values, plus the payload of the secret named in `admin.passwordSecretName` | Reveal it with `cpln secret reveal my-dbeaver-admin-password`. |
+
+Add database connections from the UI after logging in, pointing them at in-GVC hosts over internal DNS.
+
+## Upgrading From 1.2.1 or Earlier
+
+<Warning>
+**After upgrading, the console is no longer reachable from the internet, and your existing admin password keeps working.** Both are expected. Plan the upgrade rather than discovering it.
+</Warning>
+
+| Behavior | 1.2.1 and earlier | 1.3.0 |
+|---|---|---|
+| Admin password | `admin.password` value, defaulting to `Password123` | `admin.passwordSecretName`, naming an opaque secret you create |
+| Admin login name | `admin.name`, defaulting to `adminusername` | `admin.name`, defaulting to `cbadmin` — still a plain value |
+| Public access | Hardcoded `0.0.0.0/0` inbound, no knob | `publicAccess.enabled`, defaulting to `false` |
+| Internal access | Hardcoded `none` | `internalAccess.type`, defaulting to `same-gvc` |
+| Chart-created secret | A secret holding the admin name and password | None — the chart creates no secret |
+
+What to do before upgrading:
+
+<Steps>
+  <Step title="Create the admin password secret">
+    Even though it will not change the account you already log in with, the workload will not start without it. Use the same password your install currently uses so nothing is ambiguous later:
+
+    ```bash
+    printf '%s' 'YOUR-EXISTING-PASSWORD' | cpln secret create-opaque --name my-dbeaver-admin-password --encoding plain -f -
+    ```
+
+    Then set `admin.passwordSecretName` to that name, and remove `admin.password` from your values — it no longer exists in the chart.
+  </Step>
+  <Step title="Decide whether you still want public access">
+    If you were relying on the internet-facing URL, set `publicAccess.enabled: true` explicitly. If you were not, do nothing and the console becomes internal-only. Either way, allow a couple of minutes for the firewall change to propagate.
+  </Step>
+  <Step title="Expect your old password to keep working">
+    The account already exists in the workspace database, so the upgrade does not re-bootstrap it — see [Admin Credentials](#admin-credentials). If the password you were using is one you would rather not keep, change it in the CloudBeaver UI after the upgrade.
+  </Step>
+</Steps>
+
+## Important Notes
+
+- **Create the admin-password secret before installing.** A missing secret does not fail the install — `cpln helm install` reports success and the workload then sits at zero replicas waiting on it, with no container logs to diagnose from.
+- **The admin password is read only when the workspace is first initialized.** Rotating the secret afterwards changes what the container sees and changes nothing about who can log in. Change it in the CloudBeaver UI instead.
+- **Anyone who can read this workload's logs can authenticate as the admin**, because CloudBeaver logs the submitted password hash and its API accepts that hash as a credential.
+- **`publicAccess.enabled: true` puts a database administration console on the public internet.** Anyone who reaches it needs only the admin password to query every connected database. Prefer leaving it off and reaching the UI from inside the GVC.
+- **Egress is closed and there is no knob for it** — only databases inside the same GVC can be connected. Managed services such as RDS, Cloud SQL, and Atlas are unreachable.
+- **Access changes take up to a couple of minutes to propagate.** A `publicAccess` or `internalAccess` change that appears to do nothing has usually just not settled yet.
+- **The first `helm upgrade` after an install restarts the workload**, taking the UI down for roughly 30 to 60 seconds even when nothing about the values changed. This template runs a single replica, so there is no other instance to serve during the restart. Later no-op upgrades do not restart it.
+- **Saved connections and users live on the volume set** and survive redeploys and upgrades. `cpln helm uninstall` deletes the volume set, taking every saved connection with it.
+- **The prerequisite secret is not owned by the release** — it survives `cpln helm uninstall` and must be deleted manually if you no longer need it.
 
 ## External References
 
 <CardGroup cols={2}>
-    <Card title="CloudBeaver Documentation" icon="book" href="https://cloudbeaver.io/docs/">
+    <Card title="CloudBeaver Documentation" icon="book" href="https://dbeaver.com/docs/cloudbeaver/">
     Official DBeaver CloudBeaver documentation
+    </Card>
+    <Card title="Server Configuration" icon="gear" href="https://dbeaver.com/docs/cloudbeaver/Server-configuration/">
+    Reference for CloudBeaver server settings
+    </Card>
+    <Card title="Admin Password Recovery" icon="key" href="https://dbeaver.com/docs/cloudbeaver/Admin-Password-Recovery/">
+    Upstream procedure for regaining admin access
     </Card>
     <Card title="DBeaver GitHub" icon="github" href="https://github.com/dbeaver/cloudbeaver">
     CloudBeaver open-source repository

--- a/template-catalog/templates/tyk.mdx
+++ b/template-catalog/templates/tyk.mdx
@@ -11,7 +11,7 @@ Tyk is an open-source API management platform that controls, secures, and monito
 Your API definitions and policies come from Control Plane secrets you control, and the Gateway Control API key — the credential that creates and revokes every API key on the gateway — comes from an [opaque secret](/guides/create-secret/opaque) you create before installing.
 
 <Warning>
-**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped three defaults that compounded: the Gateway Control API key was the `values.yaml` value `mysecret`, `externalAccess` defaulted to `true` so that API was on the public internet, and `TYK_GW_ALLOWMASTERKEYS` was hardcoded to `true` so a key created with no `access_rights` reached every API on the gateway. One guessed word yielded a key to everything. In 1.3.0 the admin key moved to a prerequisite secret, external access defaults to off, and master keys are a knob that defaults to off — **the last two change the behavior of an existing install when you upgrade.**
+**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped three defaults that compounded: the Gateway Control API key was the `values.yaml` value `mysecret`, `externalAccess` defaulted to `true` so that API was on the public internet, and `TYK_GW_ALLOWMASTERKEYS` was hardcoded to `true` so a key created with no `access_rights` reached every API on the gateway. One guessed word yielded a key to everything. In 1.3.0 the admin key moved to a prerequisite secret, external access defaults to off, master keys are a knob that defaults to off, and `internalAccess.type` now defaults to `same-gvc` instead of `none` — **those last three change the behavior of an existing install when you upgrade, and the internal-access change widens in-GVC reachability rather than narrowing it.**
 </Warning>
 
 <Note>
@@ -21,7 +21,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 ### What Gets Created
 
 - **Standard Tyk Gateway Workload** (`RELEASE_NAME-tyk-api-gateway`) — the gateway process, autoscaling between `minScale` and `maxScale` replicas on CPU. API definitions and policies are mounted from your secrets at startup.
-- **Redis and Redis Sentinel** — the [Redis](/template-catalog/templates/redis) template (v3.4.2) is deployed as a subchart, creating a Redis workload, a Sentinel workload, their volume sets, and their config and password secrets. The gateway connects through Sentinel, not to Redis directly.
+- **Redis and Redis Sentinel** — the [Redis](/template-catalog/templates/redis) template (v3.4.2) is deployed as a subchart, creating a Redis workload, a Sentinel workload, their volume sets, their config and password secrets, and an identity and policy for each (`RELEASE_NAME-redis-identity`, `RELEASE_NAME-sentinel-identity`, `RELEASE_NAME-redis-policy`, `RELEASE_NAME-sentinel-policy`). The gateway connects through Sentinel, not to Redis directly.
 - **Identity & Policy** — an identity (`RELEASE_NAME-tyk-identity`) bound to the gateway with `reveal` on exactly the secrets it mounts: your admin secret, your API and policy secrets when set, and the bundled Redis and Sentinel password secrets.
 - **No template-created credential secret** — the admin API key lives only in the prerequisite secret you create.
 
@@ -318,7 +318,7 @@ cpln secret reveal my-tyk-admin-secret
 ## Upgrading From 1.2.1 or Earlier
 
 <Warning>
-**Two defaults change behavior on upgrade: the gateway stops being reachable from the internet, and key-creation requests without `access_rights` start failing.** Neither is a fault; both will surprise you if you have not planned for them.
+**Three defaults change behavior on upgrade: the gateway stops being reachable from the internet, key-creation requests without `access_rights` start failing, and the internal firewall opens from `none` to `same-gvc` so every workload in the GVC can now reach the gateway.** None is a fault; all three will surprise you if you have not planned for them — set `internalAccess.type` explicitly if you want the old, closed behavior.
 </Warning>
 
 | Behavior | 1.2.1 and earlier | 1.3.0 |

--- a/template-catalog/templates/tyk.mdx
+++ b/template-catalog/templates/tyk.mdx
@@ -1,12 +1,18 @@
 ---
 title: Tyk
-description: Deploy Tyk on Control Plane using the Template Catalog. Covers configuration, scaling, and API gateway management with Redis-backed token storage, rate limiting, and analytics.
-keywords: ['api gateway', 'kong alternative', 'apigee alternative', 'developer portal', 'oauth gateway', 'api auth', 'api throttle', 'api management', 'gateway proxy']
+description: Deploy Tyk on Control Plane using the Template Catalog. An API gateway with authentication, rate limiting, quotas and analytics, backed by Redis Sentinel, with the admin API key held in a prerequisite secret and no public access by default.
+keywords: ['api gateway', 'kong alternative', 'apigee alternative', 'developer portal', 'oauth gateway', 'api auth', 'api throttle', 'api management', 'gateway proxy', 'master keys', 'prerequisite secret', 'redis sentinel']
 ---
 
 ## Overview
 
-Tyk is an open-source API management platform that controls, secures, and monitors API traffic. This template deploys a Tyk API Gateway workload on Control Plane alongside Redis and Redis Sentinel, which serve as the backing store for tokens, analytics, rate limits, and gateway state.
+Tyk is an open-source API management platform that controls, secures, and monitors API traffic. This template deploys a Tyk Gateway workload on Control Plane alongside Redis and Redis Sentinel, which back the gateway's token, rate-limit, quota, and analytics storage.
+
+Your API definitions and policies come from Control Plane secrets you control, and the Gateway Control API key — the credential that creates and revokes every API key on the gateway — comes from an [opaque secret](/guides/create-secret/opaque) you create before installing.
+
+<Warning>
+**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped three defaults that compounded: the Gateway Control API key was the `values.yaml` value `mysecret`, `externalAccess` defaulted to `true` so that API was on the public internet, and `TYK_GW_ALLOWMASTERKEYS` was hardcoded to `true` so a key created with no `access_rights` reached every API on the gateway. One guessed word yielded a key to everything. In 1.3.0 the admin key moved to a prerequisite secret, external access defaults to off, and master keys are a knob that defaults to off — **the last two change the behavior of an existing install when you upgrade.**
+</Warning>
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -14,18 +20,28 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ### What Gets Created
 
-- **Standard Workload** — Tyk API Gateway (`RELEASE_NAME-tyk-api-gateway`): the gateway process, autoscaling between `minScale` and `maxScale` replicas. API definitions and policies are mounted from Control Plane secrets at startup.
-- **Secret** — Gateway admin secret (`RELEASE_NAME-tyk-gateway-secret`): a dictionary secret containing the admin API key used for management operations.
-- **Identity & Policy** — An identity (`RELEASE_NAME-tyk-identity`) bound to the gateway workload with `reveal` access to the gateway secret, Redis auth secrets, and optionally the API definitions and policy secrets.
-- **Redis and Redis Sentinel** — The [Redis](/template-catalog/templates/redis) template (v3.1.1) is deployed as a dependency, creating a Redis workload, a Sentinel workload, and their associated secrets, identities, and policies.
+- **Standard Tyk Gateway Workload** (`RELEASE_NAME-tyk-api-gateway`) — the gateway process, autoscaling between `minScale` and `maxScale` replicas on CPU. API definitions and policies are mounted from your secrets at startup.
+- **Redis and Redis Sentinel** — the [Redis](/template-catalog/templates/redis) template (v3.4.2) is deployed as a subchart, creating a Redis workload, a Sentinel workload, their volume sets, and their config and password secrets. The gateway connects through Sentinel, not to Redis directly.
+- **Identity & Policy** — an identity (`RELEASE_NAME-tyk-identity`) bound to the gateway with `reveal` on exactly the secrets it mounts: your admin secret, your API and policy secrets when set, and the bundled Redis and Sentinel password secrets.
+- **No template-created credential secret** — the admin API key lives only in the prerequisite secret you create.
 
 ## Prerequisites
 
-Tyk loads API definitions and policies from files at startup. You must create the corresponding Control Plane secrets **before** deploying the template.
+**The admin secret must exist before you install**, and you will normally want the API and policy secrets too. All are referenced by name only, so none of their contents pass through Helm values or land in the release.
 
-### 1. Create the API Definitions Secret
+### 1. Admin API Key (Required)
 
-Each key in the dictionary is a filename (e.g. `app1.json`) containing a Tyk API definition object. Create the secret using `cpln apply`:
+This is `TYK_GW_SECRET`, the key for the Gateway Control API served under `/tyk/*` and sent as the `X-Tyk-Authorization` header. Whoever holds it can create, list, and revoke every API key on the gateway, so generate a strong random value:
+
+```bash
+printf '%s' "$(openssl rand -hex 32)" | cpln secret create-opaque --name my-tyk-admin-secret --encoding plain -f -
+```
+
+Set `adminSecretName` to the name you used. The chart refuses to render without it.
+
+### 2. API Definitions (Optional)
+
+A [dictionary secret](/guides/create-secret/dictionary) whose keys are `*.json` filenames and whose values are Tyk API definitions, mounted at `/opt/tyk-gateway/apps`. Because the values are multi-line JSON, write a manifest and apply it:
 
 ```yaml
 kind: secret
@@ -44,11 +60,19 @@ data:
     "active": true}
 ```
 
-Set `apiSecretName` in your values to the name of this secret. To omit API definitions entirely, leave `apiSecretName` empty.
+```bash
+cpln apply -f my-tyk-apis.yaml
+```
 
-### 2. Create the Policies Secret
+Set `apiSecretName` to the name you used.
 
-The policies secret is a single opaque secret containing a JSON object where each key is a policy ID:
+<Warning>
+**Leaving `apiSecretName` empty does not serve nothing — it serves Tyk's demo API.** With no definitions mounted, the gateway falls back to the API definitions baked into the upstream image and boots serving `Tyk Test API`. The install looks entirely healthy — the workload is ready and `/hello` reports `redis: pass` — while serving none of your APIs. Set the secret, or expect the vendor demo endpoint on your listener.
+</Warning>
+
+### 3. Policies (Optional)
+
+An [opaque secret](/guides/create-secret/opaque) with encoding `plain`, holding a single JSON object of policies keyed by policy ID, mounted at `/opt/tyk-gateway/policies/policies.json`:
 
 ```yaml
 kind: secret
@@ -79,7 +103,15 @@ data:
     }
 ```
 
-Set `policySecretName` in your values to the name of this secret. To omit policies entirely, leave `policySecretName` empty.
+```bash
+cpln apply -f my-tyk-policies.yaml
+```
+
+Set `policySecretName` to the name you used, or leave it `""` to run with no policies. You can edit both secrets independently after install, as long as their names stay the same.
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, every resource is created, and the gateway then never becomes ready — with no container logs at all, because the container never started. The only place the reason appears is `cpln workload get-deployments RELEASE_NAME-tyk-api-gateway --gvc GVC_NAME`, as `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` Create the secrets first and check the deployment rather than trusting the Helm output.
+</Warning>
 
 ## Installation
 
@@ -114,13 +146,25 @@ The default `values.yaml` for this template:
 ```yaml
 image: tykio/tyk-gateway:v5.10.0
 
-listenPort: 8080 # REQUIRED - The port exposed on the Tyk workload
+listenPort: 8080 # REQUIRED - the port the gateway listens on
 
-apiSecretName: my-tyk-apis # REQUIRED - The name of the pre-configured Control Plane secret that contains your API definitions
-policySecretName: my-tyk-policies # REQUIRED - The name of the pre-configured Control Plane secret that contains your policies
-# Note: if you wish to omit one of these secrets, leave the value empty and it will be omitted from the workload's configuration
+# ─── Prerequisite secrets ─────────────────────────────────────────────────────
+# All three must EXIST BEFORE INSTALL. See README Prerequisites for the exact
+# `cpln secret create-*` commands.
 
-adminSecret: mysecret # REQUIRED - The value you set to be the admin API key for management of Tyk
+# The admin secret is the Gateway Control API key (X-Tyk-Authorization on /tyk/*),
+# which creates, lists and revokes API keys — so it never transits Helm values.
+adminSecretName: my-tyk-admin-secret # REQUIRED - opaque secret (encoding: plain) holding the admin API key
+
+# These two are OPTIONAL — set either to "" to omit it. But note what happens if
+# you omit the APIs: the gateway falls back to the demo API definitions baked
+# into the upstream image and will happily serve "Tyk Test API" instead of
+# nothing, which looks like a working install until you notice it is not yours.
+apiSecretName: my-tyk-apis # dictionary secret holding your API definition JSON files; "" = serve the image's demo APIs
+policySecretName: my-tyk-policies # opaque secret holding your policies JSON; "" = no policies
+
+# ─── Gateway ──────────────────────────────────────────────────────────────────
+allowMasterKeys: false # true lets a key created with no access_rights reach EVERY API on this gateway
 
 resources:
   cpu: 50m
@@ -135,24 +179,26 @@ autoscaling:
 
 multiZone: false # OPTIONAL - Deploys replicas across multiple zones (confirm availability in your location)
 
-externalAccess: true # OPTIONAL - Set to true to expose the workload to the internet; set to false for internal-only access
+# ─── Access ───────────────────────────────────────────────────────────────────
+externalAccess: false # true publishes the gateway — INCLUDING its /tyk admin API — to the internet
 internalAccess: # OPTIONAL - Sets the internal firewall scope
-  type: none # options: none, same-gvc, same-org, workload-list
-  workloads:  # Note: can only be used if type is same-gvc or workload-list
-    #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
+  type: same-gvc # options: none, same-gvc, same-org, workload-list
+  workloads: [] # used with workload-list, e.g. //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
+# ─── Bundled Redis + Sentinel ─────────────────────────────────────────────────
+# Tyk's token, rate-limit and analytics store. It serves this gateway only and is
+# never reachable from outside the GVC, so the passwords are template plumbing —
+# but they are used AS-IS, so change them before installing.
 redis:
   redis:
     resources:
       cpu: 200m
       memory: 256Mi
-      minCpu: 80m
-      minMemory: 128Mi
     replicas: 2
     auth:
       password:
         enabled: true
-        value: myRedisPassword
+        value: change-me-tyk-redis
     firewall:
       internal_inboundAllowType: same-gvc
     persistence:
@@ -161,92 +207,181 @@ redis:
     resources:
       cpu: 200m
       memory: 256Mi
-      minCpu: 80m
-      minMemory: 128Mi
     replicas: 3
     auth:
       password:
         enabled: true
-        value: mySentinelPassword
+        value: change-me-tyk-sentinel
     firewall:
       internal_inboundAllowType: same-gvc
     persistence:
       enabled: true
 ```
 
-### API Definitions & Policies
+### API Definitions and Policies
 
-- `apiSecretName` — Name of the pre-existing Control Plane secret containing API definitions. Each key in the dictionary is a JSON filename mounted at `/opt/tyk-gateway/apps`. **Must be created before deploying.**
-- `policySecretName` — Name of the pre-existing Control Plane opaque secret containing the policies JSON, mounted at `/opt/tyk-gateway/policies/policies.json`. **Must be created before deploying.**
+- `apiSecretName` — name of the dictionary secret holding your API definitions. Each key is a JSON filename mounted at `/opt/tyk-gateway/apps`. Set to `""` to omit the mount — but see the demo-API warning in [Prerequisites](#2-api-definitions-optional).
+- `policySecretName` — name of the opaque secret holding your policies JSON, mounted at `/opt/tyk-gateway/policies/policies.json`. Set to `""` to run with no policies.
+- `listenPort` — the port the gateway listens on. Control Plane reserves a set of container ports; the chart refuses to render on one of them rather than letting the workload be rejected at apply time.
 
-Leave either value empty to omit that mount from the gateway workload.
+Both secrets are read at boot. After editing either one, redeploy the gateway workload or call `/tyk/reload` for the change to take effect.
 
-### Admin Secret
+### Master Keys
 
-- `adminSecret` — The admin API key used for gateway management operations (e.g. creating keys, reloading APIs). **Change before deploying to production.** Stored in a dictionary secret and injected into the gateway at startup.
+- `allowMasterKeys` — when `true`, a key created through `/tyk/keys` with no `access_rights` section can call **every** API on this gateway. **Defaults to `false`**, matching upstream Tyk.
 
-### Resources & Autoscaling
+<Warning>
+**This default changed in 1.3.0 and it will break key-creation requests that used to work.** Versions up to 1.2.1 hardcoded master keys on, so any request that POSTed a bare session object was silently granted blanket access. With `allowMasterKeys: false`, the same request is refused — the exact response depends on the endpoint:
 
-- `resources.cpu` / `resources.memory` — CPU and memory allocated to the Tyk Gateway workload.
-- `autoscaling.minScale` / `autoscaling.maxScale` — Minimum and maximum number of gateway replicas.
-- `autoscaling.metric` — Scaling metric (`cpu` by default).
-- `autoscaling.target` — Target metric value that triggers a scale-up.
-- `autoscaling.scaleToZeroDelay` — Seconds of inactivity before scaling to zero (only applies when `minScale` is `0`).
-- `multiZone` — When `true`, spreads replicas across availability zones within the location.
+| Request | Response |
+|---|---|
+| `POST /tyk/keys/create` with `"access_rights": {}` | `400` — `Failed to create key, keys must have at least one Access Rights record set.` |
+| `POST /tyk/keys/{custom-key}` with `"access_rights": {}` | `500` — `Failed to create key, ensure security settings are correct.` |
+
+In both cases the gateway logs the real reason: `Master keys disallowed in configuration, key not added.` with `err="master keys disabled"`. The fix is to give each key an `access_rights` entry naming the APIs it may reach; setting `allowMasterKeys: true` restores the old behavior and the old exposure.
+</Warning>
 
 ### Access
 
-- `externalAccess` — Set to `true` to expose the gateway publicly. Set to `false` for internal-only access.
-- `internalAccess.type` — Controls which workloads can connect to the gateway internally:
+- `externalAccess` — when `true`, the gateway's external inbound firewall opens to `0.0.0.0/0` and Control Plane assigns a `*.cpln.app` canonical endpoint. **Defaults to `false`.**
+- `internalAccess.type` — which workloads inside Control Plane may reach the gateway. **Defaults to `same-gvc`.**
+- `internalAccess.workloads` — list of workload links, used only when `type` is `workload-list`.
 
 | Type | Description |
 |------|-------------|
 | `none` | No internal access allowed |
 | `same-gvc` | Allow access from all workloads in the same GVC |
 | `same-org` | Allow access from all workloads in the same organization |
-| `workload-list` | Allow access only from specific workloads listed in `workloads` |
+| `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads` |
 
-- `internalAccess.workloads` — List of specific workload links, used when `type` is `workload-list`.
+<Warning>
+**`externalAccess: true` puts the Tyk admin API on the public internet.** `/tyk/*` is served on the same port as your proxied APIs and cannot be split onto another listener, so publishing the gateway publishes its key-management API with it and the admin secret becomes the only thing in front of it. Prefer leaving it `false` and reaching the gateway from inside the GVC.
+</Warning>
 
-### Redis
+<Note>
+Setting `externalAccess: false` together with `internalAccess.type: none` would leave nothing able to reach the gateway, so the chart fails the render with a message naming both knobs instead of installing something unreachable.
 
-The Redis subchart is configured under the `redis` key. See the [Redis template](/template-catalog/templates/redis) for full configuration details. Key options:
+**An access change takes up to a couple of minutes to take effect.** Enabling external access was measured at 30 seconds from upgrade to the first `200`, and closing internal access at about 32 seconds; re-poll before concluding a knob did nothing. Note that a request blocked by the internal firewall **times out** rather than returning `403` — a hang is what a correctly closed internal firewall looks like here, not a sign that the gateway is down.
+</Note>
 
-- `redis.redis.replicas` — Number of Redis replicas.
-- `redis.redis.auth.password.enabled` / `redis.redis.auth.password.value` — Redis password authentication. **Change before deploying to production.**
-- `redis.redis.persistence.enabled` — Persist Redis data to a volume set.
-- `redis.sentinel.replicas` — Number of Sentinel replicas (3 recommended for production).
-- `redis.sentinel.auth.password.enabled` / `redis.sentinel.auth.password.value` — Sentinel password authentication. **Change before deploying to production.**
-- `redis.sentinel.persistence.enabled` — Persist Sentinel state to a volume set.
+### Resources and Autoscaling
 
-### Connecting to the Gateway
+- `resources.cpu` / `resources.memory` — CPU and memory allocated to the gateway workload.
+- `autoscaling.minScale` / `autoscaling.maxScale` — minimum and maximum number of gateway replicas.
+- `autoscaling.metric` — scaling metric (`cpu` by default).
+- `autoscaling.target` — target metric value that triggers a scale-up.
+- `autoscaling.scaleToZeroDelay` — seconds of inactivity before scaling to zero (only applies when `minScale` is `0`).
+- `multiZone` — when `true`, spreads replicas across availability zones within the location.
 
-Access the gateway from within the same GVC at:
+### Redis and Sentinel
 
-```text
-RELEASE_NAME-tyk-api-gateway.GVC_NAME.cpln.local:8080
+The bundled Redis is configured under the `redis` key; see the [Redis template](/template-catalog/templates/redis) for full configuration details.
+
+- `redis.redis.replicas` — number of Redis replicas.
+- `redis.sentinel.replicas` — number of Sentinel replicas; 3 is the default and the recommended minimum for failover.
+- `redis.redis.persistence.enabled` / `redis.sentinel.persistence.enabled` — persist data and Sentinel state to volume sets.
+- `redis.redis.auth.password.value` / `redis.sentinel.auth.password.value` — the Redis and Sentinel passwords.
+
+This Redis serves only this gateway and is never reachable from outside the GVC, so its passwords remain Helm values rather than prerequisite secrets. **They are used exactly as written**, so replace both `change-me-…` placeholders before installing.
+
+### Outbound Connectivity
+
+The gateway ships with an empty outbound firewall (`outboundAllowCIDR: []`), so it cannot open connections to the public internet.
+
+<Warning>
+**Every API's `target_url` must point at an upstream inside the same GVC**, addressed over internal DNS — for example `http://my-app.GVC_NAME.cpln.local:8080`. GVC-internal traffic is governed by the destination workload's internal firewall rather than by the gateway's egress, so in-GVC proxying works normally with egress closed. To proxy to an API on the public internet, add `outboundAllowCIDR` or `outboundAllowHostname` to the gateway workload; there is no value for it in the chart.
+</Warning>
+
+## Connecting
+
+| Path | Address | Notes |
+|------|---------|-------|
+| Public gateway | `https://CANONICAL_ENDPOINT` | Only when `externalAccess` is `true`. Read the endpoint from `status.canonicalEndpoint` in `cpln workload get RELEASE_NAME-tyk-api-gateway --gvc GVC_NAME -o yaml`. |
+| Internal gateway | `http://RELEASE_NAME-tyk-api-gateway.GVC_NAME.cpln.local:8080` | Subject to `internalAccess.type`. Use `listenPort` if you changed it. |
+| Proxied API | `GATEWAY_ADDRESS/LISTEN_PATH` | `listen_path` comes from each API definition, e.g. `/app1`. |
+| Admin API | `GATEWAY_ADDRESS/tyk/keys`, `/tyk/apis`, `/tyk/reload` | Send the header `X-Tyk-Authorization` set to the payload of your `adminSecretName` secret. |
+| Health check | `GATEWAY_ADDRESS/hello` | Reports gateway version and Redis connectivity. |
+| Redis and Sentinel | `RELEASE_NAME-redis.GVC_NAME.cpln.local:6379`, `RELEASE_NAME-sentinel.GVC_NAME.cpln.local:26379` | Internal only; passwords are the `redis.*.auth.password.value` values. |
+
+Reveal the admin key when you need it:
+
+```bash
+cpln secret reveal my-tyk-admin-secret
 ```
-
-When `externalAccess` is `true`, the gateway is also reachable via its public Control Plane endpoint.
-
-The Tyk management API is available on the same port under the `/tyk/` path. Requests require the `x-tyk-authorization` header set to the value of `adminSecret`.
 
 ### Ports
 
 | Port | Protocol | Description |
 |------|----------|-------------|
-| `8080` | HTTP | API traffic and management API (`/tyk/`) |
+| `8080` | HTTP | API traffic and the admin API under `/tyk/` |
+
+## Upgrading From 1.2.1 or Earlier
+
+<Warning>
+**Two defaults change behavior on upgrade: the gateway stops being reachable from the internet, and key-creation requests without `access_rights` start failing.** Neither is a fault; both will surprise you if you have not planned for them.
+</Warning>
+
+| Behavior | 1.2.1 and earlier | 1.3.0 |
+|---|---|---|
+| Admin API key | `adminSecret` value, defaulting to `mysecret` | `adminSecretName`, naming an opaque secret you create |
+| External access | `externalAccess`, defaulting to `true` | `externalAccess`, defaulting to `false` |
+| Internal access | `internalAccess.type`, defaulting to `none` | `internalAccess.type`, defaulting to `same-gvc` |
+| Master keys | Hardcoded on, no knob | `allowMasterKeys`, defaulting to `false` |
+| Redis and Sentinel passwords | `myRedisPassword` / `mySentinelPassword` | `change-me-tyk-redis` / `change-me-tyk-sentinel` placeholders |
+| Chart-created secret | A dictionary secret holding the admin key | None for the admin key — only the bundled Redis and Sentinel secrets |
+
+What to do before upgrading:
+
+<Steps>
+  <Step title="Create the admin key secret">
+    The gateway will not start without it. Use a freshly generated value rather than carrying `mysecret` forward — it has been published in a public repository for the life of the earlier versions, and any key minted with it should be considered compromised:
+
+    ```bash
+    printf '%s' "$(openssl rand -hex 32)" | cpln secret create-opaque --name my-tyk-admin-secret --encoding plain -f -
+    ```
+
+    Set `adminSecretName` to that name and remove `adminSecret` from your values — it no longer exists in the chart. Every client calling `/tyk/*` needs the new value in its `X-Tyk-Authorization` header.
+  </Step>
+  <Step title="Decide whether the gateway should stay public">
+    If clients outside Control Plane call your APIs, set `externalAccess: true` explicitly — and understand that this also republishes `/tyk/*`. If every caller is inside the GVC, do nothing and the default `same-gvc` covers them.
+  </Step>
+  <Step title="Audit any key created without access rights">
+    Under the old hardcoded setting, such keys reach every API on the gateway. List them with `GET /tyk/keys`, then reissue each one with an `access_rights` entry naming only the APIs it needs. Requests that create bare keys now fail — see [Master Keys](#master-keys) for the exact responses.
+  </Step>
+  <Step title="Set the Redis and Sentinel passwords">
+    The placeholder defaults are used verbatim if you leave them, so set both `redis.redis.auth.password.value` and `redis.sentinel.auth.password.value` to values of your own.
+  </Step>
+</Steps>
+
+## Important Notes
+
+- **Create the admin secret before installing.** A missing secret does not fail the install — Helm reports success and the gateway then sits at zero replicas with no container logs at all.
+- **`externalAccess: true` publishes the admin API**, because `/tyk/*` shares the listener with your proxied APIs. The admin secret is then the only control in front of key creation and revocation.
+- **`allowMasterKeys: true` grants blanket access.** Any key created without `access_rights` reaches every API on the gateway. Leave it `false` unless you have a specific reason.
+- **Leaving `apiSecretName` empty serves Tyk's demo API**, not an empty gateway. The install looks healthy while none of your APIs are loaded.
+- **Egress is closed**, so every `target_url` must resolve to an in-GVC `*.cpln.local` host.
+- **Change the bundled Redis and Sentinel passwords** — they ship as `change-me-…` placeholders and are used exactly as written.
+- **The gateway declares no health probes, so `ready: true` arrives before it can serve.** A workload was ready roughly 30 seconds before it had connected to Redis, logging `storage: Redis is either down or was not configured` in between. Use `GET /hello` and check that `redis` reports `pass` rather than trusting the readiness signal, and expect the same gap when an autoscaled replica starts.
+- **Access changes take up to a couple of minutes to propagate.** A change that appears to do nothing has usually just not settled yet.
+- **The first `helm upgrade` after an install restarts the bundled Redis**, briefly interrupting rate-limit and key lookups even when nothing changed. Later no-op upgrades do not.
+- **The prerequisite secrets are not owned by the release** — your admin, API, and policy secrets survive `cpln helm uninstall` and must be deleted manually if you no longer need them.
 
 ## External References
 
 <CardGroup cols={2}>
-    <Card title="Tyk Documentation" icon="book" href="https://tyk.io/docs">
+    <Card title="Tyk Gateway Documentation" icon="book" href="https://tyk.io/docs/">
     Official Tyk API Gateway documentation
     </Card>
-    <Card title="Tyk API Definition Objects" icon="book" href="https://tyk.io/docs/5.0/tyk-gateway-api/api-definition-objects/">
+    <Card title="Gateway Configuration Options" icon="gear" href="https://tyk.io/docs/tyk-oss-gateway/configuration/">
+    Every gateway setting and its environment-variable name
+    </Card>
+    <Card title="Gateway Control API" icon="code" href="https://tyk.io/docs/api-management/gateway-config-managing-classic/">
+    Reference for the admin endpoints under /tyk/
+    </Card>
+    <Card title="API Definition Objects" icon="file-code" href="https://tyk.io/docs/api-management/gateway-config-tyk-classic/">
     Reference for the API definition JSON structure
     </Card>
-    <Card title="Tyk Policies Guide" icon="book" href="https://tyk.io/docs/5.1/basic-config-and-security/security/security-policies/policies-guide/">
+    <Card title="Security Policies" icon="shield" href="https://tyk.io/docs/api-management/policies/">
     Guide for configuring Tyk access policies
     </Card>
     <Card title="Tyk Template" icon="github" href="https://github.com/controlplane-com/templates/tree/main/tyk">


### PR DESCRIPTION
The docs half of two tier-1 fixes from the 2026-08-14 catalog secrets audit. Both template PRs are merged: **#416** (dbeaver 1.3.0) and **#418** (tyk 1.3.0). Templates PR **#419** corrects the corresponding template READMEs/briefings, so the pages and the shipped READMEs now agree.

**dbeaver** (`template-catalog/templates/dbeaver.mdx`)
- Admin password is now a prerequisite opaque secret (`admin.passwordSecretName`); `Password123` is gone from the chart.
- `publicAccess.enabled` defaults to `false` — the console is no longer on the public internet.
- New "Upgrading From 1.2.1 or Earlier" section: existing admin login is unchanged in **both name and password**, so upgraders keep signing in as `adminusername` and the new `cbadmin` default applies to new installs only.
- Documents the first-boot-only credential behavior, the log-hash authentication caveat, closed egress, and that the volume set takes no scheduled snapshots (only a final snapshot on delete, kept 7 days).

**tyk** (`template-catalog/templates/tyk.mdx`)
- Gateway Control API key is now a prerequisite opaque secret; the `mysecret` default is gone.
- `externalAccess` defaults to `false`, `allowMasterKeys` defaults to `false`, `internalAccess.type` moves from `none` to `same-gvc`.
- Upgrade section names all three defaults that change behavior on an existing install, including that the internal-access change *widens* in-GVC reachability.

**Review summary:** PASS on re-review after one revision round (1 blocker + 1 warning + 4 nits, all addressed). Verified every documented key against the shipped `values.yaml` (code blocks byte-identical), the volume-set snapshot claim against `dbeaver/versions/1.3.0/templates/volumeset.yaml`, the firewall-propagation timings and codes against test report T3, the first-boot-only `CB_ADMIN_NAME` claim against T5, the Redis subchart identity/policy names against `redis` 3.4.2 `_helpers.tpl`, and both versions' access defaults against 1.2.1 and 1.3.0 sources. Headings and anchors unchanged, no new external URLs, changelog entries present under 2026-08 for both templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)