### PR TITLE
byok/workload: document extras.metadata.labels and extras.spec.schedulerName

### DIFF
--- a/byok/settings/workload.mdx
+++ b/byok/settings/workload.mdx
@@ -18,10 +18,17 @@ spec:
     affinity: ...
     tolerations: ...
     topologySpreadConstraints: ...
+    metadata:
+      labels:
+        my-label: my-value
+    spec:
+      schedulerName: my-scheduler
 ```
 
-- Right now, only `affinity`, `tolerations`, and `topologySpreadConstraints` are supported.
-- These options will be **merged** with the default ones.
+- Supported options: `affinity`, `tolerations`, `topologySpreadConstraints`, `metadata.labels`, and `spec.schedulerName`.
+- `metadata.labels` are added to the workload's pods. They are merged with the platform-managed labels, which cannot be overridden.
+- `spec.schedulerName` sets the Kubernetes scheduler used to place the workload's pods, for use with a custom scheduler running on your cluster.
+- `affinity`, `tolerations`, and `topologySpreadConstraints` are **merged** with the default ones.
 
 ## Custom Tags
 


### PR DESCRIPTION
Documents two new BYOK workload `extras` fields in `byok/settings/workload.mdx`:

- `extras.metadata.labels` — extra labels applied to the workload's pods (merged with platform-managed labels, which can't be overridden).
- `extras.spec.schedulerName` — the Kubernetes scheduler used to place the workload's pods (for a custom scheduler on the BYOK cluster).

Adds both to the YAML example and the supported-options list.

**Hold until the feature ships.** These fields are not yet implemented — tracked in https://gitlab.com/controlplane/controlplane/-/work_items/4875. This PR should merge alongside that work so the docs don't describe unshipped behavior.
