### PR TITLE
docs: tier-1 security cycle — all eight templates

### DIFF
--- a/template-catalog/templates/dbeaver.mdx
+++ b/template-catalog/templates/dbeaver.mdx
@@ -17,7 +17,7 @@ The admin account is bootstrapped from an [opaque secret](/guides/create-secret/
 ### What Gets Created
 
 - **Stateful CloudBeaver Workload** (`RELEASE_NAME-dbeaver`) — a single CloudBeaver instance serving the web UI and API on port `8978`.
-- **Volume Set** (`RELEASE_NAME-dbeaver-vs`) — a 10 GiB `ext4` volume mounted at `/opt/cloudbeaver/workspace`, holding the server configuration, saved connections, and user accounts. Daily snapshots with 7-day retention.
+- **Volume Set** (`RELEASE_NAME-dbeaver-vs`) — a 10 GiB `ext4` volume mounted at `/opt/cloudbeaver/workspace`, holding the server configuration, saved connections, and user accounts. A final snapshot is taken when the volume set is deleted and kept for 7 days; there are no scheduled snapshots.
 - **Identity & Policy** — an identity bound to the workload and a policy granting it `reveal` on exactly the admin-password secret you created, and nothing else.
 - **No template-created secret** — the only credential lives in the prerequisite secret you own.
 
@@ -31,7 +31,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 <Steps>
   <Step title="Create the admin password secret">
-    Choose your own strong password (CloudBeaver requires at least 8 characters) and store it as the secret's payload:
+    Choose your own strong password — use at least 8 characters — and store it as the secret's payload:
 
     ```bash
     printf '%s' 'YOUR-STRONG-PASSWORD' | cpln secret create-opaque --name my-dbeaver-admin-password --encoding plain -f -
@@ -141,7 +141,7 @@ To change the password, use the CloudBeaver UI (**Administration → Users**), o
 | `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads` |
 
 <Note>
-**An access change takes up to a couple of minutes to take effect.** Firewall changes propagate asynchronously: enabling public access was measured at 107 seconds from upgrade to the first `200`, and disabling it at about 120 seconds, passing through `503` and `504` on the way. Re-poll before concluding the knob did nothing.
+**An access change takes up to a couple of minutes to take effect.** Firewall changes propagate asynchronously: enabling public access was measured at 107 seconds from upgrade to the first `200`, passing through `504` on the way, and disabling it at about 120 seconds, passing through `503` and `504` before settling on `403`. Re-poll before concluding the knob did nothing.
 
 A request blocked by `internalAccess.type: none` **hangs until your client times out** rather than being refused — the TCP connection is accepted by the local sidecar and no bytes are ever returned. "Connected, but no response" is what a correctly closed internal firewall looks like here.
 </Note>
@@ -174,13 +174,13 @@ Add database connections from the UI after logging in, pointing them at in-GVC h
 ## Upgrading From 1.2.1 or Earlier
 
 <Warning>
-**After upgrading, the console is no longer reachable from the internet, and your existing admin password keeps working.** Both are expected. Plan the upgrade rather than discovering it.
+**After upgrading, the console is no longer reachable from the internet, and your existing admin login is unchanged — both the name and the password stay whatever the workspace was first bootstrapped with.** In particular, keep logging in as your old admin name (`adminusername` if you never changed it); the new `cbadmin` default never applies to an existing workspace. Both behaviors are expected. Plan the upgrade rather than discovering it.
 </Warning>
 
 | Behavior | 1.2.1 and earlier | 1.3.0 |
 |---|---|---|
 | Admin password | `admin.password` value, defaulting to `Password123` | `admin.passwordSecretName`, naming an opaque secret you create |
-| Admin login name | `admin.name`, defaulting to `adminusername` | `admin.name`, defaulting to `cbadmin` — still a plain value |
+| Admin login name | `admin.name`, defaulting to `adminusername` | `admin.name`, defaulting to `cbadmin` — still a plain value, and the new default applies to new installs only; an existing workspace keeps the name it was bootstrapped with |
 | Public access | Hardcoded `0.0.0.0/0` inbound, no knob | `publicAccess.enabled`, defaulting to `false` |
 | Internal access | Hardcoded `none` | `internalAccess.type`, defaulting to `same-gvc` |
 | Chart-created secret | A secret holding the admin name and password | None — the chart creates no secret |
@@ -200,21 +200,22 @@ What to do before upgrading:
   <Step title="Decide whether you still want public access">
     If you were relying on the internet-facing URL, set `publicAccess.enabled: true` explicitly. If you were not, do nothing and the console becomes internal-only. Either way, allow a couple of minutes for the firewall change to propagate.
   </Step>
-  <Step title="Expect your old password to keep working">
-    The account already exists in the workspace database, so the upgrade does not re-bootstrap it — see [Admin Credentials](#admin-credentials). If the password you were using is one you would rather not keep, change it in the CloudBeaver UI after the upgrade.
+  <Step title="Expect your old login name and password to keep working">
+    The account already exists in the workspace database, so the upgrade does not re-bootstrap it — neither `admin.name` nor the password secret is applied to a workspace that is already initialized (see [Admin Credentials](#admin-credentials)). Keep signing in with the name and password the workspace was bootstrapped with — typically `adminusername`, not the new `cbadmin` default. If either is one you would rather not keep, change it in the CloudBeaver UI after the upgrade.
   </Step>
 </Steps>
 
 ## Important Notes
 
 - **Create the admin-password secret before installing.** A missing secret does not fail the install — `cpln helm install` reports success and the workload then sits at zero replicas waiting on it, with no container logs to diagnose from.
-- **The admin password is read only when the workspace is first initialized.** Rotating the secret afterwards changes what the container sees and changes nothing about who can log in. Change it in the CloudBeaver UI instead.
+- **The admin name and password are read only when the workspace is first initialized.** Rotating the secret or changing `admin.name` afterwards changes what the container sees and changes nothing about who can log in. Change the password in the CloudBeaver UI instead.
 - **Anyone who can read this workload's logs can authenticate as the admin**, because CloudBeaver logs the submitted password hash and its API accepts that hash as a credential.
 - **`publicAccess.enabled: true` puts a database administration console on the public internet.** Anyone who reaches it needs only the admin password to query every connected database. Prefer leaving it off and reaching the UI from inside the GVC.
 - **Egress is closed and there is no knob for it** — only databases inside the same GVC can be connected. Managed services such as RDS, Cloud SQL, and Atlas are unreachable.
 - **Access changes take up to a couple of minutes to propagate.** A `publicAccess` or `internalAccess` change that appears to do nothing has usually just not settled yet.
 - **The first `helm upgrade` after an install restarts the workload**, taking the UI down for roughly 30 to 60 seconds even when nothing about the values changed. This template runs a single replica, so there is no other instance to serve during the restart. Later no-op upgrades do not restart it.
 - **Saved connections and users live on the volume set** and survive redeploys and upgrades. `cpln helm uninstall` deletes the volume set, taking every saved connection with it.
+- **There is no scheduled-backup feature.** The volume set takes no scheduled snapshots — the only one is the final snapshot taken when it is deleted, kept for 7 days. Export anything you cannot lose from the CloudBeaver UI before uninstalling.
 - **The prerequisite secret is not owned by the release** — it survives `cpln helm uninstall` and must be deleted manually if you no longer need it.
 
 ## External References

--- a/template-catalog/templates/dbeaver.mdx
+++ b/template-catalog/templates/dbeaver.mdx
@@ -1,27 +1,58 @@
 ---
 title: DBeaver
-description: Deploy DBeaver on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and web-based database administration with CloudBeaver.
-keywords: ['cloudbeaver', 'sql client', 'db gui', 'sql workbench', 'datagrip alternative', 'pgadmin alternative', 'web sql ide', 'multi-db client', 'browser db tool', 'phpmyadmin alternative']
+description: Deploy DBeaver CloudBeaver on Control Plane using the Template Catalog. A browser-based SQL client and database administration console with a persistent workspace, an admin password held in a prerequisite secret, and no public access by default.
+keywords: ['cloudbeaver', 'sql client', 'db gui', 'sql workbench', 'datagrip alternative', 'pgadmin alternative', 'web sql ide', 'multi-db client', 'browser db tool', 'phpmyadmin alternative', 'prerequisite secret', 'admin password rotation']
 ---
 
 ## Overview
 
-DBeaver is a web-based database administration tool that provides a modern interface for managing multiple database connections. This template deploys the self-hosted [CloudBeaver](https://github.com/dbeaver/cloudbeaver) web application — the browser-based edition of DBeaver — with automatic admin user creation, giving you immediate access to a full-featured SQL editor, connection manager, and data browser for a wide range of database systems including PostgreSQL, MySQL, MariaDB, MongoDB, Redis, SQLite, Oracle, SQL Server, and more.
+DBeaver is a web-based database administration tool that provides a modern interface for managing multiple database connections. This template deploys the self-hosted [CloudBeaver](https://github.com/dbeaver/cloudbeaver) web application — the browser-based edition of DBeaver — giving you a full-featured SQL editor, connection manager, and data browser for PostgreSQL, MySQL, MariaDB, MongoDB, Redis, SQLite, Oracle, SQL Server, and more.
+
+The admin account is bootstrapped from an [opaque secret](/guides/create-secret/opaque) you create before installing, and the console is reachable only from inside the GVC unless you deliberately publish it.
+
+<Warning>
+**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped a working admin password (`Password123`) as a `values.yaml` default and hardcoded the workload's inbound firewall to `0.0.0.0/0` with no way to turn it off, so a default install published a database administration console to the internet behind a password published in a public repository. In 1.3.0 the password moved to a prerequisite secret and public access became an opt-in knob that defaults to off — **which changes the behavior of an existing install when you upgrade.**
+</Warning>
 
 ### What Gets Created
 
-- **Workload** — A DBeaver web application container with persistent storage and an admin user pre-configured on startup.
-- **Volume Set** — Persistent storage for workspace data, connections, and settings.
-- **Secret** — An opaque secret storing the admin username and password, injected into the container at startup.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to the admin credentials secret.
+- **Stateful CloudBeaver Workload** (`RELEASE_NAME-dbeaver`) — a single CloudBeaver instance serving the web UI and API on port `8978`.
+- **Volume Set** (`RELEASE_NAME-dbeaver-vs`) — a 10 GiB `ext4` volume mounted at `/opt/cloudbeaver/workspace`, holding the server configuration, saved connections, and user accounts. Daily snapshots with 7-day retention.
+- **Identity & Policy** — an identity bound to the workload and a policy granting it `reveal` on exactly the admin-password secret you created, and nothing else.
+- **No template-created secret** — the only credential lives in the prerequisite secret you own.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Prerequisites
+
+**One [opaque secret](/guides/create-secret/opaque) must exist before you install.** The admin password guards a database administration console, and whoever holds it can query every database that console is connected to — so it is never a Helm value and never lands in the release.
+
+<Steps>
+  <Step title="Create the admin password secret">
+    Choose your own strong password (CloudBeaver requires at least 8 characters) and store it as the secret's payload:
+
+    ```bash
+    printf '%s' 'YOUR-STRONG-PASSWORD' | cpln secret create-opaque --name my-dbeaver-admin-password --encoding plain -f -
+    ```
+
+    Set `admin.passwordSecretName` to the name you used. The default in `values.yaml` is `my-dbeaver-admin-password`.
+  </Step>
+  <Step title="Pick an admin login name">
+    Set `admin.name` to the login name you want. It is not sensitive and stays a plain value; the default is `cbadmin`.
+  </Step>
+</Steps>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, all four resources are created, and the workload then never starts — it sits at zero replicas with the message `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` There are no container logs to diagnose from, because the container never ran. Create the secret first, and after installing confirm with `cpln workload get-deployments RELEASE_NAME-dbeaver --gvc GVC_NAME` rather than trusting the Helm output.
+</Warning>
+
+Nothing else is required for a default install.
+
 ## Installation
 
-This template has no external prerequisites. To install, follow the instructions for your preferred method:
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -52,9 +83,26 @@ The default `values.yaml` for this template:
 ```yaml
 image: dbeaver/cloudbeaver:25.2.0
 
+# ─── Admin Login (prerequisite secret) ────────────────────────────────────────
+# The admin password guards the CloudBeaver web login, and whoever holds it can
+# reach every database this console is connected to — so it never transits
+# values or the Helm release. Create the opaque secret (encoding: plain) BEFORE
+# install; see README Prerequisites.
 admin:
-  name: adminusername
-  password: Password123
+  name: cbadmin # admin login name (not sensitive)
+  passwordSecretName: my-dbeaver-admin-password # opaque secret holding the admin password; must EXIST BEFORE INSTALL
+
+# ─── Access ───────────────────────────────────────────────────────────────────
+publicAccess:
+  # false = not reachable from the internet. Setting this true publishes a
+  # database administration console, and its login form, to the whole internet.
+  enabled: false
+
+internalAccess:
+  type: same-gvc # options: none, same-gvc, same-org, workload-list
+  workloads: [] # used with workload-list
+  # workloads:
+  #   - //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
 resources:
   cpu: 500m
@@ -66,25 +114,120 @@ volumeset:
 
 ### Admin Credentials
 
-- `admin.name` — Username for the admin account created on first startup.
-- `admin.password` — Password for the admin account. **Change this before deploying.**
+- `admin.name` — the admin login name, created when the workspace is first initialized. Not sensitive, so it stays a plain value. Default `cbadmin`.
+- `admin.passwordSecretName` — the name of the opaque secret holding the admin password. The chart references it as `cpln://secret/NAME.payload`, so the password itself never appears in the workload spec or the Helm release.
 
-These values are stored as a Control Plane secret and injected into the container at startup. No manual user creation is required — log in with these credentials immediately after deployment.
+<Warning>
+**The admin password cannot be rotated by changing the secret.** Both credentials are consumed only when an empty workspace is initialized on the volume set. On every later boot CloudBeaver reads the account it already stored in its workspace database and ignores the environment. This was measured: after rewriting the secret's payload and restarting the workload, the container held the **new** value while the **old password still logged in** and the new one was rejected with `Invalid user credentials`.
+
+To change the password, use the CloudBeaver UI (**Administration → Users**), or uninstall — which deletes the volume set and every saved connection with it — and reinstall.
+</Warning>
+
+<Warning>
+**CloudBeaver logs the submitted password hash, and its API accepts that hash in place of the password.** At the image's default log level, login requests appear in `cpln logs` with the credential included, and replaying that value against the API authenticates successfully — so anyone who can read this workload's logs can log in as the admin. This is upstream CloudBeaver behavior, not something the chart configures; the move to a prerequisite secret does not close it. Treat log access to this workload as equivalent to admin access to every database it is connected to.
+</Warning>
+
+### Access
+
+- `publicAccess.enabled` — when `true`, the workload's external inbound firewall opens to `0.0.0.0/0` and Control Plane assigns a `*.cpln.app` canonical endpoint. **Defaults to `false`.** With it off, requests to the canonical endpoint return `403 RBAC: access denied`.
+- `internalAccess.type` — which workloads inside Control Plane may reach the console. **Defaults to `same-gvc`.**
+- `internalAccess.workloads` — list of workload links, used only when `type` is `workload-list`.
+
+| Type | Description |
+|------|-------------|
+| `none` | No internal access allowed |
+| `same-gvc` | Allow access from all workloads in the same GVC |
+| `same-org` | Allow access from all workloads in the same organization |
+| `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads` |
+
+<Note>
+**An access change takes up to a couple of minutes to take effect.** Firewall changes propagate asynchronously: enabling public access was measured at 107 seconds from upgrade to the first `200`, and disabling it at about 120 seconds, passing through `503` and `504` on the way. Re-poll before concluding the knob did nothing.
+
+A request blocked by `internalAccess.type: none` **hangs until your client times out** rather than being refused — the TCP connection is accepted by the local sidecar and no bytes are ever returned. "Connected, but no response" is what a correctly closed internal firewall looks like here.
+</Note>
+
+### Outbound Connectivity
+
+The workload ships with an empty outbound firewall (`outboundAllowCIDR: []`), and there is no value to change it.
+
+<Warning>
+**CloudBeaver can only reach databases inside its own GVC.** Outbound TLS connections to the public internet do not complete — measured as a connection reset during the TLS handshake (`curl` exit code 35) from the CloudBeaver container, while a control workload in the same GVC with open egress reached the same hosts normally. In practice this means **managed databases such as Amazon RDS, Google Cloud SQL, and MongoDB Atlas cannot be connected**. Point connections at in-GVC hosts over internal DNS instead, e.g. `my-postgres.GVC_NAME.cpln.local:5432`.
+
+Note that DNS still resolves and a bare TCP connect can appear to succeed, because the sidecar accepts the socket before the connection is reset — do not infer working egress from either.
+</Warning>
 
 ### Resources and Storage
 
 - `resources.cpu` / `resources.memory` — CPU and memory allocated to the CloudBeaver workload.
-- `volumeset.capacity` — Persistent volume size in GiB for workspace data, connections, and settings (minimum 10).
+- `volumeset.capacity` — persistent volume size in GiB for workspace data, saved connections, and user accounts (minimum 10).
 
-### Accessing CloudBeaver
+## Connecting
 
-Once deployed, open the workload's endpoint in your browser and log in with the admin credentials configured in your values file.
+| Path | Address | Notes |
+|------|---------|-------|
+| Public UI | `https://CANONICAL_ENDPOINT` | Only when `publicAccess.enabled` is `true`. Read the endpoint from `status.canonicalEndpoint` in `cpln workload get RELEASE_NAME-dbeaver --gvc GVC_NAME -o yaml`. |
+| Internal UI and API | `http://RELEASE_NAME-dbeaver.GVC_NAME.cpln.local:8978` | Subject to `internalAccess.type`. |
+| Admin credentials | `admin.name` from your values, plus the payload of the secret named in `admin.passwordSecretName` | Reveal it with `cpln secret reveal my-dbeaver-admin-password`. |
+
+Add database connections from the UI after logging in, pointing them at in-GVC hosts over internal DNS.
+
+## Upgrading From 1.2.1 or Earlier
+
+<Warning>
+**After upgrading, the console is no longer reachable from the internet, and your existing admin password keeps working.** Both are expected. Plan the upgrade rather than discovering it.
+</Warning>
+
+| Behavior | 1.2.1 and earlier | 1.3.0 |
+|---|---|---|
+| Admin password | `admin.password` value, defaulting to `Password123` | `admin.passwordSecretName`, naming an opaque secret you create |
+| Admin login name | `admin.name`, defaulting to `adminusername` | `admin.name`, defaulting to `cbadmin` — still a plain value |
+| Public access | Hardcoded `0.0.0.0/0` inbound, no knob | `publicAccess.enabled`, defaulting to `false` |
+| Internal access | Hardcoded `none` | `internalAccess.type`, defaulting to `same-gvc` |
+| Chart-created secret | A secret holding the admin name and password | None — the chart creates no secret |
+
+What to do before upgrading:
+
+<Steps>
+  <Step title="Create the admin password secret">
+    Even though it will not change the account you already log in with, the workload will not start without it. Use the same password your install currently uses so nothing is ambiguous later:
+
+    ```bash
+    printf '%s' 'YOUR-EXISTING-PASSWORD' | cpln secret create-opaque --name my-dbeaver-admin-password --encoding plain -f -
+    ```
+
+    Then set `admin.passwordSecretName` to that name, and remove `admin.password` from your values — it no longer exists in the chart.
+  </Step>
+  <Step title="Decide whether you still want public access">
+    If you were relying on the internet-facing URL, set `publicAccess.enabled: true` explicitly. If you were not, do nothing and the console becomes internal-only. Either way, allow a couple of minutes for the firewall change to propagate.
+  </Step>
+  <Step title="Expect your old password to keep working">
+    The account already exists in the workspace database, so the upgrade does not re-bootstrap it — see [Admin Credentials](#admin-credentials). If the password you were using is one you would rather not keep, change it in the CloudBeaver UI after the upgrade.
+  </Step>
+</Steps>
+
+## Important Notes
+
+- **Create the admin-password secret before installing.** A missing secret does not fail the install — `cpln helm install` reports success and the workload then sits at zero replicas waiting on it, with no container logs to diagnose from.
+- **The admin password is read only when the workspace is first initialized.** Rotating the secret afterwards changes what the container sees and changes nothing about who can log in. Change it in the CloudBeaver UI instead.
+- **Anyone who can read this workload's logs can authenticate as the admin**, because CloudBeaver logs the submitted password hash and its API accepts that hash as a credential.
+- **`publicAccess.enabled: true` puts a database administration console on the public internet.** Anyone who reaches it needs only the admin password to query every connected database. Prefer leaving it off and reaching the UI from inside the GVC.
+- **Egress is closed and there is no knob for it** — only databases inside the same GVC can be connected. Managed services such as RDS, Cloud SQL, and Atlas are unreachable.
+- **Access changes take up to a couple of minutes to propagate.** A `publicAccess` or `internalAccess` change that appears to do nothing has usually just not settled yet.
+- **The first `helm upgrade` after an install restarts the workload**, taking the UI down for roughly 30 to 60 seconds even when nothing about the values changed. This template runs a single replica, so there is no other instance to serve during the restart. Later no-op upgrades do not restart it.
+- **Saved connections and users live on the volume set** and survive redeploys and upgrades. `cpln helm uninstall` deletes the volume set, taking every saved connection with it.
+- **The prerequisite secret is not owned by the release** — it survives `cpln helm uninstall` and must be deleted manually if you no longer need it.
 
 ## External References
 
 <CardGroup cols={2}>
-    <Card title="CloudBeaver Documentation" icon="book" href="https://cloudbeaver.io/docs/">
+    <Card title="CloudBeaver Documentation" icon="book" href="https://dbeaver.com/docs/cloudbeaver/">
     Official DBeaver CloudBeaver documentation
+    </Card>
+    <Card title="Server Configuration" icon="gear" href="https://dbeaver.com/docs/cloudbeaver/Server-configuration/">
+    Reference for CloudBeaver server settings
+    </Card>
+    <Card title="Admin Password Recovery" icon="key" href="https://dbeaver.com/docs/cloudbeaver/Admin-Password-Recovery/">
+    Upstream procedure for regaining admin access
     </Card>
     <Card title="DBeaver GitHub" icon="github" href="https://github.com/dbeaver/cloudbeaver">
     CloudBeaver open-source repository

--- a/template-catalog/templates/langfuse.mdx
+++ b/template-catalog/templates/langfuse.mdx
@@ -1,32 +1,38 @@
 ---
 title: Langfuse
-description: Deploy the full Langfuse LLM observability stack on Control Plane. Covers object storage prerequisites, secret generation, accessing the UI, sending traces, LLM connections, and backup recommendations.
-keywords: ['langfuse', 'llm observability', 'llm tracing', 'ai evaluation', 'opentelemetry', 'clickhouse', 'bullmq', 'nextjs', 'self-hosted langfuse', 'prompt management', 'llm monitoring']
+description: Deploy the Langfuse LLM observability stack on Control Plane. Covers the prerequisite auth secret, the headless admin account, closed self-service signup, object storage for traces and media, sending traces, and upgrading from 1.0.x.
+keywords: ['llm observability', 'llm tracing', 'prompt management', 'llm evaluation', 'langsmith alternative', 'helicone alternative', 'clickhouse', 'bullmq', 'nextauth', 'openai api key storage', 'ai agent monitoring', 'trace ingestion', 'self-hosted']
 ---
 
 ## Overview
 
-Langfuse is an open-source LLM observability and evaluation platform. This template deploys the full Langfuse stack on Control Plane — UI, background worker, and all required data stores — ready to receive traces from any LLM application.
+Langfuse is an open-source LLM observability and evaluation platform — traces, prompt management, evaluations, and a playground. This template deploys the full self-hosted stack on Control Plane: the web app, a background worker, and its three datastores, with trace data landing in an object store you own.
+
+The instance is closed by default. Self-service registration is off, and the owner account is provisioned at boot from a secret you create — so a public endpoint does not hand a stranger an account.
+
+<Warning>
+**Upgrading an existing 1.0.0 or 1.0.1 install?** Version 1.1.0 removed six values keys and moved all auth key material into a prerequisite secret. `helm upgrade` fails at render if you carry the old keys forward. See [Upgrading From 1.0.0 or 1.0.1](#upgrading-from-1-0-0-or-1-0-1) before you start.
+</Warning>
 
 ### Architecture
 
-- **Langfuse Web** — Next.js application serving the UI and public API. Autoscales between 2 and 5 replicas.
-- **Langfuse Worker** — Background processor for trace ingestion, automated evaluations, and third-party integrations.
-- **PostgreSQL** — Stores all configuration data: users, projects, API keys, prompts, datasets, and evaluation configs.
-- **Redis** — BullMQ ingestion queue and short-lived cache for API keys and prompts.
-- **ClickHouse** — Columnar store for all traces, observations, and scores. Powers all dashboard queries. Data files are written directly to object storage.
-- **Object Storage** — AWS S3 or GCS. Shared between ClickHouse (data files) and Langfuse (raw event buffer and media uploads) using separate key prefixes (`clickhouse/`, `events/`, `media/`).
+- **Langfuse Web** — Next.js app serving the UI and public API on port `3000`. Autoscales between 2 and 5 replicas on CPU.
+- **Langfuse Worker** — Background processor for trace ingestion, automated evaluations, and integrations.
+- **PostgreSQL** — The [postgres](/template-catalog/templates/postgres) template as a subchart. Stores users, projects, API keys, prompts, datasets, and evaluation configs.
+- **Redis** — BullMQ ingestion queue and the API key/prompt cache, on a persistent volume set.
+- **ClickHouse** — Columnar store for all traces, observations, and scores; powers the dashboards. Its data parts live in the object store, so the volume set holds local metadata only.
+- **Object Storage** — AWS S3 or Google Cloud Storage. One bucket serves both ClickHouse (`clickhouse/`) and Langfuse (`events/`, `media/`).
 
 ### What Gets Created
 
-- **Standard Langfuse Web Workload** — The Next.js UI and public API with autoscaling enabled.
-- **Standard Langfuse Worker Workload** — Background trace ingestion and evaluation processor.
-- **Stateful PostgreSQL Workload** — Single-replica Postgres with a persistent volume set.
-- **Stateful Redis Workload** — Single-replica Redis for the BullMQ queue and cache.
-- **Stateful ClickHouse Workload** — Single-node ClickHouse with a persistent volume set for local metadata.
-- **Volume Sets** — One persistent volume set each for PostgreSQL and ClickHouse.
-- **Identity & Policy** — An identity bound to all workloads with `reveal` access to all secrets, and cloud storage access for the object store.
-- **Secrets** — Opaque secrets for all component credentials and Langfuse auth keys.
+- **Stateful Langfuse Web Workload** — The UI and public API on port `3000`, autoscaling between `langfuse.web.minReplicas` and `langfuse.web.maxReplicas`.
+- **Stateful Langfuse Worker Workload** — One replica by default, processing the ingestion queue.
+- **Stateful ClickHouse Workload** — Single node on ports `8123` (HTTP) and `9000` (native).
+- **Stateful Redis Workload** — Single node on port `6379`.
+- **PostgreSQL Subchart Resources** — A stateful PostgreSQL workload with its own volume set, identity, policy, and credentials secret.
+- **Volume Sets** — `{release}-langfuse-redis-vs` and `{release}-langfuse-clickhouse-vs`, plus the PostgreSQL subchart's, at 10 GiB each by default.
+- **Secrets** — A dictionary secret holding the bundled datastore credentials, and two secrets holding the ClickHouse startup and storage configuration. The auth secret and the GCS credentials secret are **prerequisite secrets you create yourself**; the chart references them by name and never creates, modifies, or deletes them.
+- **Identity & Policy** — An identity for the Langfuse workloads and a policy granting it `reveal` on exactly those secrets. On the AWS path the identity is also linked to your cloud account with your bucket-scoped IAM policy.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -34,18 +40,53 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-Object storage must be configured before deploying. Both ClickHouse and Langfuse use the same bucket with separate key prefixes — create the bucket and credentials as described below, then fill in the `objectStore` section of `values.yaml`.
+Two things must be in place before you install: the auth secret, and the object storage the traces are written to.
 
-### AWS S3
+### Auth Secret
+
+**A [dictionary secret](/guides/create-secret/dictionary) holding five keys must exist before you install.** It carries the key material that signs sessions and encrypts stored provider credentials, plus the login for the account the template provisions — none of which should ever sit in `values.yaml`, where it would land in the Helm release for the life of the install.
+
+Create it with your own values, then set `langfuse.auth.secretName` to the name you used:
+
+```bash
+cpln secret create-dictionary --name my-langfuse-auth \
+  --entry nextAuthSecret="$(openssl rand -base64 32)" \
+  --entry encryptionKey="$(openssl rand -hex 32)" \
+  --entry salt="$(openssl rand -base64 32)" \
+  --entry adminEmail="you@example.com" \
+  --entry adminPassword="$(openssl rand -base64 18)"
+```
+
+Every one of the five keys is required, and the names are exact:
+
+| Key | What it does |
+|---|---|
+| `nextAuthSecret` | Signs session tokens. Anyone holding it can forge a signed-in session. |
+| `encryptionKey` | Encrypts the LLM provider API keys your users store in Langfuse — their OpenAI, Anthropic, and other credentials. Must be exactly 64 hex characters. **It cannot be rotated**: changing it makes every stored provider key unreadable. |
+| `salt` | Hashes Langfuse's own API keys. |
+| `adminEmail` | The owner account provisioned at boot — this is how you first sign in. |
+| `adminPassword` | Its password, 8 characters minimum. Record it; it is shown nowhere. |
+
+Use three different random values for `nextAuthSecret`, `encryptionKey`, and `salt`, and keep a copy of `encryptionKey` somewhere safe outside Control Plane.
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, but the web and worker workloads never start — they report `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` Create the secret first, and after installing confirm with `cpln workload get-deployments {release}-langfuse-web --gvc {gvc}` rather than trusting the Helm output.
+</Warning>
+
+### Object Storage
+
+Both ClickHouse and Langfuse use one bucket with separate key prefixes. Pick one provider and complete its setup before installing.
+
+#### AWS S3
 
 <Steps>
   <Step title="Create a bucket">
     Create an S3 bucket. Set `objectStore.aws.bucket` to its name and `objectStore.aws.region` to its region.
   </Step>
   <Step title="Set up a Cloud Account">
-    If you do not have one, [create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account). Set `objectStore.aws.cloudAccountName` to its name.
+    If you do not have one, [create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) for your AWS account. Set `objectStore.aws.cloudAccountName` to its name — the workloads then reach the bucket keylessly, with no stored credentials.
   </Step>
-  <Step title="Create an IAM policy">
+  <Step title="Create a bucket-scoped IAM policy">
     Create an IAM policy with the following JSON (replace `YOUR_BUCKET_NAME`) and set `objectStore.aws.policyName` to its name:
 
     ```json
@@ -73,20 +114,18 @@ Object storage must be configured before deploying. Both ClickHouse and Langfuse
   </Step>
 </Steps>
 
-### GCS
+#### Google Cloud Storage
 
 <Note>
-GCS uses S3-compatible HMAC authentication for this template. A Control Plane Cloud Account is not required.
+Langfuse and ClickHouse reach GCS over its S3-compatible endpoint, so this path uses an HMAC key pair rather than a Control Plane Cloud Account.
 </Note>
 
 <Steps>
   <Step title="Create a bucket">
     Create a GCS bucket. Set `objectStore.gcp.bucket` to its name.
   </Step>
-  <Step title="Create a service account and HMAC key">
-    In the GCP console, go to **Settings → Interoperability** and click **Create a key for a service account → Create new account**. Name the service account, assign the `Storage Object Admin` role, and click **Done**. Copy the provided HMAC access key and secret into `objectStore.gcp.accessKeyId` and `objectStore.gcp.secretAccessKey`.
-
-    Or use the CLI:
+  <Step title="Create a service account and an HMAC key">
+    Grant the service account `roles/storage.objectAdmin` on the bucket, then create an HMAC key for it:
 
     ```bash
     gcloud config set project YOUR_PROJECT_ID
@@ -99,14 +138,23 @@ GCS uses S3-compatible HMAC authentication for this template. A Control Plane Cl
       --member="serviceAccount:langfuse-storage@$(gcloud config get-value project).iam.gserviceaccount.com" \
       --role="roles/storage.objectAdmin"
 
-    gsutil hmac create langfuse-storage@$(gcloud config get-value project).iam.gserviceaccount.com
+    gcloud storage hmac create langfuse-storage@$(gcloud config get-value project).iam.gserviceaccount.com
+    ```
+
+    In the console the same key lives under **Cloud Storage → Settings → Interoperability → Create a key for a service account**.
+  </Step>
+  <Step title="Put the pair in a dictionary secret">
+    The HMAC pair never passes through Helm values. Create a second [dictionary secret](/guides/create-secret/dictionary) and set `objectStore.gcp.credentialsSecretName` to its name:
+
+    ```bash
+    cpln secret create-dictionary --name my-langfuse-gcs-credentials \
+      --entry accessKeyId="YOUR_HMAC_ACCESS_ID" \
+      --entry secretAccessKey="YOUR_HMAC_SECRET"
     ```
   </Step>
 </Steps>
 
-### Installation
-
-Once object storage is ready, install using your preferred method:
+Once the auth secret and object storage are ready, install using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -135,25 +183,36 @@ Once object storage is ready, install using your preferred method:
 The default `values.yaml` for this template:
 
 ```yaml
-# Object store - used by both ClickHouse (data files) and Langfuse (raw event buffer + media)
-# Both services share the same bucket using separate key prefixes
+# ─── Object store ─────────────────────────────────────────────────────────────
+# One bucket serves BOTH ClickHouse (data parts, prefix `clickhouse/`) and
+# Langfuse (raw event buffer `events/`, media uploads `media/`).
 objectStore:
   provider: aws # Options: aws, gcp
   aws:
     bucket: my-langfuse-bucket
     region: us-east-1
-    cloudAccountName: my-cloudaccount
-    policyName: my-custom-policy
+    cloudAccountName: my-langfuse-cloudaccount # Control Plane Cloud Account — keyless S3 access
+    policyName: my-langfuse-policy # pre-created AWS IAM policy scoped to the bucket above
   gcp:
     bucket: my-langfuse-bucket
-    accessKeyId: my-gcs-key        # GCS HMAC key ID
-    secretAccessKey: my-gcs-secret # GCS HMAC secret key
+    # REQUIRED PREREQUISITE SECRET when provider is `gcp` — CREATE IT BEFORE YOU
+    # INSTALL, or the deployment wedges waiting on a secret that does not exist.
+    # A `dictionary` secret with exactly two keys: `accessKeyId`, `secretAccessKey`
+    # (a GCS HMAC pair). See README Prerequisites for the exact command.
+    credentialsSecretName: my-langfuse-gcs-credentials
 
-# Langfuse application
+# ─── Langfuse application ─────────────────────────────────────────────────────
 langfuse:
+  # Public base URL — feeds auth redirects and the sign-out/error pages NextAuth
+  # renders server-side, and decides whether the session cookie gets the Secure
+  # flag. Empty = derived from the platform canonical endpoint when publicAccess
+  # is on. Set it only for a custom domain, and include the scheme:
+  #   publicUrl: https://langfuse.example.com
+  publicUrl: ""
+
   web:
-    image: langfuse/langfuse:3
-    minReplicas: 2  # Keep at 2+ for zero-downtime rolling deploys
+    image: langfuse/langfuse:3.225.2
+    minReplicas: 2 # Keep at 2+ for zero-downtime rolling deploys
     maxReplicas: 5
     resources:
       minCpu: 500m
@@ -162,7 +221,7 @@ langfuse:
       maxMemory: 2Gi
 
   worker:
-    image: langfuse/langfuse-worker:3
+    image: langfuse/langfuse-worker:3.225.2
     replicas: 1
     resources:
       minCpu: 250m
@@ -171,15 +230,40 @@ langfuse:
       maxMemory: 1Gi
 
   auth:
-    nextAuthSecret: ""    # Required: openssl rand -base64 32
-    encryptionKey: ""     # Required: openssl rand -hex 32 (must be exactly 64 hex characters)
-    salt: ""              # Required: openssl rand -base64 32
+    # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. If it does not
+    # exist the deployment WEDGES waiting on it and looks like a platform fault.
+    # A `dictionary` secret holding exactly five keys:
+    #   nextAuthSecret  — signs session tokens (openssl rand -base64 32)
+    #   encryptionKey   — encrypts the LLM provider API keys your users store in
+    #                     Langfuse; CANNOT be rotated without losing every one of
+    #                     them (openssl rand -hex 32, exactly 64 hex characters)
+    #   salt            — hashes Langfuse's own API keys (openssl rand -base64 32)
+    #   adminEmail      — first-run owner account, provisioned at boot
+    #   adminPassword   — its password (8 characters minimum)
+    # Use three DIFFERENT random values for the three key material entries.
+    # See README Prerequisites for the exact command.
+    secretName: my-langfuse-auth
 
-  firewall:
-    inboundAllowCIDR:
-      - 0.0.0.0/0  # Restrict to specific IPs in production
+    # Langfuse ships with email/password registration OPEN, so a public instance
+    # would let any stranger create an account AND their own organization. Closed
+    # here: the admin above is provisioned headlessly at boot, which bypasses the
+    # block. Set to false only if you want self-service registration.
+    disableSignup: true
+    organizationName: Langfuse # organization created for the first-run admin
 
-# PostgreSQL - stores users, projects, API keys, prompts, datasets, eval configs
+# ─── Access ───────────────────────────────────────────────────────────────────
+# Applies to the Langfuse web UI and public API. A firewall change takes up to
+# a couple of minutes to propagate.
+publicAccess:
+  enabled: true # false keeps the UI reachable only from inside the GVC
+internalAccess:
+  type: same-gvc # options: none, same-gvc, same-org, workload-list
+  workloads: [] # used with workload-list, e.g. //gvc/GVC_NAME/workload/WORKLOAD_NAME
+
+# ─── PostgreSQL ───────────────────────────────────────────────────────────────
+# Stores users, projects, API keys, prompts, datasets and eval configs.
+# Bundled plumbing: it serves Langfuse only and is unreachable from outside the
+# GVC — but the password is used AS-IS, so change it before installing.
 postgres:
   image: postgres:18
   resources:
@@ -189,12 +273,14 @@ postgres:
     maxMemory: 1Gi
   config:
     username: langfuse
-    password: mypassword
+    password: change-me-langfuse-db
     database: langfuse
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 
-# Redis - BullMQ ingestion queue and API key/prompt cache
+# ─── Redis ────────────────────────────────────────────────────────────────────
+# BullMQ ingestion queue and API key/prompt cache. Bundled plumbing — change the
+# password before installing.
 redis:
   image: redis:7.4
   resources:
@@ -203,10 +289,14 @@ redis:
     minMemory: 256Mi
     maxMemory: 512Mi
   auth:
-    password: mypassword
+    password: change-me-langfuse-redis
+  volumeset:
+    capacity: 10 # initial capacity in GiB (minimum is 10)
 
-# ClickHouse - stores all traces, observations, and scores; powers dashboards
-# Data files are stored in the object store above; volumeset holds local metadata only
+# ─── ClickHouse ───────────────────────────────────────────────────────────────
+# Stores all traces, observations and scores; powers the dashboards. Data parts
+# live in the object store above; the volumeset holds local metadata only.
+# Bundled plumbing — change the password before installing.
 clickhouse:
   image: clickhouse/clickhouse-server:25.10
   resources:
@@ -215,46 +305,63 @@ clickhouse:
     minMemory: 2Gi
     maxMemory: 4Gi
   config:
-    password: mypassword
+    password: change-me-langfuse-clickhouse
     database: langfuse
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 ```
 
-### Required Auth Secrets
+### Auth and the Admin Account
 
-Three auth values must be generated and set in `values.yaml` before deploying:
+All five auth keys are read from the dictionary secret named by `langfuse.auth.secretName` (see [Auth Secret](#auth-secret)). The web workload reads all five; the worker reads only `nextAuthSecret`, `encryptionKey`, and `salt`.
 
-```bash
-# nextAuthSecret and salt — any base64 string
-openssl rand -base64 32
+**`langfuse.auth.disableSignup` defaults to `true`, and the admin account is the only way in.** Langfuse OSS has no first-user exemption — its `AUTH_DISABLE_SIGNUP` flag is enforced in both the signup handler and the NextAuth adapter, so closing registration on its own would leave an instance nobody could enter. The template therefore provisions the owner headlessly at boot from `adminEmail` and `adminPassword`, using Langfuse's [headless initialization](https://langfuse.com/self-hosting/administration/headless-initialization). The bootstrap runs on every boot and leaves existing rows alone.
 
-# encryptionKey — must be exactly 64 hex characters (32 bytes)
-openssl rand -hex 32
-```
+With the defaults in place:
+
+- Signing in with `adminEmail` / `adminPassword` yields a session whose role is `OWNER`, and that account can create projects immediately.
+- Anyone else hitting `/api/auth/signup` is refused with `HTTP 422` and `{"message":"Sign up is disabled."}`, and the sign-up page reports registration as disabled.
+
+`langfuse.auth.organizationName` names the organization created for that owner. It is required and defaults to `Langfuse`.
+
+Set `langfuse.auth.disableSignup: false` if you want self-service registration instead — anyone who can reach the UI can then create their own account **and their own organization**.
 
 <Warning>
-`encryptionKey` encrypts LLM API keys and other sensitive project data stored in PostgreSQL. It must be generated with `openssl rand -hex 32` — a base64 value will fail validation on startup. Run each command separately and copy the output into the corresponding field.
+**Closing signup does not take effect the moment the upgrade returns.** The flag is a container environment variable, so it applies only once the web tier has finished rolling — about **93 seconds** in a measured run. Registrations kept succeeding for the whole of that window after `helm upgrade` reported success. Re-test after a couple of minutes before concluding the knob did not work.
 </Warning>
 
-### Passwords
+### Public URL and Session Cookies
 
-Change all component passwords before deploying to production:
+`langfuse.publicUrl` sets the origin the browser uses. Leave it empty and the template derives it: with `publicAccess.enabled: true` the web workload uses its own canonical `https://*.cpln.app` endpoint, and with public access off it falls back to the internal `cpln.local` address. Set it only for a custom domain, and **include the scheme** — a scheme-less value is rejected at render.
 
-- `postgres.config.password` — PostgreSQL admin password
-- `redis.auth.password` — Redis password
-- `clickhouse.config.password` — ClickHouse password
+This value does more than build redirect links:
 
-### Firewall
+- **The session cookie's `Secure` flag is derived from it.** NextAuth turns on `useSecureCookies` and the `__Secure-` cookie prefix only when the URL starts with `https:`. On a public instance the derived HTTPS endpoint gives you `__Secure-next-auth.session-token` with `secure=true`. On a private instance the origin genuinely is plain HTTP, so the flag is correctly left off — a `Secure` cookie there would simply be dropped.
+- **NextAuth's own server-rendered pages build their form actions from it.** The sign-out confirmation page at `/api/auth/signout` is one of them; a URL the browser cannot reach leaves that page's button dead-ending on a browser error interstitial.
 
-The Langfuse web UI and API are publicly accessible by default (`0.0.0.0/0`). To restrict access to specific IP ranges, update `langfuse.firewall.inboundAllowCIDR`:
+The interactive sign-in page is unaffected either way — it is a client-side React form that routes on its own `targetPath` parameter rather than following a redirect header.
 
-```yaml
-langfuse:
-  firewall:
-    inboundAllowCIDR:
-      - 203.0.113.0/24  # restrict to your office or application IPs
-```
+<Note>
+If you serve Langfuse on a custom domain, set `langfuse.publicUrl` to that domain. The derived value is the platform-assigned canonical endpoint, which is not your domain.
+</Note>
+
+### Access
+
+- `publicAccess.enabled` — Serve the UI and public API on the canonical `*.cpln.app` HTTPS endpoint (default `true`). Everything behind it is gated by Langfuse's own login. Set to `false` and external requests are refused at the edge with `403`, while in-GVC callers still reach it per `internalAccess`.
+- `internalAccess.type` — Internal firewall scope of the web workload:
+
+| Type | Description |
+|------|-------------|
+| `none` | No internal access. |
+| `same-gvc` | Allow access from all workloads in the same GVC (default). |
+| `same-org` | Allow access from all workloads in the same organization. |
+| `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads`. |
+
+Firewall changes take up to a couple of minutes to propagate — measured transitions landed between 51 and 105 seconds. The old behavior keeps serving for the first minute or so after the upgrade returns, so re-poll instead of trusting the first response.
+
+<Warning>
+**With `publicAccess.enabled: false` there is currently no browser path to the UI.** `cpln port-forward` cannot reach the Langfuse web workload — it returns `{"code":502,"message":"Unable to connect to upstream workload"}` — because Next.js standalone binds the address in `HOSTNAME`, and Control Plane sets that to the replica name, so the app never listens on loopback. Service-mesh traffic is unaffected: other workloads in the GVC reach it normally, and its API is fully usable from inside the GVC. Only an operator's own browser has no route in.
+</Warning>
 
 ### Object Store
 
@@ -262,55 +369,143 @@ Both ClickHouse and Langfuse share one bucket with separate key prefixes:
 
 | Prefix | Used by |
 |--------|---------|
-| `clickhouse/` | ClickHouse data files (tables, parts, metadata) |
+| `clickhouse/` | ClickHouse data parts, tables, and metadata |
 | `events/` | Langfuse raw event ingestion buffer |
 | `media/` | Langfuse media uploads (screenshots, attachments) |
 
-Set `objectStore.provider` to `aws` or `gcp` and fill in the corresponding block. Leave the unused provider block empty.
+Set `objectStore.provider` to `aws` or `gcp` and fill in the matching block; the other block is ignored, and nothing from it is rendered into the workloads. On the GCS path the HMAC pair is read from your credentials secret at runtime — the ClickHouse storage configuration references it by environment variable, so the key never appears in a rendered file.
+
+### Datastores
+
+The three datastore passwords are internal plumbing: PostgreSQL, Redis, and ClickHouse serve Langfuse only and are unreachable from outside the GVC. They are still used exactly as written, so **change all three before installing** — they ship as obvious `change-me-` placeholders:
+
+- `postgres.config.password`
+- `redis.auth.password`
+- `clickhouse.config.password`
+
+Each datastore's `volumeset.capacity` is its initial size in GiB, with 10 the minimum.
 
 ## Accessing Langfuse
 
-Once deployed, the Langfuse UI is accessible via the Control Plane external endpoint for the `{release-name}-langfuse-web` workload. Navigate to the endpoint in your browser to create an account and log in.
+| What | Where |
+|---|---|
+| Web UI and public API | The canonical endpoint of the `{release}-langfuse-web` workload (`status.canonicalEndpoint`), when `publicAccess.enabled` is `true` |
+| Internal HTTP | `http://{release}-langfuse-web.{gvc}.cpln.local:3000` |
+| Health | `/api/public/health` on either address — returns `{"status":"OK","version":"..."}` |
+| First login | `adminEmail` / `adminPassword` from your auth secret |
+| Langfuse API keys | Created in the UI under **Settings → API Keys**, per project |
+| PostgreSQL, Redis, ClickHouse | Internal only; credentials are the values you set in `postgres.config`, `redis.auth`, and `clickhouse.config` |
 
-### Sending Traces via API
+A fresh install takes roughly two minutes to become usable: the datastores converge in about 45 seconds and the web tier follows.
 
-After creating a project and generating API keys (**Settings → API Keys**), send traces using the public API:
+### Sending Traces
+
+Create a project in the UI, generate a key pair under **Settings → API Keys**, then post to the public API:
 
 ```bash
-curl -X POST https://YOUR_LANGFUSE_ENDPOINT/api/public/traces \
+curl -X POST https://YOUR_LANGFUSE_ENDPOINT/api/public/ingestion \
   -H "Content-Type: application/json" \
   -u "YOUR_PUBLIC_KEY:YOUR_SECRET_KEY" \
   -d '{
-    "name": "my-first-trace",
-    "input": "Hello",
-    "output": "Hello back"
+    "batch": [{
+      "id": "event-1",
+      "type": "trace-create",
+      "timestamp": "2026-01-01T00:00:00.000Z",
+      "body": {
+        "id": "my-first-trace",
+        "name": "my-first-trace",
+        "input": "Hello",
+        "output": "Hello back"
+      }
+    }]
   }'
 ```
 
-Or integrate using the [Langfuse SDK](https://langfuse.com/docs/sdk) for Python, TypeScript, and other languages.
+Ingestion is asynchronous: the web app writes the raw event to the `events/` prefix in your bucket, the worker picks it up off the Redis queue and writes it into ClickHouse, and the trace becomes queryable at `GET /api/public/traces/{id}` a few seconds later. For application instrumentation, use a [Langfuse SDK](https://langfuse.com/docs/sdk/overview) instead of the raw API.
 
-### LLM Connections (Playground and Evaluations)
+### LLM Connections
 
-The Langfuse playground and LLM-as-a-Judge evaluations require LLM API keys configured through the UI. These keys are stored encrypted in PostgreSQL using your `encryptionKey`.
+The playground and LLM-as-a-Judge evaluations need provider API keys, added in the UI under **Settings → LLM Connections**. Those keys are stored in PostgreSQL encrypted with your `encryptionKey` — which is why that key can never be rotated, and why it belongs in a secret rather than in your Helm release.
 
-To configure:
+## Upgrades
 
-1. In the Langfuse UI, go to **Settings → LLM API Keys** (for the playground) or **Evaluation → Set up default model** (for automated evals).
-2. Click **Add LLM Connection**, choose your provider (OpenAI, Anthropic, etc.), and enter your API key.
+### Upgrading From 1.0.0 or 1.0.1
+
+<Warning>
+**Version 1.1.0 removed six values keys, and a values file that still carries any of them fails at render.** The upgrade is aborted before anything is applied, so a live release is untouched and no failed revision is created — but the upgrade does not proceed until you have created the prerequisite secrets and removed the old keys. There are deliberately no compatibility fallbacks.
+</Warning>
+
+| Removed in 1.1.0 | Replacement |
+|---|---|
+| `langfuse.auth.nextAuthSecret` | `nextAuthSecret` key in the secret named by `langfuse.auth.secretName` |
+| `langfuse.auth.encryptionKey` | `encryptionKey` key in the same secret |
+| `langfuse.auth.salt` | `salt` key in the same secret |
+| `objectStore.gcp.accessKeyId` | `accessKeyId` key in the secret named by `objectStore.gcp.credentialsSecretName` |
+| `objectStore.gcp.secretAccessKey` | `secretAccessKey` key in the same secret |
+| `langfuse.firewall.inboundAllowCIDR` | `publicAccess.enabled` and `internalAccess.type` |
+
+Each one fails with a message naming its own replacement, for example:
+
+```text
+langfuse.auth.nextAuthSecret was removed in 1.1.0. Put it in the prerequisite dictionary secret
+named by langfuse.auth.secretName (key: nextAuthSecret) — see the README.
+```
+
+<Steps>
+  <Step title="Back up PostgreSQL">
+    It holds your users, projects, API keys, prompts, and datasets. Take a volume set snapshot before you change anything.
+  </Step>
+  <Step title="Create the prerequisite secrets">
+    Create the auth secret with all five keys (see [Auth Secret](#auth-secret)), and on the GCS path the credentials secret as well. `adminEmail` and `adminPassword` have no 1.0.x equivalent — they are new, and they provision the owner account.
+  </Step>
+  <Step title="Remove the six keys and name the secrets">
+    Delete every removed key from your values file, then set `langfuse.auth.secretName` and, on GCS, `objectStore.gcp.credentialsSecretName`. Replace `langfuse.firewall.inboundAllowCIDR` with `publicAccess.enabled` and `internalAccess.type`.
+  </Step>
+  <Step title="Upgrade">
+    Run the upgrade, then confirm both `{release}-langfuse-web` and `{release}-langfuse-worker` reach `ready` with `cpln workload get-deployments`.
+  </Step>
+</Steps>
+
+<Warning>
+**Treat the 1.0.x auth defaults as compromised.** Versions 1.0.0 and 1.0.1 shipped working values for `nextAuthSecret`, `encryptionKey`, and `salt` as defaults in a public repository, so any install that did not override them shared one publicly known set. Generate fresh values for all three. Note the trade-off on `encryptionKey`: carrying the old one forward keeps existing LLM connections readable but leaves them encrypted under a published key, while a new one makes them undecryptable and they must be re-added under **Settings → LLM Connections**.
+</Warning>
+
+### The First Upgrade Interrupts Trace Ingestion
+
+<Warning>
+**The first `helm upgrade` after an install re-applies and restarts Redis — even when nothing in your values changed — and trace ingestion fails for up to about 94 seconds while `/api/public/health` keeps returning `200` the whole time.** Uptime monitors and health checks see nothing. Ingestion stayed broken for roughly 48 seconds after Redis itself was ready again, which is the web tier's reconnect backoff. Later upgrades caused no disruption at all.
+</Warning>
+
+Plan the first upgrade as a short ingestion outage, and check that traces are landing again afterwards rather than relying on the health endpoint.
+
+### Changes That Wait for the Web Tier
+
+Anything carried in the web container's environment — `langfuse.auth.disableSignup`, `langfuse.publicUrl`, values from the auth secret — only takes effect as replicas roll. Measured windows on a two-replica tier: about 93 seconds to close signup, about 152 seconds to open it, and 120 to 141 seconds for a `publicUrl` change to reach both replicas. During a rollout the old replicas still serve the old behavior.
 
 ## Backups
 
 <CardGroup cols={1}>
   <Card title="PostgreSQL" icon="database">
-    Stores all critical config: users, projects, API keys, prompts, datasets, and eval configs. **Most important to back up.** Enable snapshot policies on the PostgreSQL volume set via the Control Plane console — snapshots capture the full disk state and restore quickly.
+    Holds all configuration: users, projects, API keys, prompts, datasets, and evaluation configs. **Most important to back up.** Enable snapshot policies on the PostgreSQL volume set — snapshots capture the full disk state and restore quickly.
   </Card>
   <Card title="ClickHouse" icon="table-columns">
-    Data files are stored directly in your object store (S3 or GCS) and are inherently durable — the volume set only holds local metadata. A full restore is performed by redeploying and pointing ClickHouse at the existing bucket.
+    Trace data parts live in your own S3 or GCS bucket and are as durable as that bucket; the volume set holds local metadata only. Back up the bucket according to your provider's practice.
   </Card>
   <Card title="Redis" icon="bolt">
-    Holds only the transient BullMQ ingestion queue and short-lived cache. Backup is not required.
+    Holds only the transient BullMQ ingestion queue and short-lived cache. No backup required.
   </Card>
 </CardGroup>
+
+## Important Notes
+
+- **Create the auth secret before installing.** A missing one does not fail the install — Helm reports success and the web and worker workloads then sit waiting on a secret that does not exist.
+- **`encryptionKey` cannot be rotated.** It encrypts every provider key stored under **Settings → LLM Connections**; changing it makes all of them unreadable. Keep a copy outside Control Plane, and never delete the secret.
+- **Self-service signup is closed by default and the owner account comes from your secret.** Record `adminPassword` — it is displayed nowhere, and with signup closed there is no other way to create an account.
+- **Change the three datastore passwords before installing.** They ship as `change-me-` placeholders and are used exactly as written.
+- **Prerequisite secrets are not owned by the release.** The auth and GCS credentials secrets survive `helm uninstall` and must be deleted by hand if you no longer want them.
+- **Web and worker log database connection errors for the first ~40 seconds of a cold install** (`Can't reach database server`, `Applying database migrations failed`) while PostgreSQL is still starting. The retry succeeds and migrations then apply; this is startup ordering, not a fault.
+- **Access-knob changes take up to a couple of minutes** to propagate, and rollout-driven changes such as `disableSignup` take a minute or two more. Re-test before concluding a knob did not work.
+- **Uninstall deletes the volume sets**, including PostgreSQL's. Trace data already in your bucket is untouched, but users, projects, and API keys are not.
 
 ## External References
 
@@ -318,13 +513,19 @@ To configure:
   <Card title="Langfuse Documentation" href="https://langfuse.com/docs" icon="book">
     Full Langfuse product documentation
   </Card>
-  <Card title="Langfuse SDK Reference" href="https://langfuse.com/docs/sdk" icon="code">
+  <Card title="Langfuse SDKs" href="https://langfuse.com/docs/sdk/overview" icon="code">
     Python, TypeScript, and other language SDK guides
   </Card>
-  <Card title="Langfuse Self-Hosting Guide" href="https://langfuse.com/docs/deployment/self-host" icon="server">
-    Self-hosting architecture and configuration reference
+  <Card title="Self-Hosting Guide" href="https://langfuse.com/self-hosting" icon="server">
+    Self-hosting architecture and operations
+  </Card>
+  <Card title="Configuration Reference" href="https://langfuse.com/self-hosting/configuration" icon="gear">
+    Every Langfuse environment variable and what it controls
+  </Card>
+  <Card title="Headless Initialization" href="https://langfuse.com/self-hosting/administration/headless-initialization" icon="user-shield">
+    How the bootstrapped owner account is provisioned
   </Card>
   <Card title="Create a Cloud Account" href="https://docs.controlplane.com/guides/create-cloud-account" icon="cloud">
-    Set up a Control Plane Cloud Account for S3 access
+    Set up a Control Plane Cloud Account for keyless S3 access
   </Card>
 </CardGroup>

--- a/template-catalog/templates/manticore.mdx
+++ b/template-catalog/templates/manticore.mdx
@@ -6,6 +6,10 @@ keywords: ['full text search', 'sphinx fork', 'elasticsearch alternative', 'meil
 
 ## Overview
 
+<Warning>
+**Upgrading from 2.0.1 or earlier?** Two values keys were removed and one default changed — see [Upgrading From 2.0.1 or Earlier](#upgrading-from-2-0-1-or-earlier). Anyone on an earlier version should also treat their agent token as compromised: it shipped as a working default in this repository and was shared by every install that did not override it.
+</Warning>
+
 Manticore Search is a high-performance, open-source search engine built for fast full-text search at scale. This template deploys a distributed Manticore Search cluster using Galera replication for high availability, with an orchestrator API for cluster management, a web UI for monitoring and operations, and support for zero-downtime data imports from AWS S3.
 
 ### What Gets Created
@@ -125,11 +129,11 @@ The default `values.yaml` for this template:
 # AWS Cloud Account and S3 Configuration
 # =============================================================================
 buckets:
-  cloudAccountName: my-cloud-account    # Name of your configured Cloud Account
+  cloudAccountName: my-manticore-cloudaccount    # Name of your configured Cloud Account
   awsPolicyRefs:                        # IAM policies for S3 access
     - aws::AmazonS3ReadOnlyAccess       # Note: if using a custom policy, omit the aws:: prefix
   awsRegion: us-east-1                  # Region of your S3 bucket
-  sourceBucket: my-bucket               # S3 bucket containing files to import
+  sourceBucket: my-manticore-bucket               # S3 bucket containing files to import
 
 # =============================================================================
 # Tables Configuration
@@ -194,7 +198,6 @@ manticore:
 
   rolloutOptions:
     maxSurgeReplicas: 25%
-    maxUnavailableReplicas: '0'
     minReadySeconds: 10
     scalingPolicy: OrderedReady
     terminationGracePeriodSeconds: 60
@@ -286,8 +289,8 @@ orchestrator:
     enabled: false
     version: v6.0.5
     image: ghcr.io/controlplane-com/manticore-orchestrator/manticore-cpln-backup
-    cloudAccountName: my-backup-cloud-account
-    s3Bucket: my-backup-bucket
+    cloudAccountName: my-manticore-backup-cloudaccount
+    s3Bucket: my-manticore-backup-bucket
     s3Policy:
       - my-backup-policy
     s3Region: us-east-1
@@ -449,6 +452,49 @@ When enabled, the domain routes `/api/*` to the orchestrator API and all other t
 - `loadTest.target.endpoint` — Search endpoint to target: `search` (JSON body) or `sql`.
 - `loadTest.thresholds.p95ResponseTime` — P95 response time threshold in milliseconds.
 - `loadTest.thresholds.errorRate` — Maximum acceptable error rate (e.g., `0.01` = 1%).
+
+## Upgrading From 2.0.1 or Earlier
+
+2.0.1 and earlier shipped a **live working bearer token** as a values default, published in this repository, so every install that did not override it shared one publicly-known credential. The management UI was also public by default while having no login of its own, and the chart's secret policy granted `reveal` on **every secret in the organization** rather than the four it needed. Treat the token on any earlier install as compromised: rotate it rather than simply upgrading.
+
+| 2.0.1 and earlier | 2.1.0 |
+|---|---|
+| `orchestrator.agent.token` (a working value) | `orchestrator.agent.tokenSecretName` → prerequisite opaque secret |
+| `orchestrator.ui.allowExternalAccess: true` | `orchestrator.ui.publicAccess.enabled: false` |
+| UI internal scope hardcoded | `orchestrator.ui.internalAccess.type` (`same-gvc`) |
+| Policy granted `reveal` org-wide | Scoped to exactly four secrets |
+| Scheduled backup failed on every run | Backup works; restore via API/UI |
+| Source-bucket IAM asked for write | Read-only is sufficient |
+
+Both removed keys stop the render with a message naming their replacement, so an upgrade cannot silently fall back to a default:
+
+```text
+orchestrator.agent.token was REMOVED in manticore 2.1.0. The bearer token is now a
+prerequisite opaque secret you create before install; set
+orchestrator.agent.tokenSecretName to its name.
+```
+
+<Steps>
+  <Step title="Create the agent-token secret">
+    Generate a fresh token — do not carry the old one forward — and create the secret as shown in [Prerequisites](#prerequisites).
+  </Step>
+  <Step title="Replace the removed keys">
+    Delete `orchestrator.agent.token` and `orchestrator.ui.allowExternalAccess` from your values, then set `orchestrator.agent.tokenSecretName`. If you were relying on external UI access, decide deliberately whether to set `orchestrator.ui.publicAccess.enabled: true` — it publishes cluster admin.
+  </Step>
+  <Step title="Narrow the source-bucket policy">
+    If you granted `s3:PutObject` or `s3:DeleteObject` on your source data bucket, you can reduce it to read-only.
+  </Step>
+  <Step title="Expect a long rollout">
+    A `helm upgrade` restarts the cluster serially and takes around nine minutes even when nothing has changed. Data survives it.
+  </Step>
+</Steps>
+
+## Operational Notes
+
+- **A no-op `helm upgrade` takes roughly 542 seconds.** The stateful tier restarts serially, so an upgrade that changes nothing still takes about nine minutes. This is expected, not a hang.
+- **Verify per-replica row counts after a restore.** A restore followed by a rolling restart has been observed to land on some replicas and not others **while every node reported `synced`** — so cluster status alone is not sufficient confirmation. Check counts on each replica.
+- **Multi-segment imports and `clusterMain: true` are unverified at the shipped resource sizes.** Testing at reduced CPU and memory saw Galera replication timeouts, but that is not a finding about the feature itself; it has not been exercised at the default 4 CPU / 8 Gi. Treat these as untested rather than known-good or known-broken.
+- **k6 load-test thresholds now appear in `cpln logs`.** Earlier versions exited before the summary was emitted, so results were unreadable.
 
 ## External References
 

--- a/template-catalog/templates/manticore.mdx
+++ b/template-catalog/templates/manticore.mdx
@@ -36,19 +36,28 @@ This template requires an AWS S3 bucket for CSV source data and a Control Plane 
 
 2. If you do not have a Control Plane Cloud Account set up, follow the [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) guide. Set `buckets.cloudAccountName` to the name of your Cloud Account.
 
-3. Set `buckets.awsPolicyRefs` to the IAM policies granting S3 access. For read-only source access, use the AWS managed policy `aws::AmazonS3ReadOnlyAccess`. For custom policies, omit the `aws::` prefix.
+3. Set `buckets.awsPolicyRefs` to the IAM policies granting S3 access. **Read-only is sufficient** — use the AWS managed policy `aws::AmazonS3ReadOnlyAccess`, or a custom policy with `s3:GetObject` and `s3:ListBucket` on the bucket (omit the `aws::` prefix for custom policies).
+
+<Note>
+Versions before 2.1.0 documented `s3:PutObject` and `s3:DeleteObject` on this bucket. That was never required: imports read from S3 and write only to the shared volume. If you granted write access on your source data bucket, you can narrow it to read-only. Backups use a **separate** bucket, which does need write access.
+</Note>
 
 ### Agent Token
 
-Generate a secure bearer token for internal cluster communication and set it in `orchestrator.agent.token`:
+The orchestrator, the agent sidecars and the UI authenticate to each other with a single bearer token. It is a **prerequisite opaque secret that must exist before you install** — the deployment otherwise hangs waiting on a secret that is not there, which looks like a platform fault rather than a missing step.
 
 ```bash
-openssl rand -base64 32
+printf '%s' "$(openssl rand -base64 32)" | \
+  cpln secret create-opaque --name my-manticore-agent-token --encoding plain -f -
 ```
 
-<Note>
-Anyone with network access to the UI can perform admin operations. Restrict external access using `orchestrator.ui.allowExternalAccess: false` or configure the domain firewall to limit access.
-</Note>
+Set `orchestrator.agent.tokenSecretName` to that name.
+
+<Warning>
+**The management UI has no authentication of its own.** It holds the bearer token server-side and injects it on behalf of whoever connects, so the token protects the orchestrator API but not the UI itself. Anyone who can reach the UI has full cluster admin — imports, repairs and cluster operations.
+
+This is why `orchestrator.ui.publicAccess.enabled` defaults to `false`. Turning it on publishes cluster admin to the internet. If you need browser access from outside the GVC, put your own authenticating proxy in front of it.
+</Warning>
 
 ### AWS S3 (Backup, Optional)
 

--- a/template-catalog/templates/manticore.mdx
+++ b/template-catalog/templates/manticore.mdx
@@ -245,8 +245,10 @@ orchestrator:
   agent:
     version: v6.0.5
     image: ghcr.io/controlplane-com/manticore-orchestrator/manticore-cpln-agent
-    # REQUIRED: Generate with `openssl rand -base64 32`
-    token: "6Gl5uO9KkKAh1u+ymoBW98WCtjTFpljuhpLdKb+tNAA="
+    # REQUIRED prerequisite: name of an opaque secret holding the bearer token.
+    # THE SECRET MUST EXIST BEFORE INSTALL — without it the deploy hangs waiting on a missing secret.
+    # printf '%s' "$(openssl rand -base64 32)" | cpln secret create-opaque --name my-manticore-agent-token --encoding plain -f -
+    tokenSecretName: my-manticore-agent-token
     resources:
       cpu: 250m
       minCpu: 100m
@@ -266,7 +268,13 @@ orchestrator:
     resources:
       cpu: 0.25
       memory: 0.25Gi
-    allowExternalAccess: true     # false = internal GVC access only
+    # DANGER: the UI has NO login of its own and injects the admin token for every caller.
+    # Enabling this publishes full cluster admin to the internet. Put an authenticating proxy in front.
+    publicAccess:
+      enabled: false
+    internalAccess:
+      type: same-gvc              # same-gvc, same-org, workload-list, none
+      workloads: []               # //gvc/{gvc}/workload/{name} links, used when type is workload-list
     autoscaling:
       maxScale: 2
       minScale: 1
@@ -399,16 +407,23 @@ The orchestrator manages all cluster lifecycle operations including data imports
 - `orchestrator.api.autoscaling` — Min/max replicas and CPU target for the orchestrator API.
 
 **Agent Sidecar**
-- `orchestrator.agent.token` — Bearer token securing all internal communication between the orchestrator and agent sidecars. **Generate with `openssl rand -base64 32` and change before deploying.**
+- `orchestrator.agent.tokenSecretName` — Names the prerequisite opaque secret holding the bearer token that secures all internal communication between the orchestrator, the agents and the UI. **The secret must exist before you install** (see [Prerequisites](#prerequisites)).
 - `orchestrator.agent.import.batchSize` — Number of rows per INSERT statement during imports (default: 20000).
 - `orchestrator.agent.recovery` — Retry settings for Galera cluster recovery after a split-brain event.
 
 **UI**
-- `orchestrator.ui.allowExternalAccess` — When `true`, the UI is accessible from the internet. Set to `false` to restrict access to within the GVC.
+- `orchestrator.ui.publicAccess.enabled` — Defaults to `false`. The UI has no authentication of its own and injects the admin token for any caller, so turning this on publishes full cluster admin to the internet.
+- `orchestrator.ui.internalAccess.type` — Inbound scope for in-GVC callers: `same-gvc` (default), `same-org`, `workload-list` or `none`. With `workload-list`, name the permitted workloads in `orchestrator.ui.internalAccess.workloads`.
 
 ### Backup (Optional)
 
 Set `orchestrator.backup.enabled: true` to enable scheduled backups to S3.
+
+<Warning>
+**Scheduled backups did not work before 2.1.0.** On every earlier version the backup job failed on every run and nothing ever reached the bucket, so an install with backups enabled had none. If you are upgrading, verify that objects appear in your bucket after the first scheduled run.
+</Warning>
+
+Restore is driven through the orchestrator API or UI — there is no `orchestrator.action: restore`.
 
 - `orchestrator.backup.cloudAccountName` — Cloud Account with write access to the backup S3 bucket.
 - `orchestrator.backup.s3Bucket` / `s3Region` — Backup bucket name and region.

--- a/template-catalog/templates/mariadb.mdx
+++ b/template-catalog/templates/mariadb.mdx
@@ -1,12 +1,18 @@
 ---
 title: MariaDB
-description: Deploy MariaDB on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and single-replica setup with optional phpMyAdmin web interface.
+description: Deploy MariaDB on Control Plane using the Template Catalog. Covers prerequisite credential secrets, volumes, internal access, the optional phpMyAdmin console, and scheduled backups to S3 or GCS.
 keywords: ['mysql fork', 'mysql alternative', 'rdbms', 'sql database', 'oltp', 'innodb', 'mariadb client', 'galera', 'mysqldump', 'binlog', 'gtid']
 ---
 
 ## Overview
 
-MariaDB is an open-source relational database management system and a drop-in replacement for MySQL. This template deploys a single-replica MariaDB instance with persistent storage and an optional phpMyAdmin web interface for database management.
+MariaDB is an open-source relational database management system and a drop-in replacement for MySQL. This template deploys a single-replica MariaDB instance with persistent storage, an optional phpMyAdmin console, and optional scheduled dumps to AWS S3 or GCS.
+
+Every credential comes from a secret you create **before** installing. Nothing sensitive passes through Helm values, so no password lands in the release, the stored workload spec, or the logs.
+
+<Warning>
+**Upgrading an install created with `1.3.2` or earlier is a breaking change.** The `config` block and `enablePhpMyAdmin` no longer exist, and an upgrade that still sets either one stops with an error naming its replacement rather than silently falling back to a default password. See [Upgrading From 1.3.2 or Earlier](#upgrading-from-1-3-2-or-earlier).
+</Warning>
 
 <Note>
 MariaDB on Control Plane operates as a single-replica deployment. Do not scale up the replica count, as this would result in multiple isolated instances rather than a replicated cluster.
@@ -14,20 +20,62 @@ MariaDB on Control Plane operates as a single-replica deployment. Do not scale u
 
 ### What Gets Created
 
-- **Stateful MariaDB Workload** — A single-replica MariaDB database container with configurable resources.
-- **Volume Set** — Persistent storage for MariaDB data, with optional autoscaling.
-- **Secret** — An opaque secret storing the database name, root password, and user credentials, injected into the container at startup.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to the database credentials secret, and cloud storage access when backup is enabled.
-- **phpMyAdmin Workload** *(optional)* — A web-based database management interface. Enabled when `enablePhpMyAdmin: true`.
-- **Backup Cron Workload** *(optional)* — A scheduled `mysqldump` backup job that writes compressed dumps to AWS S3 or GCS.
+- **Stateful MariaDB Workload** — `{release}-maria`, a single-replica MariaDB container serving TCP on port `3306`, with configurable resources.
+- **Volume Set** — `{release}-maria-vs`, an `ext4` volume mounted at `/var/lib/mysql` holding all database data, with optional autoscaling.
+- **Identity & Policy** — `{release}-maria-identity` and `{release}-maria-policy`, granting the database and backup workloads `reveal` on exactly the two credential secrets you created, and nothing else. Cloud storage access is added to the identity when backup is enabled.
+- **phpMyAdmin Workload** *(optional)* — `{release}-phpmyadmin`, a browser-based database console on port `80`. Off by default, and internal-only when enabled.
+- **Backup Cron Workload** *(optional)* — `{release}-maria-backup`, a scheduled `mysqldump` job that writes compressed dumps to AWS S3 or GCS.
+
+<Note>
+This template creates no secret of its own. Both credentials live in secrets you own, which means uninstalling the release never destroys them.
+</Note>
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Prerequisites
+
+**Two secrets must exist before you install.** They are deliberately separate: granting an application `reveal` on the database credentials must not also hand it the MariaDB `root` account. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the application credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly three keys — `username`, `password` and `database`. MariaDB creates this user and this database on first boot, and this is the credential your applications put in their connection strings:
+
+    ```bash
+    cpln secret create-dictionary --name my-mariadb-credentials \
+      --entry username=appuser \
+      --entry password="$(openssl rand -hex 24)" \
+      --entry database=appdb
+    ```
+
+    Set `credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Create the root password secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain`, whose payload is the MariaDB `root` password:
+
+    ```bash
+    printf '%s' "$(openssl rand -hex 24)" | cpln secret create-opaque --name my-mariadb-root-password --encoding plain -f -
+    ```
+
+    Set `rootPasswordSecretName` to the name you used.
+  </Step>
+  <Step title="Read either credential back later">
+    ```bash
+    cpln secret reveal my-mariadb-credentials
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+Create both secrets **before** installing. `helm install` still reports success without them, but the workload never starts and reports `The secret ... no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` in `cpln workload get-deployments` — which reads as a broken template rather than a missing prerequisite.
+</Warning>
+
+Backups need a bucket and a cloud account as well — see [Backup](#backup). Nothing else is required.
+
 ## Installation
 
-This template has no external prerequisites unless backup is enabled. To install, follow the instructions for your preferred method:
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -51,12 +99,74 @@ This template has no external prerequisites unless backup is enabled. To install
     </Card>
 </CardGroup>
 
+The database reaches `ready` roughly 40 seconds after install, once its readiness probe has authenticated against the root password from your secret.
+
+## Upgrading From 1.3.2 or Earlier
+
+Version `1.4.0` moved every credential out of Helm values and closed the phpMyAdmin console by default. Earlier versions shipped working defaults — a `root-password` root password and a `password` user password — behind a console that was enabled and published to the entire internet with no way to turn it off.
+
+| | `1.3.2` and earlier | `1.4.0` |
+|---|---|---|
+| Database credentials | `config.user`, `config.password`, `config.db` values | `credentialsSecretName` — a dictionary secret you create |
+| Root password | `config.rootPassword` value | `rootPasswordSecretName` — an opaque secret you create |
+| Chart-created credentials secret | Held every credential | Not created at all |
+| phpMyAdmin | `enablePhpMyAdmin: true`, always public | `phpMyAdmin.enabled: false`, with its own `publicAccess` and `internalAccess` |
+| phpMyAdmin image | `phpmyadmin/phpmyadmin:latest` | `phpmyadmin:5.2.3-apache`, pinned |
+
+<Warning>
+**A `helm upgrade` that still carries the old values is rejected before anything is applied.** Both removed keys stop the render and name their replacement. A real `cpln helm upgrade` that still set `config.rootPassword` was refused with the first message below and left the running release untouched and healthy:
+
+```text
+mariadb: the `config` block was removed in 1.4.0 — database credentials are no longer values. Create a
+`dictionary` secret with `username`, `password` and `database`, an `opaque` secret with the root password,
+and set `credentialsSecretName` and `rootPasswordSecretName` to their names. See Prerequisites in the README.
+```
+
+```text
+mariadb: `enablePhpMyAdmin` was renamed in 1.4.0 — use `phpMyAdmin.enabled` instead. Note phpMyAdmin now
+defaults to OFF, and to internal-only access when enabled (`phpMyAdmin.publicAccess.enabled`).
+```
+
+This is deliberate: a silently ignored `config.rootPassword` would leave you believing you had set a password you had not.
+</Warning>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the two secrets">
+    Follow [Prerequisites](#prerequisites). Set their contents to the credentials your database **already uses** if you want existing applications to keep connecting unchanged.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `config` in its entirety and `enablePhpMyAdmin`. Set `credentialsSecretName` and `rootPasswordSecretName` instead, and set `phpMyAdmin.enabled: true` if you still want the console.
+  </Step>
+  <Step title="Upgrade">
+    The upgrade restarts the single replica; data on the volume set is untouched.
+  </Step>
+</Steps>
+
+<Note>
+Credentials are read only when the data directory is first initialized, so an upgrade does not rewrite them. If the secrets you create hold different values from the ones the volume was built with, the database keeps its existing users and passwords — change them with `ALTER USER` from inside MariaDB.
+</Note>
+
 ## Configuration
 
 The default `values.yaml` for this template:
 
 ```yaml
 image: mariadb:11
+
+# ─── Credentials (prerequisite secrets) ───────────────────────────────────────
+# BOTH SECRETS MUST EXIST BEFORE YOU INSTALL — the deployment wedges waiting on a
+# secret that does not exist. Neither value passes through Helm values, so neither
+# lands in the release. See Prerequisites in the README for the exact commands.
+
+# `dictionary` secret holding exactly three keys: `username`, `password`, `database`.
+# This is the credential you put in your applications' connection strings.
+credentialsSecretName: my-mariadb-credentials
+
+# `opaque` secret (encoding: plain) holding the MariaDB root password. Deliberately
+# separate, so sharing the application credentials above does not hand out root.
+rootPasswordSecretName: my-mariadb-root-password
 
 resources:
   minCpu: 100m
@@ -66,30 +176,36 @@ resources:
 
 timeoutSeconds: 15
 
-config:
-  user: username
-  password: password
-  rootPassword: root-password
-  db: test
-
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
   autoscaling:
-    enabled: false
-    maxCapacity: 100 # Maximum capacity in GiB
-    minFreePercentage: 10 # Trigger scaling when free space drops below this percentage
-    scalingFactor: 1.2 # Multiply current capacity by this factor when scaling up
+    enabled: false # Set to true to enable autoscaling
+    maxCapacity: 100 # Maximum capacity in GiB when autoscaling is enabled
+    minFreePercentage: 10 # Minimum free percentage to trigger scaling when autoscaling is enabled
+    scalingFactor: 1.2 # Scaling factor to determine how much to scale up when autoscaling is triggered
 
-internalAccess:
+internalAccess: # Which workloads may reach MariaDB on port 3306
   type: same-gvc # options: none, same-gvc, same-org, workload-list
-  workloads: # Note: can only be used if type is same-gvc or workload-list
+  workloads: [] # only used when type is workload-list
     #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
-enablePhpMyAdmin: true
+# ─── phpMyAdmin (optional admin console) ──────────────────────────────────────
+phpMyAdmin:
+  enabled: false # true deploys a phpMyAdmin console alongside the database
+  image: phpmyadmin:5.2.3-apache
+  publicAccess:
+    enabled: false # true publishes the console, and its login form, to the whole internet
+  internalAccess:
+    type: same-gvc # options: none, same-gvc, same-org, workload-list
+    workloads: [] # only used when type is workload-list
+      #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
+  resources:
+    cpu: 100m
+    memory: 128Mi
 
 backup:
   enabled: false
-  image: controlplanecorporation/mysql-backup:1.0 # compatible with all MariaDB versions
+  image: ghcr.io/controlplane-com/backup-images/mysql-backup:1.0.0 # compatible with all MariaDB versions
   schedule: "0 2 * * *"   # daily at 2am UTC
 
   resources:
@@ -103,23 +219,23 @@ backup:
     region: us-east-1
     cloudAccountName: my-backup-cloudaccount
     policyName: my-backup-policy
-    prefix: mariadb/backups
+    prefix: mariadb/backups # folder name where your backups will be stored
 
   gcp:
     bucket: my-backup-bucket
     cloudAccountName: my-backup-cloudaccount
-    prefix: mariadb/backups
+    prefix: mariadb/backups # folder name where your backups will be stored
 ```
 
 ### Credentials
 
-- `config.db` — Name of the database created on startup.
-- `config.rootPassword` — Password for the MariaDB root user. **Change before deploying to production.**
-- `config.user` — Name of the non-root database user created on startup.
-- `config.password` — Password for the non-root user. **Change before deploying to production.**
+- `credentialsSecretName` — Name of the dictionary secret holding `username`, `password` and `database`. MariaDB creates that user and that database on first boot.
+- `rootPasswordSecretName` — Name of the opaque secret (encoding `plain`) holding the `root` password.
+
+Both are referenced as `cpln://secret/...` in the workload, so the values you install with contain only the secret **names**. The policy grants `reveal` on exactly these two secrets, and an application handed the dictionary secret has no path to the root account — the application password is rejected as `root`.
 
 <Note>
-These values are only applied on first startup when the data directory is empty. Updating them after the initial deployment will have no effect on the running database. To change credentials or the database name on an existing instance, use MariaDB's native commands (e.g. `ALTER USER`, `RENAME DATABASE`).
+Credentials are applied only on first startup, while the data directory is empty. Rotating either secret afterwards does not change the stored passwords; use MariaDB's native commands (for example `ALTER USER`) on a running instance.
 </Note>
 
 ### Resources
@@ -136,6 +252,8 @@ These values are only applied on first startup when the data directory is empty.
   - `minFreePercentage` — Trigger a scale-up when free space drops below this percentage.
   - `scalingFactor` — Multiply the current capacity by this factor when scaling up.
 
+Data survives redeploys and upgrades. `cpln helm uninstall` deletes the volume set, and the database with it.
+
 ### Internal Access
 
 - `internalAccess.type` — Controls which workloads can connect to MariaDB on port `3306`:
@@ -147,26 +265,49 @@ These values are only applied on first startup when the data directory is empty.
 | `same-org` | Allow access from all workloads in the same organization |
 | `workload-list` | Allow access only from specific workloads listed in `workloads` |
 
+- `internalAccess.workloads` — Workload links (`//gvc/GVC_NAME/workload/WORKLOAD_NAME`), used only when `type` is `workload-list`.
+
+The database itself is never published to the internet by this template. Reach it from inside the GVC, or from outside through your own proxy.
+
 ### phpMyAdmin
 
-- `enablePhpMyAdmin` — When `true`, deploys a phpMyAdmin workload for browser-based database management. Disable by setting to `false`.
+- `phpMyAdmin.enabled` — Deploy a phpMyAdmin console alongside the database. **Off by default.**
+- `phpMyAdmin.image` — Pinned console image (`phpmyadmin:5.2.3-apache`, the official Docker library repository).
+- `phpMyAdmin.publicAccess.enabled` — Publish the console, and its login form, to the whole internet. Off by default.
+- `phpMyAdmin.internalAccess` — Which workloads may reach the console, using the same `type` values as the database's own `internalAccess`. This knob governs the console only; the database has its own.
+- `phpMyAdmin.resources.cpu` / `phpMyAdmin.resources.memory` — Resources for the console container.
 
-### Connecting to MariaDB
+The console holds **no credential of its own**. It runs without an identity and with no access to any secret: it presents a login form, and you supply either the application credentials or `root` plus the root password there. Nothing is pre-filled, and a compromise of the console container yields no password.
 
-Once deployed, connect to the database from within the same GVC using:
+<Warning>
+**`phpMyAdmin.publicAccess.enabled: true` puts a database console on the public internet.** Anyone who reaches it needs only a valid database password to read and write everything. Prefer leaving it off and reaching the console over `http://{release}-phpmyadmin.GVC_NAME.cpln.local` from inside the GVC.
+</Warning>
 
-```text
-RELEASE_NAME-maria.GVC_NAME.cpln.local:3306
-```
+<Note>
+Access changes take a short while to propagate. Turning `publicAccess` on was measured returning `421`, then `503`, then `200` over roughly 34 seconds — a request made immediately after the upgrade is not evidence that the knob failed. Toggling console access re-applies only the console workload; the database is not restarted.
+</Note>
+
+## Connecting to MariaDB
+
+| Path | Address | Notes |
+|---|---|---|
+| Database | `{release}-maria.GVC_NAME.cpln.local:3306` | Subject to `internalAccess.type`. |
+| phpMyAdmin (internal) | `http://{release}-phpmyadmin.GVC_NAME.cpln.local` | Only when `phpMyAdmin.enabled: true`. |
+| phpMyAdmin (public) | `https://CANONICAL_ENDPOINT` | Only when `phpMyAdmin.publicAccess.enabled: true`. Read the endpoint from `status.canonicalEndpoint` in `cpln workload get {release}-phpmyadmin -o yaml`. |
+| Application credentials | `cpln secret reveal CREDENTIALS_SECRET_NAME` | Never stored in the Helm release. |
+| Root password | `cpln secret reveal ROOT_SECRET_NAME` | Never stored in the Helm release. |
 
 ## Backup
 
-Backup is disabled by default. When enabled, a cron workload runs `mysqldump` on the configured schedule and uploads compressed dumps to AWS S3 or GCS.
+Backup is disabled by default. When enabled, a cron workload dumps the database named in your credentials secret and uploads a compressed dump to AWS S3 or GCS on the configured schedule.
 
 - `backup.enabled` — Enable scheduled backups.
+- `backup.image` — Backup container image, compatible with all MariaDB versions.
 - `backup.schedule` — Cron expression for backup frequency (default: daily at 2am UTC).
 - `backup.provider` — `aws` or `gcp`.
 - `backup.resources.cpu` / `backup.resources.memory` — Resources for the backup cron container.
+
+The job reads the database name, user, password and root password from your two prerequisite secrets, and takes the bucket, region and prefix as plain configuration.
 
 ### AWS S3
 
@@ -208,12 +349,12 @@ Before enabling backup with `provider: gcp`, complete the following in your GCP 
 
 1. Create a GCS bucket. Set `backup.gcp.bucket` to its name.
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.gcp.cloudAccountName` to its name.
-3. Add the **Storage Admin** role to the GCP service account associated with the Cloud Account.
+3. Add the **Storage Admin** role to the GCP service account associated with the Cloud Account. The template binds `roles/storage.objectAdmin` on exactly that bucket.
 4. Set `backup.gcp.prefix` to the folder path where backups will be stored.
 
 ## Restoring a Backup
 
-Run the following from a client with access to the backup bucket. For GCS, replace `aws s3 cp s3://...` with `gsutil cp gs://...`.
+Run the following from a client with access to the backup bucket. For GCS, replace `aws s3 cp s3://...` with `gsutil cp gs://...`. Add `-p` to have the client prompt for the root password, which you can read with `cpln secret reveal ROOT_SECRET_NAME`.
 
 ```sh
 aws s3 cp s3://BUCKET_NAME/PREFIX/BACKUP_FILE.gz - \

--- a/template-catalog/templates/mysql.mdx
+++ b/template-catalog/templates/mysql.mdx
@@ -1,12 +1,18 @@
 ---
 title: MySQL
-description: Deploy MySQL on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and single-replica setup with optional phpMyAdmin and S3/GCS backups.
-keywords: ['mariadb alternative', 'oltp', 'rdbms template', 'sql template', 'innodb', 'mysqldump', 'mysql client', 'gtid', 'binlog', 'database template', 'phpmyadmin']
+description: Deploy MySQL on Control Plane using the Template Catalog. Covers prerequisite credential secrets, volumes, internal access, the optional phpMyAdmin console, S3/GCS backups, and migrating from template version 1.4.3.
+keywords: ['mariadb alternative', 'oltp', 'rdbms template', 'sql template', 'innodb', 'mysqldump', 'mysql client', 'gtid', 'binlog', 'database template', 'phpmyadmin', 'root password rotation']
 ---
 
 ## Overview
 
-MySQL is a widely used open-source relational database management system. This template deploys a single-replica MySQL instance with persistent storage, an optional phpMyAdmin web interface, and optional scheduled backups to AWS S3 or GCS.
+MySQL is a widely used open-source relational database management system. This template deploys a single-replica MySQL instance with persistent storage, an optional phpMyAdmin web console, and optional scheduled backups to AWS S3 or GCS.
+
+Database credentials are **not** template values. MySQL reads both the application credentials and the `root` password from two secrets you create before installing, so no password passes through Helm or lands in the release.
+
+<Warning>
+**Template version 1.5.0 is a breaking security change.** The `config` block and `enablePhpMyAdmin` were removed, and an install or upgrade that still sets either one now fails at render instead of silently falling back to a default password. If you are running 1.4.3 or earlier, read [Upgrading From 1.4.3 or Earlier](#upgrading-from-1-4-3-or-earlier) before you touch the release.
+</Warning>
 
 <Note>
 MySQL on Control Plane operates as a single-replica deployment. Do not scale up the replica count, as this would result in multiple isolated instances rather than a replicated cluster.
@@ -14,61 +20,115 @@ MySQL on Control Plane operates as a single-replica deployment. Do not scale up 
 
 ### What Gets Created
 
-- **Stateful Workload** — A single-replica MySQL database container with configurable resources.
-- **Volume Set** — Persistent storage for MySQL data, with optional autoscaling.
-- **Secret** — A dictionary secret storing the database name, root password, and user credentials. When backup is enabled, the secret also includes backup storage configuration.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to the database credentials secret. When backup is enabled, the identity also grants the backup cron job access to the configured cloud storage.
-- **Backup Cron Job** (optional) — A scheduled job that dumps the MySQL database to an S3 or GCS bucket. Enabled when `backup.enabled: true`.
-- **phpMyAdmin Workload** (optional) — A web-based database management interface. Enabled when `enablePhpMyAdmin: true`.
+- **Stateful Workload** — (`RELEASE_NAME-mysql`): a single-replica MySQL container serving TCP on port `3306`, with configurable resources.
+- **Volume Set** — (`RELEASE_NAME-mysql-vs`): an `ext4` volume mounted at `/var/lib/mysql` holding all database data, with optional autoscaling.
+- **Identity & Policy** — An identity bound to the database and backup workloads, and a policy granting it `reveal` on exactly the two credential secrets you created — nothing else. When backups are enabled, the identity also carries the Cloud Account binding the backup job uses to reach your bucket.
+- **phpMyAdmin Workload** *(optional)* — (`RELEASE_NAME-mysql-phpmyadmin`): a serverless browser console on port `80`, created when `phpMyAdmin.enabled: true`. It has no identity and no access to any secret.
+- **Backup Cron Workload** *(optional)* — (`RELEASE_NAME-mysql-backup`): a scheduled `mysqldump` to an S3 or GCS bucket, created when `backup.enabled: true`.
+
+The template creates **no credential secret of its own**. Every password lives in the prerequisite secrets described below.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
-## Prerequisites
+## Upgrading From 1.4.3 or Earlier
 
-Prerequisites are only required if you plan to enable MySQL backups (`backup.enabled: true`). The backup feature requires MySQL 9+. Skip this section if backups are not needed.
+Template versions up to 1.4.3 took the database credentials as plain Helm values and shipped working defaults for them, and they deployed phpMyAdmin enabled and reachable from the entire internet, with no knob to restrict it short of disabling the console. Version 1.5.0 removes both.
 
-### AWS S3
+| | 1.4.3 and earlier | 1.5.0 |
+|---|---|---|
+| Application credentials | `config.user`, `config.password`, `config.db` values | `credentialsSecretName` → a dictionary secret you create |
+| Root password | `config.rootPassword` value | `rootPasswordSecretName` → an opaque secret you create |
+| phpMyAdmin | `enablePhpMyAdmin: true`, public, hardcoded to `0.0.0.0/0` | `phpMyAdmin.enabled: false`, with its own `publicAccess` (off) and `internalAccess` knobs |
+| phpMyAdmin image | `phpmyadmin/phpmyadmin:latest` | `phpmyadmin:5.2.3-apache` |
+| phpMyAdmin credentials | An identity plus the root password in its environment | None — no identity, no secret access |
+| Credential secret | `RELEASE_NAME-mysql-config` held every credential | Not created — credentials live only in your secrets |
 
-1. Create an S3 bucket. Set `backup.aws.bucket` and `backup.aws.region` in your values file.
+<Warning>
+**Carrying old values forward stops the upgrade.** Both removed keys are rejected at render, so `cpln helm upgrade` fails and your existing release is left untouched and running rather than quietly restarting with a different password:
 
-2. If you do not have a Control Plane Cloud Account set up, follow the [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) guide. Set `backup.aws.cloudAccountName` to the name of your Cloud Account.
-
-3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
-
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject",
-                "s3:ListBucket",
-                "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
-            ],
-            "Resource": [
-                "arn:aws:s3:::YOUR_BUCKET_NAME",
-                "arn:aws:s3:::YOUR_BUCKET_NAME/*"
-            ]
-        }
-    ]
-}
+```text
+Error: execution error at (mysql/templates/workload-mysql.yaml:1:4): mysql: the `config` block was
+removed in 1.5.0 — database credentials are no longer values. Create a `dictionary` secret with
+`username`, `password` and `database`, an `opaque` secret with the root password, and set
+`credentialsSecretName` and `rootPasswordSecretName` to their names. See Prerequisites in the README.
 ```
 
-4. Set `backup.aws.policyName` to the name of the policy created in step 3.
+```text
+Error: ... mysql: `enablePhpMyAdmin` was renamed in 1.5.0 — use `phpMyAdmin.enabled` instead. Note
+phpMyAdmin now defaults to OFF, and to internal-only access when enabled
+(`phpMyAdmin.publicAccess.enabled`).
+```
+</Warning>
 
-### GCS
+<Steps>
+  <Step title="Read the credentials the database already uses">
+    Credentials are written into the data directory the first time the volume is initialized, so an existing database keeps whatever it was created with. Recover them from your current values file, or from the secret the old version created:
 
-1. Create a GCS bucket. Set `backup.gcp.bucket` in your values file.
+    ```bash
+    cpln secret reveal RELEASE_NAME-mysql-config -o yaml
+    ```
 
-2. If you do not have a Control Plane Cloud Account set up, follow the [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) guide. Set `backup.gcp.cloudAccountName` to the name of your Cloud Account.
+    The keys are `user`, `password`, `database` and `rootPassword`.
+  </Step>
+  <Step title="Create the two prerequisite secrets with those same values">
+    Follow [Prerequisites](#prerequisites), using the existing username, password, database name and root password. Using different values here does not change the database — it just leaves the workload unable to authenticate.
+  </Step>
+  <Step title="Remove the old keys from your values">
+    Delete the entire `config` block and `enablePhpMyAdmin`, then set `credentialsSecretName` and `rootPasswordSecretName` to the two secret names. If you were using the console, add `phpMyAdmin.enabled: true` — it is off by default now, and internal-only unless you also set `phpMyAdmin.publicAccess.enabled: true`.
+  </Step>
+  <Step title="Upgrade, then rotate the passwords">
+    After the upgrade succeeds, change any password that came from a 1.4.x default — those defaults were published in the public template repository, so treat them as compromised. Rotate inside MySQL and update the secret to match:
 
-3. Add the **Storage Admin** role to the GCP service account associated with the Cloud Account.
+    ```sql
+    ALTER USER 'root'@'localhost' IDENTIFIED BY 'NEW-STRONG-ROOT-PASSWORD';
+    ALTER USER 'root'@'%' IDENTIFIED BY 'NEW-STRONG-ROOT-PASSWORD';
+    ALTER USER 'appuser'@'%' IDENTIFIED BY 'NEW-STRONG-PASSWORD';
+    ```
+
+    The image creates `root` for both `localhost` and `%`, so rotating root means changing both. Use your own username in place of `appuser`, then update the two secrets so the workload can still authenticate after a restart.
+  </Step>
+</Steps>
+
+## Prerequisites
+
+**Two secrets must exist before you install.** They are deliberately separate: an application handed `reveal` on the database credentials must not also get `root`. Neither value passes through Helm values, so neither lands in the release. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the application credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly three keys — `username`, `password` and `database`. MySQL creates this user and this database on first boot, and this is the credential your applications put in their connection strings:
+
+    ```bash
+    cpln secret create-dictionary --name my-mysql-credentials \
+      --entry username=appuser \
+      --entry password='YOUR-STRONG-PASSWORD' \
+      --entry database=appdb
+    ```
+
+    Set `credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Create the root password secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain` holding the MySQL `root` password:
+
+    ```bash
+    printf '%s' 'YOUR-STRONG-ROOT-PASSWORD' | cpln secret create-opaque --name my-mysql-root-password --encoding plain -f -
+    ```
+
+    Set `rootPasswordSecretName` to the name you used.
+  </Step>
+  <Step title="Read either secret back later">
+    ```bash
+    cpln secret reveal my-mysql-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+Create both secrets **before** installing. The template refuses to render when either name is blank, but a name that points at a secret which does not exist installs "successfully" and then wedges: the workload waits on the missing secret and looks broken. Confirm the database actually started with `cpln workload get-deployments RELEASE_NAME-mysql --gvc GVC_NAME` rather than trusting the Helm output.
+</Warning>
+
+Backups need a bucket and a Control Plane Cloud Account before they can be enabled — see [Backup Prerequisites](#backup-prerequisites). Nothing else is required.
 
 ## Installation
 
@@ -101,7 +161,20 @@ To install, follow the instructions for your preferred method:
 The default `values.yaml` for this template:
 
 ```yaml
-image: mysql:9 # versions before mysql:9 are compatible but do not support backup feature
+image: mysql:9 # any supported MySQL major works, including the backup feature (the backup image dumps whichever database is configured)
+
+# ─── Credentials (prerequisite secrets) ───────────────────────────────────────
+# BOTH SECRETS MUST EXIST BEFORE YOU INSTALL — the deployment wedges waiting on a
+# secret that does not exist. Neither value passes through Helm values, so neither
+# lands in the release. See Prerequisites in the README for the exact commands.
+
+# `dictionary` secret holding exactly three keys: `username`, `password`, `database`.
+# This is the credential you put in your applications' connection strings.
+credentialsSecretName: my-mysql-credentials
+
+# `opaque` secret (encoding: plain) holding the MySQL root password. Deliberately
+# separate, so sharing the application credentials above does not hand out root.
+rootPasswordSecretName: my-mysql-root-password
 
 resources:
   minCpu: 100m
@@ -111,31 +184,37 @@ resources:
 
 timeoutSeconds: 15
 
-config:
-  db: test
-  rootPassword: root-password
-  user: username
-  password: password
-
-internalAccess:
+internalAccess: # Which workloads may reach MySQL on port 3306
   type: same-gvc # options: none, same-gvc, same-org, workload-list
-  workloads: # Note: can only be used if type is same-gvc or workload-list
+  workloads: [] # only used when type is workload-list
     #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
   autoscaling:
-    enabled: false
-    maxCapacity: 100 # Maximum capacity in GiB
-    minFreePercentage: 10 # Trigger scaling when free space drops below this percentage
-    scalingFactor: 1.2 # Multiply current capacity by this factor when scaling up
+    enabled: false # Set to true to enable autoscaling
+    maxCapacity: 100 # Maximum capacity in GiB when autoscaling is enabled
+    minFreePercentage: 10 # Minimum free percentage to trigger scaling when autoscaling is enabled
+    scalingFactor: 1.2 # Scaling factor to determine how much to scale up when autoscaling is triggered
 
-enablePhpMyAdmin: false
+# ─── phpMyAdmin (optional admin console) ──────────────────────────────────────
+phpMyAdmin:
+  enabled: false # true deploys a phpMyAdmin console alongside the database
+  image: phpmyadmin:5.2.3-apache
+  publicAccess:
+    enabled: false # true publishes the console, and its login form, to the whole internet
+  internalAccess:
+    type: same-gvc # options: none, same-gvc, same-org, workload-list
+    workloads: [] # only used when type is workload-list
+      #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
+  resources:
+    cpu: 100m
+    memory: 128Mi
 
-backup: # compatible with MySQL 9+
-  enabled: true
-  image: controlplanecorporation/mysql-backup:9.1 # tag 9.1 = MySQL 9 compatible
-  schedule: "0 2 * * *" # daily at 2am UTC
+backup:
+  enabled: false
+  image: ghcr.io/controlplane-com/backup-images/mysql-backup:1.0.0 # compatible with all MySQL image versions
+  schedule: "0 2 * * *"   # daily at 2am UTC
 
   resources:
     cpu: 100m
@@ -144,27 +223,27 @@ backup: # compatible with MySQL 9+
   provider: aws # Options: aws or gcp
 
   aws:
-    bucket: mysql-backup-bucket
+    bucket: my-backup-bucket
     region: us-east-1
-    cloudAccountName: mysql-backup-cloudaccount
-    policyName: mysql-backup-policy
-    prefix: mysql/backups # Folder path within the bucket
+    cloudAccountName: my-backup-cloudaccount
+    policyName: my-backup-policy
+    prefix: mysql/backups # folder name where your backups will be stored
 
   gcp:
-    bucket: mysql-backup-bucket
-    cloudAccountName: mysql-backup-cloudaccount
-    prefix: mysql/backups
+    bucket: my-backup-bucket
+    cloudAccountName: my-backup-cloudaccount
+    prefix: mysql/backups # folder name where your backups will be stored
 ```
 
 ### Credentials
 
-- `config.db` — Name of the database created on startup.
-- `config.rootPassword` — Password for the MySQL root user. **Change before deploying to production.**
-- `config.user` — Name of the non-root database user created on startup.
-- `config.password` — Password for the non-root user. **Change before deploying to production.**
+- `credentialsSecretName` — Name of the dictionary secret holding `username`, `password` and `database`. MySQL creates that user and that database on first boot.
+- `rootPasswordSecretName` — Name of the opaque secret holding the `root` password.
+
+Both secrets must exist before installing — see [Prerequisites](#prerequisites). The workload reads them through `cpln://secret/...` references, so the values appear in neither the Helm release nor the stored workload spec.
 
 <Note>
-These values are only applied on first startup when the data directory is empty. Updating them after the initial deployment will have no effect on the running database. To change credentials or the database name on an existing instance, use MySQL's native commands (e.g. `ALTER USER`, `RENAME DATABASE`).
+These credentials are only applied on first startup when the data directory is empty. Rotating either secret afterwards does not change the stored passwords; change them inside MySQL with `ALTER USER` and update the secret to match.
 </Note>
 
 ### Resources
@@ -192,19 +271,80 @@ These values are only applied on first startup when the data directory is empty.
 | `same-org` | Allow access from all workloads in the same organization |
 | `workload-list` | Allow access only from specific workloads listed in `workloads` |
 
+The database is never published to the internet by this template. Reach it from inside the GVC, or from outside through your own proxy.
+
 ### phpMyAdmin
 
-- `enablePhpMyAdmin` — When `true`, deploys a phpMyAdmin workload for browser-based database management.
+- `phpMyAdmin.enabled` — When `true`, deploys a phpMyAdmin workload for browser-based database management. Off by default.
+- `phpMyAdmin.image` — Pinned to `phpmyadmin:5.2.3-apache` from the official Docker library repository.
+- `phpMyAdmin.publicAccess.enabled` — When `true`, publishes the console, and its login form, to the whole internet. Off by default.
+- `phpMyAdmin.internalAccess` — Which workloads may reach the console, using the same four types as the database. This governs the **console only**; the database has its own `internalAccess` knob.
+- `phpMyAdmin.resources.cpu` / `phpMyAdmin.resources.memory` — Console resources.
+
+The console holds **no standing credential**: it has no identity, no `reveal` grant, and no password in its environment. It presents a login form, you supply either the application credentials or `root` plus the root password, and it connects to the database as whoever logged in. Compromising the console container therefore yields no password.
+
+<Warning>
+`phpMyAdmin.publicAccess.enabled: true` puts a database console on the public internet, where anyone who reaches it needs only a valid database password to read and write everything. Prefer leaving it off and reaching the console from inside the GVC.
+</Warning>
+
+<Note>
+Access changes take up to a couple of minutes to propagate. Enabling public access was measured moving through `421` and `503` before serving `200`, settling in about 34 seconds — a request made immediately after the upgrade is not evidence the knob is broken.
+</Note>
 
 ### Backup
 
-Set `backup.enabled: true` to enable scheduled database dumps to object storage. The backup feature requires MySQL 9+.
+Set `backup.enabled: true` to enable scheduled database dumps to object storage. The job authenticates as `root` and dumps the database named in your credentials secret; both come from the same two secrets the database uses.
 
-Set `backup.provider` to `aws` or `gcp` and fill in the corresponding section. The `prefix` field controls the folder path within the bucket where backups are stored.
+Set `backup.provider` to `aws` or `gcp` and fill in the corresponding section. The `prefix` field controls the folder path within the bucket where backups are stored. See [Backup Prerequisites](#backup-prerequisites) for the bucket, Cloud Account and permissions setup.
 
-### Restoring a Backup
+## Backup Prerequisites
 
-To restore from a backup, run the following from a client with access to the bucket:
+Only needed when `backup.enabled: true`.
+
+### AWS S3
+
+1. Create an S3 bucket. Set `backup.aws.bucket` and `backup.aws.region` in your values file.
+
+2. If you do not have a Control Plane Cloud Account set up, follow the [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) guide. Set `backup.aws.cloudAccountName` to the name of your Cloud Account.
+
+3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:GetObjectVersion",
+                "s3:DeleteObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::YOUR_BUCKET_NAME",
+                "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+            ]
+        }
+    ]
+}
+```
+
+4. Set `backup.aws.policyName` to the name of the policy created in step 3. The template attaches it to the workload's identity.
+
+### GCS
+
+1. Create a GCS bucket. Set `backup.gcp.bucket` in your values file.
+
+2. If you do not have a Control Plane Cloud Account set up, follow the [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) guide. Set `backup.gcp.cloudAccountName` to the name of your Cloud Account.
+
+3. Add the **Storage Admin** role to the GCP service account associated with the Cloud Account. The template binds `roles/storage.objectAdmin` on exactly that bucket.
+
+## Restoring a Backup
+
+Run the following from a client with access to the bucket, using the `root` password from your `rootPasswordSecretName` secret. Dumps carry a `SET @@GLOBAL.GTID_PURGED` statement that must be stripped when loading into a running server:
 
 **AWS S3**
 
@@ -213,6 +353,7 @@ export MYSQL_PWD="ROOT_PASSWORD"
 
 aws s3 cp "s3://BUCKET_NAME/PREFIX/BACKUP_FILE.sql.gz" - \
   | gunzip \
+  | sed '/^SET @@GLOBAL.GTID_PURGED/d' \
   | mysql \
       --host=WORKLOAD_NAME \
       --port=3306 \
@@ -229,6 +370,7 @@ export MYSQL_PWD="ROOT_PASSWORD"
 
 gsutil cp "gs://BUCKET_NAME/PREFIX/BACKUP_FILE.sql.gz" - \
   | gunzip \
+  | sed '/^SET @@GLOBAL.GTID_PURGED/d' \
   | mysql \
       --host=WORKLOAD_NAME \
       --port=3306 \
@@ -238,13 +380,23 @@ gsutil cp "gs://BUCKET_NAME/PREFIX/BACKUP_FILE.sql.gz" - \
 unset MYSQL_PWD
 ```
 
-### Connecting to MySQL
+## Connecting
 
-Once deployed, connect to the database from within the same GVC using:
+| Path | Address | Notes |
+|---|---|---|
+| Database | `RELEASE_NAME-mysql.GVC_NAME.cpln.local:3306` | Subject to `internalAccess.type`. |
+| phpMyAdmin (internal) | `http://RELEASE_NAME-mysql-phpmyadmin.GVC_NAME.cpln.local` | Only when `phpMyAdmin.enabled: true`. |
+| phpMyAdmin (public) | `https://CANONICAL_ENDPOINT` | Only when `phpMyAdmin.publicAccess.enabled: true`. Read it from `status.canonicalEndpoint` in `cpln workload get RELEASE_NAME-mysql-phpmyadmin -o yaml`. |
+| Application credentials | `cpln secret reveal CREDENTIALS_SECRET_NAME -o yaml` | Never stored in the Helm release. |
+| Root password | `cpln secret reveal ROOT_SECRET_NAME -o yaml` | Never stored in the Helm release. |
 
-```text
-RELEASE_NAME-mysql.GVC_NAME.cpln.local:3306
-```
+## Important Notes
+
+- **Create both prerequisite secrets before installing.** A reference to a secret that does not exist wedges the workload instead of failing the install.
+- **Credentials are read only when the volume is first initialized.** Rotating a secret afterwards does not change the stored passwords — use `ALTER USER` inside MySQL and update the secret to match.
+- **Do not scale past one replica.** This is a single instance on a single volume, not a replicated cluster.
+- **Data lives on the volume set** and survives redeploys; `cpln helm uninstall` deletes it, taking the database with it.
+- **Upgrading from 1.4.3 or earlier is a breaking change** — the removed keys stop the upgrade rather than resetting a password. See [Upgrading From 1.4.3 or Earlier](#upgrading-from-1-4-3-or-earlier).
 
 ## External References
 
@@ -252,7 +404,7 @@ RELEASE_NAME-mysql.GVC_NAME.cpln.local:3306
     <Card title="MySQL Documentation" icon="book" href="https://dev.mysql.com/doc/">
     Official MySQL documentation
     </Card>
-    <Card title="phpMyAdmin Documentation" icon="database" href="https://www.phpmyadmin.net/docs/">
+    <Card title="phpMyAdmin Documentation" icon="database" href="https://docs.phpmyadmin.net/">
     phpMyAdmin user documentation
     </Card>
     <Card title="Cloud Accounts" icon="cloud" href="https://docs.controlplane.com/guides/create-cloud-account">

--- a/template-catalog/templates/open-webui.mdx
+++ b/template-catalog/templates/open-webui.mdx
@@ -1,26 +1,28 @@
 ---
 title: Open WebUI
-description: Deploy Open WebUI on Control Plane using the Template Catalog. Self-hosted, ChatGPT-style chat interface for LLMs, backed by an in-GVC Ollama server and any OpenAI-compatible API, with users, RAG, and model management on a persistent volume served over HTTPS.
+description: Deploy Open WebUI on Control Plane using the Template Catalog. Self-hosted, ChatGPT-style chat interface for LLMs, backed by an in-GVC Ollama server and any OpenAI-compatible API, with users, RAG, and model management on a persistent volume. Private by default — you claim the admin account before publishing the UI.
 keywords: ['chatgpt alternative', 'self-hosted chatgpt', 'llm chat ui', 'ollama frontend', 'ollama web ui', 'openai compatible', 'rag', 'private ai', 'ai chat', 'llm frontend', 'chatbot ui', 'open webui template']
 ---
 
 ## Overview
 
-Open WebUI is a self-hosted, ChatGPT-style chat interface for large language models with user accounts, RAG (chat grounded in your uploaded documents), and model management. This template deploys a single stateful workload that keeps all of its state on a persistent volume and connects to your models through an in-GVC [Ollama](/template-catalog/templates/ollama) server and/or any OpenAI-compatible endpoint, served over HTTPS on the canonical `*.cpln.app` endpoint. Sign-ups are open on a fresh install so you can onboard immediately — the first account you register becomes the admin, and you [lock registration down](#important-notes) afterward.
+Open WebUI is a self-hosted, ChatGPT-style chat interface for large language models with user accounts, RAG (chat grounded in your uploaded documents), and model management. This template deploys a single stateful workload that keeps all of its state on a persistent volume and connects to your models through an in-GVC [Ollama](/template-catalog/templates/ollama) server and/or any OpenAI-compatible endpoint.
+
+The install is **private by default**: `publicAccess.enabled` is `false` and self-registration is closed, because the first account registered on a fresh install becomes the administrator. You reach the UI over a port-forward, claim that admin account, and then opt in to publishing it — see [First Run](#first-run).
 
 ### Architecture
 
-- **Open WebUI** — A single-replica stateful workload serving the web UI and API on port `8080`. Its public `WEBUI_URL` is derived from the canonical endpoint at boot, so links resolve correctly with no manual configuration.
+- **Open WebUI** — A single-replica stateful workload serving the web UI and API on port `8080`. A mounted start script sets its public `WEBUI_URL` from the canonical endpoint at boot, so links resolve correctly with no manual configuration.
 - **Embedded SQLite on a persistent volume** — All durable state (the `webui.db` database, uploaded files, the default Chroma vector store used for RAG, and cache) lives on the workload's volume set at `/app/backend/data`. SQLite is single-writer, so there is no external database dependency and the workload runs as exactly one replica.
 - **Model backends** — Chat completions are served by an existing Ollama workload in the same GVC (default), an OpenAI-compatible API (optional), or both. Neither backend is bundled by this template — you point it at model providers you run or subscribe to.
+- **No template-created credential** — The key that signs sessions and JWTs lives only in a secret you create yourself, so it never enters the Helm release.
 
 ### What Gets Created
 
 - **Stateful Open WebUI Workload** — A single replica serving the web UI and API on port `8080`.
 - **Volume Set** — A 10 GiB persistent volume mounted at `/app/backend/data` holding the SQLite database, uploaded files, the RAG vector store, and cache. Scheduled snapshots protect the data, and a final snapshot is kept on delete.
-- **Config Secret** — Holds the stable `WEBUI_SECRET_KEY` that signs sessions and JWTs.
 - **Start-Script Secret** — An opaque secret whose boot script sets `WEBUI_URL` from the canonical endpoint.
-- **Identity & Policy** — An identity bound to the workload with a least-privilege policy granting `reveal` access to exactly the secrets it mounts (the config and start-script secrets, plus your OpenAI-key secret only when you configure one).
+- **Identity & Policy** — An identity bound to the workload with a least-privilege policy granting `reveal` access to exactly the secrets it mounts: your session-key secret, the start-script secret, and your OpenAI-key secret only when you configure one.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -28,13 +30,38 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-None for a default install — no secrets, cloud accounts, or external resources are required to bring the UI up. The items below are optional and only needed for the corresponding feature.
+**One [opaque secret](/guides/create-secret/opaque) must exist before you install.** The key that signs every session and JWT is a long-lived credential, so it is not a value — a value would sit in the Helm release for the life of the install.
 
-- **License awareness** — Open WebUI ships under the "Open WebUI License" (BSD-3-Clause plus a branding-protection clause). It is free to self-host and run in production at any scale, but you must keep the "Open WebUI" branding visible in the UI **unless** your deployment serves 50 or fewer users, or you obtain enterprise permission. See [Important Notes](#important-notes).
-- **Ollama backend (recommended)** — An existing [Ollama](/template-catalog/templates/ollama) workload in the same GVC. Deploy the Ollama template first, then set its workload name in `ollama.workloadName`. Enabled by default.
-- **OpenAI-compatible backend (optional)** — Create, **before installing**, an [opaque secret](https://docs.controlplane.com/reference/secret#opaque) (`encoding: plain`) in your org holding your API key, and set its name in `openai.apiKeySecretName`. An empty value leaves this backend off.
+<Steps>
+  <Step title="Create the session signing key secret">
+    Generate a random key and store it as the secret's payload:
 
-Install the template using your preferred method:
+    ```bash
+    printf '%s' "$(openssl rand -base64 32)" | cpln secret create-opaque --name my-openwebui-secret-key --encoding plain -f -
+    ```
+
+    Set `auth.secretKeyName` to the name you used.
+  </Step>
+  <Step title="Keep it forever">
+    Back the key up somewhere safe outside Control Plane. It is never rotated: replacing it invalidates every issued session and JWT, logging every user out.
+  </Step>
+</Steps>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, but the workload never starts: it sits at zero replicas with the message `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` Create the secret first, and after installing confirm with `cpln workload get-deployments {release}-open-webui --gvc {gvc}` rather than trusting the Helm output.
+</Warning>
+
+These are optional and only needed for the corresponding feature:
+
+| Feature | What you must create first |
+|---|---|
+| Ollama models (enabled by default) | An existing [Ollama](/template-catalog/templates/ollama) workload in the same GVC. Set its workload name in `ollama.workloadName` |
+| OpenAI-compatible backend | An [opaque secret](/guides/create-secret/opaque) with encoding `plain` holding your API key, named in `openai.apiKeySecretName`. Empty (default) leaves this backend off |
+| Custom domain | A Control Plane [domain](/guides/configure-domain) and its DNS records. `customDomain` alone does not create one — see [Access](#access) |
+
+**License awareness** — Open WebUI ships under the "Open WebUI License" (BSD-3-Clause plus a branding-protection clause). It is free to self-host and run in production at any scale, but you must keep the "Open WebUI" branding visible in the UI **unless** your deployment serves 50 or fewer users, or you obtain enterprise permission. See [Important Notes](#important-notes).
+
+Once the secret exists, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -58,11 +85,53 @@ Install the template using your preferred method:
     </Card>
 </CardGroup>
 
+## First Run
+
+A default install is closed on every side: the canonical endpoint returns `403` to the internet, and `internalAccess.type: none` blocks other workloads in the GVC. Claim the admin account through a port-forward first, then publish the UI.
+
+<Steps>
+  <Step title="Install with the defaults">
+    Install with `auth.secretKeyName` pointing at the secret you created, and leave `publicAccess.enabled: false` and `auth.enableSignup: false` alone. Wait for the workload to report ready:
+
+    ```bash
+    cpln workload get-deployments {release}-open-webui --gvc {gvc}
+    ```
+  </Step>
+  <Step title="Register the admin account over a port-forward">
+    Forward the UI to your own machine:
+
+    ```bash
+    cpln port-forward {release}-open-webui 8080:8080 --gvc {gvc}
+    ```
+
+    Then open `http://localhost:8080`, which shows Open WebUI's "create admin account" screen. Port forwarding reaches the workload even though it is closed to both the internet and the GVC, and the account you create there is the administrator.
+
+    If you would rather not leave the terminal, the same registration works over the container's own loopback address:
+
+    ```bash
+    cpln workload exec {release}-open-webui --gvc {gvc} --container open-webui -- \
+      curl -sS -X POST http://localhost:8080/api/v1/auths/signup \
+      -H 'Content-Type: application/json' \
+      -d '{"name":"Admin","email":"admin@example.com","password":"YOUR-STRONG-PASSWORD"}'
+    ```
+
+    The response carries `"role":"admin"`. A second registration attempt returns `403`, because only the first account is exempt from `auth.enableSignup: false`.
+  </Step>
+  <Step title="Publish the UI">
+    Now that the admin account is claimed, upgrade the release with `publicAccess.enabled: true` and sign in at the canonical endpoint. Allow up to a couple of minutes for the firewall change to take effect — a measured toggle moved through `403` → `503` → `200` over about 143 seconds.
+  </Step>
+</Steps>
+
+<Warning>
+**Do not plan to close sign-ups later with an upgrade — it does nothing.** `auth.enableSignup` is read only while no account exists. Creating the first account writes the setting into `webui.db`, and from then on the stored value wins over the environment: an upgrade can neither open nor close self-registration. Add users, or re-open self-service sign-ups, from **Admin Settings → Users** in the UI.
+</Warning>
+
 ## Configuration
 
 The default `values.yaml` for this template:
 
 ```yaml
+# ─── Image & Resources ────────────────────────────────────────────────────────
 image: ghcr.io/open-webui/open-webui:v0.11.0
 
 resources:
@@ -79,6 +148,7 @@ volumeset:
 
 # ─── Backup ───────────────────────────────────────────────────────────────────
 # Platform-managed crash-consistent snapshots (no cloud account/bucket needed).
+# SQLite recovers cleanly from a snapshot. A final snapshot is taken on uninstall.
 backup:
   enabled: true
   schedule: "0 3 * * *" # cron in UTC — daily 03:00 (hourly is the platform max)
@@ -86,10 +156,15 @@ backup:
 
 # ─── Authentication ───────────────────────────────────────────────────────────
 auth:
-  # Signs sessions/JWTs. Override ONCE at install (openssl rand -base64 32).
-  # Must stay STABLE across upgrades — changing it logs every user out.
-  webuiSecretKey: "CHANGE-ME-openssl-rand-base64-32-abcdEFGH1234"
-  enableSignup: true # first registered user becomes ADMIN — turn OFF after onboarding
+  # REQUIRED opaque secret (encoding: plain) holding the session/JWT signing key.
+  # It must EXIST BEFORE INSTALL — the deployment wedges waiting on it otherwise —
+  # and must stay the same forever: replacing it logs every user out.
+  # Create it with: printf '%s' "$(openssl rand -base64 32)" | cpln secret create-opaque --name my-openwebui-secret-key --encoding plain -f -
+  secretKeyName: my-openwebui-secret-key
+  # false = nobody can create their own account. The FIRST account is exempt, so
+  # you can still register the admin on a fresh install (see the README first-run
+  # steps); invite everyone else from Admin Settings → Users.
+  enableSignup: false
 
 # ─── Model backends ───────────────────────────────────────────────────────────
 # Point at an existing `ollama` template deployment in this same GVC.
@@ -107,14 +182,22 @@ openai:
   apiKeySecretName: "" # e.g. my-openwebui-openai-key ; empty = OpenAI backend off
 
 # ─── Access ───────────────────────────────────────────────────────────────────
+# Sets WEBUI_URL only — it does NOT create a cpln domain. Create and verify the
+# domain separately, or the hostname will not resolve. Read at FIRST BOOT ONLY
+# (see Important Notes); set it at install, not in a later upgrade.
 customDomain: "" # full URL, e.g. https://chat.example.com ; empty = canonical *.cpln.app
 
 publicAccess:
-  enabled: true # serve the UI over public HTTPS on the canonical *.cpln.app endpoint
+  # false = not reachable from the internet. Turning this on publishes the chat
+  # UI, and its sign-in/sign-up form, to the whole internet — so register your
+  # admin account FIRST (see the README first-run steps), then turn it on.
+  enabled: false
 
 internalAccess: # inbound firewall scope for in-GVC callers of the Open WebUI API
   type: none # options: none, same-gvc, same-org, workload-list
   workloads: [] # used with workload-list
+  # workloads:
+  #   - //gvc/GVC_NAME/workload/WORKLOAD_NAME
 ```
 
 ### Instance & Resources
@@ -125,7 +208,7 @@ internalAccess: # inbound firewall scope for in-GVC callers of the Open WebUI AP
 
 ### Backup
 
-Scheduled, crash-consistent snapshots of the data volume, managed by the platform — no cloud account or bucket is required. See [Backing Up](#backing-up) for how snapshots and restores work.
+Scheduled, crash-consistent snapshots of the data volume, managed by the platform — no cloud account or bucket is required. See [Backing Up](#backing-up) for how snapshots work and [Restoring a Backup](#restoring-a-backup) for the manual restore procedure.
 
 - `backup.enabled` — Take periodic snapshots of the data volume (default `true`).
 - `backup.schedule` — Cron expression in UTC (default `0 3 * * *`, daily at 03:00). The platform does not accept schedules more frequent than hourly.
@@ -133,27 +216,31 @@ Scheduled, crash-consistent snapshots of the data volume, managed by the platfor
 
 ### Authentication
 
-- `auth.webuiSecretKey` — Signs session tokens and JWTs. Override it **once** at install with `openssl rand -base64 32`, then keep it stable forever — see [Important Notes](#important-notes).
-- `auth.enableSignup` — Open registration on the public endpoint (default `true` so a fresh install is usable). The first account registered becomes the admin; **turn this off after onboarding** — see [Important Notes](#important-notes).
+- `auth.secretKeyName` — Name of the opaque secret holding the session and JWT signing key. It must exist **before** you install (see [Prerequisites](#prerequisites)) and must never change afterward.
+- `auth.enableSignup` — Whether users can create their own accounts (default `false`). The **first** account on a fresh install is exempt, so a default install is still usable — that is how you create the admin in [First Run](#first-run).
 
-### Model backends
+<Warning>
+`auth.enableSignup` only has an effect while no account exists. Once the first account is created the value is stored in `webui.db` and the stored setting wins permanently, so changing this knob in a later `helm upgrade` has no effect in either direction. Manage users and self-registration from **Admin Settings → Users**.
+</Warning>
+
+### Model Backends
 
 At least one backend is needed to actually chat. The Ollama backend is on by default; the OpenAI-compatible backend is off until you supply a key secret. You can enable both.
 
 - `ollama.enabled` — Connect to an existing Ollama workload in this GVC (default `true`).
 - `ollama.workloadName` — The Ollama workload's name in this GVC. The base URL is derived as `http://{workloadName}.{gvc}.cpln.local:{port}`.
 - `ollama.port` — The Ollama API port (default `11434`).
-- `openai.baseUrl` — Any OpenAI-compatible endpoint (default `https://api.openai.com/v1`).
-- `openai.apiKeySecretName` — Name of your pre-created opaque secret holding the API key (see [Prerequisites](#prerequisites)). Empty (default) leaves the OpenAI backend off.
+- `openai.baseUrl` — Any OpenAI-compatible endpoint (default `https://api.openai.com/v1`). The workload's outbound firewall is open, so hosted providers such as `api.openai.com` are reachable.
+- `openai.apiKeySecretName` — Name of your pre-created opaque secret holding the API key (see [Prerequisites](#prerequisites)). Empty (default) leaves the OpenAI backend off, and the policy grants no access to any key secret.
 
 <Warning>
-Model-backend settings are read from the environment only on the **first** boot and are then stored in the app database. Changing `ollama.workloadName` or `openai.*` via a later `helm upgrade` is ignored — update model connections afterward from the admin UI under **Settings → Connections**. See [Important Notes](#important-notes).
+**Backend settings apply on the first boot only, and a later change fails silently.** `ollama.*`, `openai.*` and `customDomain` are read from the environment the first time the workload starts and are then stored in `webui.db`; a later `helm upgrade` is ignored. The danger is that nothing looks wrong — the **original backend keeps working**, so a user who "retargets" their model provider by upgrade sees the upgrade succeed and keeps talking to the old provider. Set these at install, and change model connections afterward from the admin UI under **Settings → Connections**.
 </Warning>
 
 ### Access
 
-- `customDomain` — Full URL of a custom domain, e.g. `https://chat.example.com`. Empty (default) uses the canonical `*.cpln.app` endpoint.
-- `publicAccess.enabled` — Serve the UI over public HTTPS on the canonical `*.cpln.app` endpoint (default). When disabled, external requests are blocked at the edge and only in-GVC callers reach it per `internalAccess`.
+- `customDomain` — Full URL of a custom domain, e.g. `https://chat.example.com`. The scheme is required; the chart fails the render without it. Empty (default) uses the canonical `*.cpln.app` endpoint.
+- `publicAccess.enabled` — Serve the UI over public HTTPS on the canonical `*.cpln.app` endpoint (default `false`). While it is off, external requests are rejected at the edge with `403` and only in-GVC callers reach the workload, per `internalAccess`.
 - `internalAccess.type` — Internal firewall scope for in-GVC callers of the Open WebUI API:
 
 | Type | Description |
@@ -163,18 +250,28 @@ Model-backend settings are read from the environment only on the **first** boot 
 | `same-org` | Allow access from all workloads in the same organization. |
 | `workload-list` | Allow access only from workloads listed in `internalAccess.workloads`. |
 
+<Warning>
+**`customDomain` sets `WEBUI_URL` and nothing else.** It does not create a Control Plane [domain](/guides/configure-domain), and the install succeeds with no error or warning if none exists — the hostname simply never resolves, and the canonical endpoint remains the only way in. Create and verify the domain separately. Because it is also frozen after the first boot, set it at install rather than adding it to a running release.
+</Warning>
+
+An access change takes effect at the edge after a short propagation delay — allow up to a couple of minutes before concluding a firewall knob did not work.
+
 ## Connecting
 
 | What | Value |
 |---|---|
-| Web UI (public) | `https://<canonical>.cpln.app` — `status.canonicalEndpoint` of `{release}-open-webui` |
-| Internal (if opened) | `http://{release}-open-webui.{gvc}.cpln.local:8080` |
+| Web UI (public) | `https://<canonical>.cpln.app` — only with `publicAccess.enabled: true`; read `status.canonicalEndpoint` of `{release}-open-webui` |
+| From your machine, no public access | `cpln port-forward {release}-open-webui 8080:8080 --gvc {gvc}`, then `http://localhost:8080` — works regardless of both firewall settings |
+| Internal API | `http://{release}-open-webui.{gvc}.cpln.local:8080` — only when `internalAccess.type` allows the caller |
 | Ollama backend | `http://{ollama.workloadName}.{gvc}.cpln.local:11434` (the existing Ollama workload) |
-| Login | The account you register in the UI — the first registration becomes the admin |
+| Login | The account you register at first run — the first registration becomes the admin |
+| Session signing key | The payload of your `auth.secretKeyName` secret; never in the Helm release |
 
 ### Using a Model Backend
 
-Deploy the [Ollama](/template-catalog/templates/ollama) template into the same GVC and pull at least one model, then install Open WebUI with `ollama.workloadName` set to that workload's name — its models appear in the model picker automatically. To use a hosted provider instead, create the API-key secret (see [Prerequisites](#prerequisites)), set `openai.apiKeySecretName`, and Open WebUI lists that provider's models. If a configured Ollama backend is unreachable the UI still boots and simply shows no Ollama models — confirm `ollama.workloadName` names a `ready` Ollama workload in the same GVC.
+Deploy the [Ollama](/template-catalog/templates/ollama) template into the same GVC and pull at least one model, then install Open WebUI with `ollama.workloadName` set to that workload's name — its models appear in the model picker automatically. To use a hosted provider instead, create the API-key secret (see [Prerequisites](#prerequisites)), set `openai.apiKeySecretName`, and Open WebUI lists that provider's models.
+
+If a configured Ollama backend is unreachable the UI still boots and simply shows no Ollama models — an empty model list is the symptom of a wrong `ollama.workloadName`. Confirm it names a `ready` Ollama workload in the same GVC.
 
 ## Backing Up
 
@@ -195,10 +292,10 @@ Snapshots live in the platform storage layer alongside the volume, not off-site.
 
 ## Restoring a Backup
 
-Restore is **in-place** on the release's own volume set: the platform provisions a fresh volume from the chosen snapshot and swaps it in, then the workload restarts to remount it.
+**There is no automated restore.** `backup.enabled` only takes snapshots; recovering from one is a manual, deliberate operation you run yourself. Restore is **in-place** on the release's own volume set: the platform provisions a fresh volume from the chosen snapshot and swaps it in, then the workload restarts to remount it.
 
 <Warning>
-Restoring reverts the volume to the exact snapshot state — any changes made after that snapshot are lost — and restarts the single-replica workload, so the UI is briefly unavailable during the swap.
+Restoring reverts the volume to the exact snapshot state, so **everything written after the snapshot is gone — including user accounts**. A user who registered after the snapshot was taken can no longer sign in. It also restarts the single-replica workload, so the UI is unavailable during the swap.
 </Warning>
 
 <Steps>
@@ -219,21 +316,26 @@ Restoring reverts the volume to the exact snapshot state — any changes made af
       --volume-index 0 \
       --gvc {gvc}
     ```
+
+    A measured restore took about 2.5 minutes end to end, of which roughly 40 seconds was workload downtime.
   </Step>
   <Step title="Verify">
-    Once the workload is ready again, log in and confirm your chats and settings are present.
+    Once the workload is ready again, sign in and confirm your chats and settings are present.
   </Step>
 </Steps>
 
 ## Important Notes
 
+- **Create the session-key secret before installing, and never change it.** `auth.secretKeyName` only names the secret; the workload wedges waiting on one that does not exist. The key signs every session and JWT, so replacing it logs every user out.
+- **The first account registered becomes the administrator.** That is why the UI ships private with sign-ups closed — an unclaimed admin account on a public URL belongs to whoever finds it first. Claim it over a port-forward before turning `publicAccess.enabled` on; see [First Run](#first-run).
+- **`auth.enableSignup` is only read while no account exists.** After the first account it is stored in `webui.db` and the stored value wins, so a later `helm upgrade` can neither open nor close sign-ups. Use **Admin Settings → Users** instead.
+- **`ollama.*`, `openai.*` and `customDomain` apply at install, then persist in the app database.** A later `helm upgrade` is ignored and the old backend keeps working, so there is no symptom to warn you. Change model connections from the admin UI under **Settings → Connections**.
+- **`customDomain` does not create a domain.** It sets `WEBUI_URL` only; create the Control Plane domain and its DNS separately, or the hostname will not resolve while the install reports success.
+- **Restoring a snapshot is manual and loses post-snapshot data**, including accounts created after it was taken. See [Restoring a Backup](#restoring-a-backup).
+- **Single replica, by design.** The embedded SQLite is single-writer and the volume set is per-replica, so the workload is pinned to one replica with no `replicas` knob. A restart or upgrade is a brief full outage of about a minute — including the first `helm upgrade` after an install, which re-applies the workload even when nothing changed.
+- **Data lives only on the volume set.** Uninstall deletes it (a final snapshot is taken first); a reinstall starts empty, including the admin account. Your own prerequisite secrets are not deleted, since the chart does not own them.
+- **Ollama unreachable is non-fatal.** The UI boots and shows no Ollama models rather than failing, so check the model list after install.
 - **License / branding clause** — You must keep the "Open WebUI" branding visible in the UI **unless** your deployment serves 50 or fewer users, or you have enterprise permission. Removing the branding outside those cases violates the license; it is not a template setting.
-- **The first user to register becomes the admin.** Sign-ups are open by default so the install is immediately usable, which means anyone reaching the public endpoint can register while it is open. Register your admin account first, then set `auth.enableSignup=false` to lock it down.
-- **`auth.webuiSecretKey` must never change after first install.** It is the key that signs session tokens and JWTs. Rotating it — or letting a fresh volume regenerate one — logs every user out. Override it once with `openssl rand -base64 32` and keep it stable.
-- **Single replica, by design.** The embedded SQLite is single-writer and the volume set is per-replica, so the workload is pinned to one replica with no `replicas` knob. A restart or upgrade is a brief full outage (about a minute).
-- **Model-backend settings apply at install, then persist in the app database.** `ollama.workloadName` and `openai.*` are read from the environment only on the first boot and then stored in `webui.db`. Changing them via a later `helm upgrade` is silently ignored — update model connections afterward from the admin UI (**Settings → Connections**).
-- **Data lives only on the volume set.** Uninstall deletes it (a final snapshot is taken first); a reinstall starts empty. Changing the secret and redeploying does not re-key existing data.
-- **Backups are in-platform, not off-site.** Scheduled snapshots and the final snapshot on uninstall live in the platform storage layer next to the volume; losing the whole GVC would lose them too. See [Backing Up](#backing-up).
 
 ## External References
 

--- a/template-catalog/templates/tyk.mdx
+++ b/template-catalog/templates/tyk.mdx
@@ -11,7 +11,7 @@ Tyk is an open-source API management platform that controls, secures, and monito
 Your API definitions and policies come from Control Plane secrets you control, and the Gateway Control API key — the credential that creates and revokes every API key on the gateway — comes from an [opaque secret](/guides/create-secret/opaque) you create before installing.
 
 <Warning>
-**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped three defaults that compounded: the Gateway Control API key was the `values.yaml` value `mysecret`, `externalAccess` defaulted to `true` so that API was on the public internet, and `TYK_GW_ALLOWMASTERKEYS` was hardcoded to `true` so a key created with no `access_rights` reached every API on the gateway. One guessed word yielded a key to everything. In 1.3.0 the admin key moved to a prerequisite secret, external access defaults to off, and master keys are a knob that defaults to off — **the last two change the behavior of an existing install when you upgrade.**
+**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped three defaults that compounded: the Gateway Control API key was the `values.yaml` value `mysecret`, `externalAccess` defaulted to `true` so that API was on the public internet, and `TYK_GW_ALLOWMASTERKEYS` was hardcoded to `true` so a key created with no `access_rights` reached every API on the gateway. One guessed word yielded a key to everything. In 1.3.0 the admin key moved to a prerequisite secret, external access defaults to off, master keys are a knob that defaults to off, and `internalAccess.type` now defaults to `same-gvc` instead of `none` — **those last three change the behavior of an existing install when you upgrade, and the internal-access change widens in-GVC reachability rather than narrowing it.**
 </Warning>
 
 <Note>
@@ -21,7 +21,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 ### What Gets Created
 
 - **Standard Tyk Gateway Workload** (`RELEASE_NAME-tyk-api-gateway`) — the gateway process, autoscaling between `minScale` and `maxScale` replicas on CPU. API definitions and policies are mounted from your secrets at startup.
-- **Redis and Redis Sentinel** — the [Redis](/template-catalog/templates/redis) template (v3.4.2) is deployed as a subchart, creating a Redis workload, a Sentinel workload, their volume sets, and their config and password secrets. The gateway connects through Sentinel, not to Redis directly.
+- **Redis and Redis Sentinel** — the [Redis](/template-catalog/templates/redis) template (v3.4.2) is deployed as a subchart, creating a Redis workload, a Sentinel workload, their volume sets, their config and password secrets, and an identity and policy for each (`RELEASE_NAME-redis-identity`, `RELEASE_NAME-sentinel-identity`, `RELEASE_NAME-redis-policy`, `RELEASE_NAME-sentinel-policy`). The gateway connects through Sentinel, not to Redis directly.
 - **Identity & Policy** — an identity (`RELEASE_NAME-tyk-identity`) bound to the gateway with `reveal` on exactly the secrets it mounts: your admin secret, your API and policy secrets when set, and the bundled Redis and Sentinel password secrets.
 - **No template-created credential secret** — the admin API key lives only in the prerequisite secret you create.
 
@@ -318,7 +318,7 @@ cpln secret reveal my-tyk-admin-secret
 ## Upgrading From 1.2.1 or Earlier
 
 <Warning>
-**Two defaults change behavior on upgrade: the gateway stops being reachable from the internet, and key-creation requests without `access_rights` start failing.** Neither is a fault; both will surprise you if you have not planned for them.
+**Three defaults change behavior on upgrade: the gateway stops being reachable from the internet, key-creation requests without `access_rights` start failing, and the internal firewall opens from `none` to `same-gvc` so every workload in the GVC can now reach the gateway.** None is a fault; all three will surprise you if you have not planned for them — set `internalAccess.type` explicitly if you want the old, closed behavior.
 </Warning>
 
 | Behavior | 1.2.1 and earlier | 1.3.0 |

--- a/template-catalog/templates/tyk.mdx
+++ b/template-catalog/templates/tyk.mdx
@@ -1,12 +1,18 @@
 ---
 title: Tyk
-description: Deploy Tyk on Control Plane using the Template Catalog. Covers configuration, scaling, and API gateway management with Redis-backed token storage, rate limiting, and analytics.
-keywords: ['api gateway', 'kong alternative', 'apigee alternative', 'developer portal', 'oauth gateway', 'api auth', 'api throttle', 'api management', 'gateway proxy']
+description: Deploy Tyk on Control Plane using the Template Catalog. An API gateway with authentication, rate limiting, quotas and analytics, backed by Redis Sentinel, with the admin API key held in a prerequisite secret and no public access by default.
+keywords: ['api gateway', 'kong alternative', 'apigee alternative', 'developer portal', 'oauth gateway', 'api auth', 'api throttle', 'api management', 'gateway proxy', 'master keys', 'prerequisite secret', 'redis sentinel']
 ---
 
 ## Overview
 
-Tyk is an open-source API management platform that controls, secures, and monitors API traffic. This template deploys a Tyk API Gateway workload on Control Plane alongside Redis and Redis Sentinel, which serve as the backing store for tokens, analytics, rate limits, and gateway state.
+Tyk is an open-source API management platform that controls, secures, and monitors API traffic. This template deploys a Tyk Gateway workload on Control Plane alongside Redis and Redis Sentinel, which back the gateway's token, rate-limit, quota, and analytics storage.
+
+Your API definitions and policies come from Control Plane secrets you control, and the Gateway Control API key — the credential that creates and revokes every API key on the gateway — comes from an [opaque secret](/guides/create-secret/opaque) you create before installing.
+
+<Warning>
+**Version 1.3.0 is a security fix. Read [Upgrading From 1.2.1 or Earlier](#upgrading-from-1-2-1-or-earlier) before you upgrade.** Versions up to 1.2.1 shipped three defaults that compounded: the Gateway Control API key was the `values.yaml` value `mysecret`, `externalAccess` defaulted to `true` so that API was on the public internet, and `TYK_GW_ALLOWMASTERKEYS` was hardcoded to `true` so a key created with no `access_rights` reached every API on the gateway. One guessed word yielded a key to everything. In 1.3.0 the admin key moved to a prerequisite secret, external access defaults to off, and master keys are a knob that defaults to off — **the last two change the behavior of an existing install when you upgrade.**
+</Warning>
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -14,18 +20,28 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ### What Gets Created
 
-- **Standard Workload** — Tyk API Gateway (`RELEASE_NAME-tyk-api-gateway`): the gateway process, autoscaling between `minScale` and `maxScale` replicas. API definitions and policies are mounted from Control Plane secrets at startup.
-- **Secret** — Gateway admin secret (`RELEASE_NAME-tyk-gateway-secret`): a dictionary secret containing the admin API key used for management operations.
-- **Identity & Policy** — An identity (`RELEASE_NAME-tyk-identity`) bound to the gateway workload with `reveal` access to the gateway secret, Redis auth secrets, and optionally the API definitions and policy secrets.
-- **Redis and Redis Sentinel** — The [Redis](/template-catalog/templates/redis) template (v3.1.1) is deployed as a dependency, creating a Redis workload, a Sentinel workload, and their associated secrets, identities, and policies.
+- **Standard Tyk Gateway Workload** (`RELEASE_NAME-tyk-api-gateway`) — the gateway process, autoscaling between `minScale` and `maxScale` replicas on CPU. API definitions and policies are mounted from your secrets at startup.
+- **Redis and Redis Sentinel** — the [Redis](/template-catalog/templates/redis) template (v3.4.2) is deployed as a subchart, creating a Redis workload, a Sentinel workload, their volume sets, and their config and password secrets. The gateway connects through Sentinel, not to Redis directly.
+- **Identity & Policy** — an identity (`RELEASE_NAME-tyk-identity`) bound to the gateway with `reveal` on exactly the secrets it mounts: your admin secret, your API and policy secrets when set, and the bundled Redis and Sentinel password secrets.
+- **No template-created credential secret** — the admin API key lives only in the prerequisite secret you create.
 
 ## Prerequisites
 
-Tyk loads API definitions and policies from files at startup. You must create the corresponding Control Plane secrets **before** deploying the template.
+**The admin secret must exist before you install**, and you will normally want the API and policy secrets too. All are referenced by name only, so none of their contents pass through Helm values or land in the release.
 
-### 1. Create the API Definitions Secret
+### 1. Admin API Key (Required)
 
-Each key in the dictionary is a filename (e.g. `app1.json`) containing a Tyk API definition object. Create the secret using `cpln apply`:
+This is `TYK_GW_SECRET`, the key for the Gateway Control API served under `/tyk/*` and sent as the `X-Tyk-Authorization` header. Whoever holds it can create, list, and revoke every API key on the gateway, so generate a strong random value:
+
+```bash
+printf '%s' "$(openssl rand -hex 32)" | cpln secret create-opaque --name my-tyk-admin-secret --encoding plain -f -
+```
+
+Set `adminSecretName` to the name you used. The chart refuses to render without it.
+
+### 2. API Definitions (Optional)
+
+A [dictionary secret](/guides/create-secret/dictionary) whose keys are `*.json` filenames and whose values are Tyk API definitions, mounted at `/opt/tyk-gateway/apps`. Because the values are multi-line JSON, write a manifest and apply it:
 
 ```yaml
 kind: secret
@@ -44,11 +60,19 @@ data:
     "active": true}
 ```
 
-Set `apiSecretName` in your values to the name of this secret. To omit API definitions entirely, leave `apiSecretName` empty.
+```bash
+cpln apply -f my-tyk-apis.yaml
+```
 
-### 2. Create the Policies Secret
+Set `apiSecretName` to the name you used.
 
-The policies secret is a single opaque secret containing a JSON object where each key is a policy ID:
+<Warning>
+**Leaving `apiSecretName` empty does not serve nothing — it serves Tyk's demo API.** With no definitions mounted, the gateway falls back to the API definitions baked into the upstream image and boots serving `Tyk Test API`. The install looks entirely healthy — the workload is ready and `/hello` reports `redis: pass` — while serving none of your APIs. Set the secret, or expect the vendor demo endpoint on your listener.
+</Warning>
+
+### 3. Policies (Optional)
+
+An [opaque secret](/guides/create-secret/opaque) with encoding `plain`, holding a single JSON object of policies keyed by policy ID, mounted at `/opt/tyk-gateway/policies/policies.json`:
 
 ```yaml
 kind: secret
@@ -79,7 +103,15 @@ data:
     }
 ```
 
-Set `policySecretName` in your values to the name of this secret. To omit policies entirely, leave `policySecretName` empty.
+```bash
+cpln apply -f my-tyk-policies.yaml
+```
+
+Set `policySecretName` to the name you used, or leave it `""` to run with no policies. You can edit both secrets independently after install, as long as their names stay the same.
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, every resource is created, and the gateway then never becomes ready — with no container logs at all, because the container never started. The only place the reason appears is `cpln workload get-deployments RELEASE_NAME-tyk-api-gateway --gvc GVC_NAME`, as `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` Create the secrets first and check the deployment rather than trusting the Helm output.
+</Warning>
 
 ## Installation
 
@@ -114,13 +146,25 @@ The default `values.yaml` for this template:
 ```yaml
 image: tykio/tyk-gateway:v5.10.0
 
-listenPort: 8080 # REQUIRED - The port exposed on the Tyk workload
+listenPort: 8080 # REQUIRED - the port the gateway listens on
 
-apiSecretName: my-tyk-apis # REQUIRED - The name of the pre-configured Control Plane secret that contains your API definitions
-policySecretName: my-tyk-policies # REQUIRED - The name of the pre-configured Control Plane secret that contains your policies
-# Note: if you wish to omit one of these secrets, leave the value empty and it will be omitted from the workload's configuration
+# ─── Prerequisite secrets ─────────────────────────────────────────────────────
+# All three must EXIST BEFORE INSTALL. See README Prerequisites for the exact
+# `cpln secret create-*` commands.
 
-adminSecret: mysecret # REQUIRED - The value you set to be the admin API key for management of Tyk
+# The admin secret is the Gateway Control API key (X-Tyk-Authorization on /tyk/*),
+# which creates, lists and revokes API keys — so it never transits Helm values.
+adminSecretName: my-tyk-admin-secret # REQUIRED - opaque secret (encoding: plain) holding the admin API key
+
+# These two are OPTIONAL — set either to "" to omit it. But note what happens if
+# you omit the APIs: the gateway falls back to the demo API definitions baked
+# into the upstream image and will happily serve "Tyk Test API" instead of
+# nothing, which looks like a working install until you notice it is not yours.
+apiSecretName: my-tyk-apis # dictionary secret holding your API definition JSON files; "" = serve the image's demo APIs
+policySecretName: my-tyk-policies # opaque secret holding your policies JSON; "" = no policies
+
+# ─── Gateway ──────────────────────────────────────────────────────────────────
+allowMasterKeys: false # true lets a key created with no access_rights reach EVERY API on this gateway
 
 resources:
   cpu: 50m
@@ -135,24 +179,26 @@ autoscaling:
 
 multiZone: false # OPTIONAL - Deploys replicas across multiple zones (confirm availability in your location)
 
-externalAccess: true # OPTIONAL - Set to true to expose the workload to the internet; set to false for internal-only access
+# ─── Access ───────────────────────────────────────────────────────────────────
+externalAccess: false # true publishes the gateway — INCLUDING its /tyk admin API — to the internet
 internalAccess: # OPTIONAL - Sets the internal firewall scope
-  type: none # options: none, same-gvc, same-org, workload-list
-  workloads:  # Note: can only be used if type is same-gvc or workload-list
-    #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
+  type: same-gvc # options: none, same-gvc, same-org, workload-list
+  workloads: [] # used with workload-list, e.g. //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
+# ─── Bundled Redis + Sentinel ─────────────────────────────────────────────────
+# Tyk's token, rate-limit and analytics store. It serves this gateway only and is
+# never reachable from outside the GVC, so the passwords are template plumbing —
+# but they are used AS-IS, so change them before installing.
 redis:
   redis:
     resources:
       cpu: 200m
       memory: 256Mi
-      minCpu: 80m
-      minMemory: 128Mi
     replicas: 2
     auth:
       password:
         enabled: true
-        value: myRedisPassword
+        value: change-me-tyk-redis
     firewall:
       internal_inboundAllowType: same-gvc
     persistence:
@@ -161,92 +207,181 @@ redis:
     resources:
       cpu: 200m
       memory: 256Mi
-      minCpu: 80m
-      minMemory: 128Mi
     replicas: 3
     auth:
       password:
         enabled: true
-        value: mySentinelPassword
+        value: change-me-tyk-sentinel
     firewall:
       internal_inboundAllowType: same-gvc
     persistence:
       enabled: true
 ```
 
-### API Definitions & Policies
+### API Definitions and Policies
 
-- `apiSecretName` — Name of the pre-existing Control Plane secret containing API definitions. Each key in the dictionary is a JSON filename mounted at `/opt/tyk-gateway/apps`. **Must be created before deploying.**
-- `policySecretName` — Name of the pre-existing Control Plane opaque secret containing the policies JSON, mounted at `/opt/tyk-gateway/policies/policies.json`. **Must be created before deploying.**
+- `apiSecretName` — name of the dictionary secret holding your API definitions. Each key is a JSON filename mounted at `/opt/tyk-gateway/apps`. Set to `""` to omit the mount — but see the demo-API warning in [Prerequisites](#2-api-definitions-optional).
+- `policySecretName` — name of the opaque secret holding your policies JSON, mounted at `/opt/tyk-gateway/policies/policies.json`. Set to `""` to run with no policies.
+- `listenPort` — the port the gateway listens on. Control Plane reserves a set of container ports; the chart refuses to render on one of them rather than letting the workload be rejected at apply time.
 
-Leave either value empty to omit that mount from the gateway workload.
+Both secrets are read at boot. After editing either one, redeploy the gateway workload or call `/tyk/reload` for the change to take effect.
 
-### Admin Secret
+### Master Keys
 
-- `adminSecret` — The admin API key used for gateway management operations (e.g. creating keys, reloading APIs). **Change before deploying to production.** Stored in a dictionary secret and injected into the gateway at startup.
+- `allowMasterKeys` — when `true`, a key created through `/tyk/keys` with no `access_rights` section can call **every** API on this gateway. **Defaults to `false`**, matching upstream Tyk.
 
-### Resources & Autoscaling
+<Warning>
+**This default changed in 1.3.0 and it will break key-creation requests that used to work.** Versions up to 1.2.1 hardcoded master keys on, so any request that POSTed a bare session object was silently granted blanket access. With `allowMasterKeys: false`, the same request is refused — the exact response depends on the endpoint:
 
-- `resources.cpu` / `resources.memory` — CPU and memory allocated to the Tyk Gateway workload.
-- `autoscaling.minScale` / `autoscaling.maxScale` — Minimum and maximum number of gateway replicas.
-- `autoscaling.metric` — Scaling metric (`cpu` by default).
-- `autoscaling.target` — Target metric value that triggers a scale-up.
-- `autoscaling.scaleToZeroDelay` — Seconds of inactivity before scaling to zero (only applies when `minScale` is `0`).
-- `multiZone` — When `true`, spreads replicas across availability zones within the location.
+| Request | Response |
+|---|---|
+| `POST /tyk/keys/create` with `"access_rights": {}` | `400` — `Failed to create key, keys must have at least one Access Rights record set.` |
+| `POST /tyk/keys/{custom-key}` with `"access_rights": {}` | `500` — `Failed to create key, ensure security settings are correct.` |
+
+In both cases the gateway logs the real reason: `Master keys disallowed in configuration, key not added.` with `err="master keys disabled"`. The fix is to give each key an `access_rights` entry naming the APIs it may reach; setting `allowMasterKeys: true` restores the old behavior and the old exposure.
+</Warning>
 
 ### Access
 
-- `externalAccess` — Set to `true` to expose the gateway publicly. Set to `false` for internal-only access.
-- `internalAccess.type` — Controls which workloads can connect to the gateway internally:
+- `externalAccess` — when `true`, the gateway's external inbound firewall opens to `0.0.0.0/0` and Control Plane assigns a `*.cpln.app` canonical endpoint. **Defaults to `false`.**
+- `internalAccess.type` — which workloads inside Control Plane may reach the gateway. **Defaults to `same-gvc`.**
+- `internalAccess.workloads` — list of workload links, used only when `type` is `workload-list`.
 
 | Type | Description |
 |------|-------------|
 | `none` | No internal access allowed |
 | `same-gvc` | Allow access from all workloads in the same GVC |
 | `same-org` | Allow access from all workloads in the same organization |
-| `workload-list` | Allow access only from specific workloads listed in `workloads` |
+| `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads` |
 
-- `internalAccess.workloads` — List of specific workload links, used when `type` is `workload-list`.
+<Warning>
+**`externalAccess: true` puts the Tyk admin API on the public internet.** `/tyk/*` is served on the same port as your proxied APIs and cannot be split onto another listener, so publishing the gateway publishes its key-management API with it and the admin secret becomes the only thing in front of it. Prefer leaving it `false` and reaching the gateway from inside the GVC.
+</Warning>
 
-### Redis
+<Note>
+Setting `externalAccess: false` together with `internalAccess.type: none` would leave nothing able to reach the gateway, so the chart fails the render with a message naming both knobs instead of installing something unreachable.
 
-The Redis subchart is configured under the `redis` key. See the [Redis template](/template-catalog/templates/redis) for full configuration details. Key options:
+**An access change takes up to a couple of minutes to take effect.** Enabling external access was measured at 30 seconds from upgrade to the first `200`, and closing internal access at about 32 seconds; re-poll before concluding a knob did nothing. Note that a request blocked by the internal firewall **times out** rather than returning `403` — a hang is what a correctly closed internal firewall looks like here, not a sign that the gateway is down.
+</Note>
 
-- `redis.redis.replicas` — Number of Redis replicas.
-- `redis.redis.auth.password.enabled` / `redis.redis.auth.password.value` — Redis password authentication. **Change before deploying to production.**
-- `redis.redis.persistence.enabled` — Persist Redis data to a volume set.
-- `redis.sentinel.replicas` — Number of Sentinel replicas (3 recommended for production).
-- `redis.sentinel.auth.password.enabled` / `redis.sentinel.auth.password.value` — Sentinel password authentication. **Change before deploying to production.**
-- `redis.sentinel.persistence.enabled` — Persist Sentinel state to a volume set.
+### Resources and Autoscaling
 
-### Connecting to the Gateway
+- `resources.cpu` / `resources.memory` — CPU and memory allocated to the gateway workload.
+- `autoscaling.minScale` / `autoscaling.maxScale` — minimum and maximum number of gateway replicas.
+- `autoscaling.metric` — scaling metric (`cpu` by default).
+- `autoscaling.target` — target metric value that triggers a scale-up.
+- `autoscaling.scaleToZeroDelay` — seconds of inactivity before scaling to zero (only applies when `minScale` is `0`).
+- `multiZone` — when `true`, spreads replicas across availability zones within the location.
 
-Access the gateway from within the same GVC at:
+### Redis and Sentinel
 
-```text
-RELEASE_NAME-tyk-api-gateway.GVC_NAME.cpln.local:8080
+The bundled Redis is configured under the `redis` key; see the [Redis template](/template-catalog/templates/redis) for full configuration details.
+
+- `redis.redis.replicas` — number of Redis replicas.
+- `redis.sentinel.replicas` — number of Sentinel replicas; 3 is the default and the recommended minimum for failover.
+- `redis.redis.persistence.enabled` / `redis.sentinel.persistence.enabled` — persist data and Sentinel state to volume sets.
+- `redis.redis.auth.password.value` / `redis.sentinel.auth.password.value` — the Redis and Sentinel passwords.
+
+This Redis serves only this gateway and is never reachable from outside the GVC, so its passwords remain Helm values rather than prerequisite secrets. **They are used exactly as written**, so replace both `change-me-…` placeholders before installing.
+
+### Outbound Connectivity
+
+The gateway ships with an empty outbound firewall (`outboundAllowCIDR: []`), so it cannot open connections to the public internet.
+
+<Warning>
+**Every API's `target_url` must point at an upstream inside the same GVC**, addressed over internal DNS — for example `http://my-app.GVC_NAME.cpln.local:8080`. GVC-internal traffic is governed by the destination workload's internal firewall rather than by the gateway's egress, so in-GVC proxying works normally with egress closed. To proxy to an API on the public internet, add `outboundAllowCIDR` or `outboundAllowHostname` to the gateway workload; there is no value for it in the chart.
+</Warning>
+
+## Connecting
+
+| Path | Address | Notes |
+|------|---------|-------|
+| Public gateway | `https://CANONICAL_ENDPOINT` | Only when `externalAccess` is `true`. Read the endpoint from `status.canonicalEndpoint` in `cpln workload get RELEASE_NAME-tyk-api-gateway --gvc GVC_NAME -o yaml`. |
+| Internal gateway | `http://RELEASE_NAME-tyk-api-gateway.GVC_NAME.cpln.local:8080` | Subject to `internalAccess.type`. Use `listenPort` if you changed it. |
+| Proxied API | `GATEWAY_ADDRESS/LISTEN_PATH` | `listen_path` comes from each API definition, e.g. `/app1`. |
+| Admin API | `GATEWAY_ADDRESS/tyk/keys`, `/tyk/apis`, `/tyk/reload` | Send the header `X-Tyk-Authorization` set to the payload of your `adminSecretName` secret. |
+| Health check | `GATEWAY_ADDRESS/hello` | Reports gateway version and Redis connectivity. |
+| Redis and Sentinel | `RELEASE_NAME-redis.GVC_NAME.cpln.local:6379`, `RELEASE_NAME-sentinel.GVC_NAME.cpln.local:26379` | Internal only; passwords are the `redis.*.auth.password.value` values. |
+
+Reveal the admin key when you need it:
+
+```bash
+cpln secret reveal my-tyk-admin-secret
 ```
-
-When `externalAccess` is `true`, the gateway is also reachable via its public Control Plane endpoint.
-
-The Tyk management API is available on the same port under the `/tyk/` path. Requests require the `x-tyk-authorization` header set to the value of `adminSecret`.
 
 ### Ports
 
 | Port | Protocol | Description |
 |------|----------|-------------|
-| `8080` | HTTP | API traffic and management API (`/tyk/`) |
+| `8080` | HTTP | API traffic and the admin API under `/tyk/` |
+
+## Upgrading From 1.2.1 or Earlier
+
+<Warning>
+**Two defaults change behavior on upgrade: the gateway stops being reachable from the internet, and key-creation requests without `access_rights` start failing.** Neither is a fault; both will surprise you if you have not planned for them.
+</Warning>
+
+| Behavior | 1.2.1 and earlier | 1.3.0 |
+|---|---|---|
+| Admin API key | `adminSecret` value, defaulting to `mysecret` | `adminSecretName`, naming an opaque secret you create |
+| External access | `externalAccess`, defaulting to `true` | `externalAccess`, defaulting to `false` |
+| Internal access | `internalAccess.type`, defaulting to `none` | `internalAccess.type`, defaulting to `same-gvc` |
+| Master keys | Hardcoded on, no knob | `allowMasterKeys`, defaulting to `false` |
+| Redis and Sentinel passwords | `myRedisPassword` / `mySentinelPassword` | `change-me-tyk-redis` / `change-me-tyk-sentinel` placeholders |
+| Chart-created secret | A dictionary secret holding the admin key | None for the admin key — only the bundled Redis and Sentinel secrets |
+
+What to do before upgrading:
+
+<Steps>
+  <Step title="Create the admin key secret">
+    The gateway will not start without it. Use a freshly generated value rather than carrying `mysecret` forward — it has been published in a public repository for the life of the earlier versions, and any key minted with it should be considered compromised:
+
+    ```bash
+    printf '%s' "$(openssl rand -hex 32)" | cpln secret create-opaque --name my-tyk-admin-secret --encoding plain -f -
+    ```
+
+    Set `adminSecretName` to that name and remove `adminSecret` from your values — it no longer exists in the chart. Every client calling `/tyk/*` needs the new value in its `X-Tyk-Authorization` header.
+  </Step>
+  <Step title="Decide whether the gateway should stay public">
+    If clients outside Control Plane call your APIs, set `externalAccess: true` explicitly — and understand that this also republishes `/tyk/*`. If every caller is inside the GVC, do nothing and the default `same-gvc` covers them.
+  </Step>
+  <Step title="Audit any key created without access rights">
+    Under the old hardcoded setting, such keys reach every API on the gateway. List them with `GET /tyk/keys`, then reissue each one with an `access_rights` entry naming only the APIs it needs. Requests that create bare keys now fail — see [Master Keys](#master-keys) for the exact responses.
+  </Step>
+  <Step title="Set the Redis and Sentinel passwords">
+    The placeholder defaults are used verbatim if you leave them, so set both `redis.redis.auth.password.value` and `redis.sentinel.auth.password.value` to values of your own.
+  </Step>
+</Steps>
+
+## Important Notes
+
+- **Create the admin secret before installing.** A missing secret does not fail the install — Helm reports success and the gateway then sits at zero replicas with no container logs at all.
+- **`externalAccess: true` publishes the admin API**, because `/tyk/*` shares the listener with your proxied APIs. The admin secret is then the only control in front of key creation and revocation.
+- **`allowMasterKeys: true` grants blanket access.** Any key created without `access_rights` reaches every API on the gateway. Leave it `false` unless you have a specific reason.
+- **Leaving `apiSecretName` empty serves Tyk's demo API**, not an empty gateway. The install looks healthy while none of your APIs are loaded.
+- **Egress is closed**, so every `target_url` must resolve to an in-GVC `*.cpln.local` host.
+- **Change the bundled Redis and Sentinel passwords** — they ship as `change-me-…` placeholders and are used exactly as written.
+- **The gateway declares no health probes, so `ready: true` arrives before it can serve.** A workload was ready roughly 30 seconds before it had connected to Redis, logging `storage: Redis is either down or was not configured` in between. Use `GET /hello` and check that `redis` reports `pass` rather than trusting the readiness signal, and expect the same gap when an autoscaled replica starts.
+- **Access changes take up to a couple of minutes to propagate.** A change that appears to do nothing has usually just not settled yet.
+- **The first `helm upgrade` after an install restarts the bundled Redis**, briefly interrupting rate-limit and key lookups even when nothing changed. Later no-op upgrades do not.
+- **The prerequisite secrets are not owned by the release** — your admin, API, and policy secrets survive `cpln helm uninstall` and must be deleted manually if you no longer need them.
 
 ## External References
 
 <CardGroup cols={2}>
-    <Card title="Tyk Documentation" icon="book" href="https://tyk.io/docs">
+    <Card title="Tyk Gateway Documentation" icon="book" href="https://tyk.io/docs/">
     Official Tyk API Gateway documentation
     </Card>
-    <Card title="Tyk API Definition Objects" icon="book" href="https://tyk.io/docs/5.0/tyk-gateway-api/api-definition-objects/">
+    <Card title="Gateway Configuration Options" icon="gear" href="https://tyk.io/docs/tyk-oss-gateway/configuration/">
+    Every gateway setting and its environment-variable name
+    </Card>
+    <Card title="Gateway Control API" icon="code" href="https://tyk.io/docs/api-management/gateway-config-managing-classic/">
+    Reference for the admin endpoints under /tyk/
+    </Card>
+    <Card title="API Definition Objects" icon="file-code" href="https://tyk.io/docs/api-management/gateway-config-tyk-classic/">
     Reference for the API definition JSON structure
     </Card>
-    <Card title="Tyk Policies Guide" icon="book" href="https://tyk.io/docs/5.1/basic-config-and-security/security/security-policies/policies-guide/">
+    <Card title="Security Policies" icon="shield" href="https://tyk.io/docs/api-management/policies/">
     Guide for configuring Tyk access policies
     </Card>
     <Card title="Tyk Template" icon="github" href="https://github.com/controlplane-com/templates/tree/main/tyk">

--- a/template-catalog/templates/umami.mdx
+++ b/template-catalog/templates/umami.mdx
@@ -1,12 +1,16 @@
 ---
 title: Umami
-description: Deploy Umami on Control Plane using the Template Catalog. Privacy-first, cookieless web and product analytics — a self-hosted Google Analytics alternative — with a stateless multi-replica app tier and a single-instance or highly available PostgreSQL backing store. Covers the tracking script, database modes, scaling, and optional backups.
-keywords: ['umami', 'web analytics', 'product analytics', 'privacy-first analytics', 'cookieless analytics', 'google analytics alternative', 'plausible alternative', 'matomo alternative', 'fathom alternative', 'self-hosted analytics', 'website tracking', 'umami template']
+description: Deploy Umami on Control Plane using the Template Catalog. Privacy-first, cookieless web and product analytics — a self-hosted Google Analytics alternative — backed by a single-instance or highly available PostgreSQL store. Covers the private-by-default first-run sequence, tracking, and scaling.
+keywords: ['umami', 'web analytics', 'product analytics', 'privacy-first analytics', 'cookieless analytics', 'google analytics alternative', 'plausible alternative', 'matomo alternative', 'fathom alternative', 'self-hosted analytics', 'website tracking', 'app secret', 'port forward', 'umami template']
 ---
 
 ## Overview
 
-Umami is a privacy-first, cookieless web and product analytics platform — a self-hosted, MIT-licensed alternative to Google Analytics. This template deploys the stateless Umami v3 app tier backed by PostgreSQL, serving both the analytics dashboard and the public tracking endpoint over HTTPS. You embed a small tracking script on your site; visitor events POST back to the same workload and are stored in PostgreSQL, with no cookies and no personal data collected.
+Umami is a privacy-first, cookieless web and product analytics platform — a self-hosted, MIT-licensed alternative to Google Analytics. This template deploys the stateless Umami v3 app tier backed by PostgreSQL, serving both the analytics dashboard and the tracking endpoint on the same port. You embed a small tracking script on your site; visitor events POST back to the same workload and are stored in PostgreSQL, with no cookies and no personal data collected.
+
+<Warning>
+**A new install is private, and it stays private until you publish it deliberately.** Umami seeds a hardcoded `admin` / `umami` account from its first database migration and offers no environment variable to override it, so `publicAccess.enabled` defaults to `false`. Tracking collects nothing while it is off — browsers on the sites you track must reach the tracking script and the collect endpoint. Publishing is therefore a required second step, not an optional one: follow [First Run](#first-run-sequence) in order.
+</Warning>
 
 ### Architecture
 
@@ -19,8 +23,10 @@ Umami is a privacy-first, cookieless web and product analytics platform — a se
 - **Standard Umami Workload** — One or more stateless replicas serving the UI, API, and tracking endpoint on port `3000`.
 - **Database Workloads** — Single mode: one stateful PostgreSQL workload. HA mode: a stateful Patroni PostgreSQL workload, a stateful etcd workload, and a standard HAProxy leader-routing workload.
 - **Volume Sets** — The database subchart's persistent volumes (10 GiB by default; per replica in HA mode). Umami itself has none.
-- **Secret, Identity & Policy** — A template-managed `appSecret` (dictionary secret) and a least-privilege policy granting the Umami identity `reveal` on exactly the app config secret and the active database credential secret.
+- **Identity & Policy** — A least-privilege policy granting the Umami identity `reveal` on exactly two secrets: the app secret you create, and the active database's credential secret.
 - **Cron Backup Workload** *(optional)* — When database backups are enabled.
+
+The template creates **no secret of its own**. The app secret is a prerequisite [opaque secret](/guides/create-secret/opaque) you create and own; the database credentials are created by the database subchart.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -28,9 +34,32 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-None for a default install. For optional database backups you need a bucket and access setup for one of the supported providers — see [Backing Up](#backing-up).
+**One [opaque secret](/guides/create-secret/opaque) must exist before you install.** It holds Umami's app secret, which signs auth tokens and sessions — anyone holding it can forge a login — so it is never a Helm value and never lands in the release.
 
-Install the template using your preferred method:
+<Steps>
+  <Step title="Create the app secret">
+    Generate a random value and store it as the secret's payload:
+
+    ```bash
+    printf '%s' "$(openssl rand -base64 32)" | cpln secret create-opaque --name my-umami-app-secret --encoding plain -f -
+    ```
+
+    Set `app.appSecretName` to the name you used.
+  </Step>
+  <Step title="Keep it for the life of the install">
+    The value must stay stable — changing it invalidates every issued token and logs every user out. In a multi-replica install all replicas read this one secret, which is what lets a session established against one replica be honored by another.
+  </Step>
+</Steps>
+
+<Warning>
+**A missing app secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports every resource created, but the Umami workload never starts — it sits at zero replicas. `cpln logs` shows **nothing at all**, because no container ever starts; the real reason appears only under `status.versions[].message` of `cpln workload get-deployments {release}-umami --gvc {gvc} -o yaml`, which names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.`
+
+**Creating the secret afterwards does not release the wedge on its own** — it stayed at zero replicas for nearly five minutes after the secret existed. Run `cpln workload force-redeployment {release}-umami --gvc {gvc}` to pick it up.
+</Warning>
+
+Nothing else is required for a default install. Optional: a bucket and access setup for one of the supported providers if you enable database backups — see [Backing Up](#backing-up). Change the database password (`postgres.config.password` or `postgresHA.postgres.password`) before installing as well; it ships with a `change-me` placeholder default.
+
+Once the secret exists, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -54,6 +83,62 @@ Install the template using your preferred method:
     </Card>
 </CardGroup>
 
+## First Run Sequence
+
+Umami's bootstrap admin is a hardcoded `admin` / `umami`, seeded by the first database migration, and there is no environment variable to override it — the credentials are published in Umami's own documentation. A public default install would therefore stand on the internet with known credentials, so the install starts private and you publish it once the password is changed.
+
+This is a sequence, not a lockdown: **the tracking endpoint is the product**, and collection does not work until public access is on.
+
+<Steps>
+  <Step title="Install with the default private access">
+    Install with `publicAccess.enabled: false` (the default). The canonical endpoint refuses external requests, while in-GVC callers still reach the workload per `internalAccess.type`.
+  </Step>
+  <Step title="Reach the dashboard over a port forward">
+    Forward the workload's port to your machine:
+
+    ```bash
+    cpln port-forward {release}-umami 3000:3000 --gvc {gvc}
+    ```
+
+    Then open `http://localhost:3000/login` in a browser and sign in as `admin` / `umami`.
+
+    <Note>
+    `cpln port-forward` is a **top-level command**, not a subcommand of `cpln workload`.
+    </Note>
+  </Step>
+  <Step title="Change the admin password">
+    In the dashboard, go to **Settings → Profile** and change the password. The old password is rejected from that moment on.
+  </Step>
+  <Step title="Publish the dashboard and tracking endpoint">
+    Set `publicAccess.enabled: true` and run a `helm upgrade`. The firewall change takes up to a couple of minutes to propagate — roughly 50 seconds in a measured run — so re-test the public URL rather than trusting the first response. Your changed password applies over the public endpoint immediately; the old `umami` password is rejected there too.
+  </Step>
+</Steps>
+
+<Warning>
+**That publishing upgrade is the first upgrade after the install, so it bounces the bundled database.** The first `helm upgrade` after an install re-applies the bundled PostgreSQL even though no database value changed, and Umami is unreachable for roughly two minutes while it restarts. This is expected, not a failed upgrade — do not roll back.
+
+**`/api/heartbeat` is not the signal to watch during that window.** It returns `200` throughout, because it never touches the database, while the dashboard and all collection are still failing. Confirm recovery with a database-backed request — loading the dashboard — instead.
+</Warning>
+
+## Upgrading From 1.0.1
+
+Version `1.1.0` is a security release that renames three values. Carrying a `1.0.1` values file forward **fails at render** with a message naming the replacement, so nothing silently reverts to a default:
+
+| `1.0.1` | `1.1.0` | Why |
+|---|---|---|
+| `app.appSecret` | `app.appSecretName` | The app secret is now a prerequisite opaque secret you create, referenced by name. `1.0.1` shipped a working signing key as a values default, so every install shared one publicly-known credential |
+| `resources.cpu` | `resources.maxCpu` | The block exposes both a reservation and a limit, so the limit is named `maxCpu` beside `minCpu` |
+| `resources.memory` | `resources.maxMemory` | Same — `maxMemory` beside `minMemory` |
+
+Two further changes need no action but are worth knowing:
+
+- **`publicAccess.enabled` now defaults to `false`.** An upgrade that does not set it explicitly makes the install private and **stops data collection**. Set it to `true` explicitly once the admin password is changed — see [First Run](#first-run-sequence).
+- **The chart-created `{release}-umami-config` secret is gone.** It existed only to hold the app secret; the template now creates no secret of its own.
+
+<Note>
+The render guards are non-destructive against a running release. Tripping one exits non-zero without creating a new revision, and the workload keeps serving at its current version — you lose nothing by hitting it mid-upgrade.
+</Note>
+
 ## Choosing a Database Mode
 
 Exactly one of the two backing stores must be enabled — the chart enforces this at render. Umami is wired to the active database automatically.
@@ -76,15 +161,15 @@ image: ghcr.io/umami-software/umami:3.2.0
 replicas: 1 # 1 = proven single-instance; 2+ = always-on, zero-downtime restarts
 
 resources: # per replica
-  cpu: 500m
-  memory: 512Mi
   minCpu: 100m
+  maxCpu: 500m
   minMemory: 256Mi
+  maxMemory: 512Mi
 
 app:
-  # Signs auth tokens; MUST be unique per install, identical across replicas,
-  # and stable across restarts (changing it logs everyone out).
-  appSecret: "change-me-KJ8xQ2mZraB7vN1pLwCf5tHgUeYd0sQ4" # override: openssl rand -base64 32
+  # Name of an opaque secret (encoding: plain) holding the app secret, which signs
+  # auth tokens and sessions. The secret MUST EXIST BEFORE INSTALL.
+  appSecretName: my-umami-app-secret
   disableTelemetry: true # opt out of Umami's anonymous usage telemetry
 
 tracker:
@@ -103,7 +188,7 @@ postgres: # default: single-instance PostgreSQL
   backup:
     enabled: false # true = scheduled backups of the analytics DB to object storage
     schedule: "0 2 * * *" # daily at 2am UTC
-    provider: aws # aws | gcp | minio
+    provider: aws # aws, gcp, or minio
     aws:
       bucket: my-backup-bucket
       region: us-east-1
@@ -122,8 +207,8 @@ postgresHA: # durable HA: 3-replica Patroni store with an HAProxy leader endpoin
     capacity: 10 # initial capacity in GiB per replica (minimum is 10)
   backup:
     enabled: false # true = scheduled backups to object storage
-    mode: logical # logical | wal-g
-    provider: aws # aws | gcp | minio
+    mode: logical # logical or wal-g
+    provider: aws # aws, gcp, or minio
     aws:
       bucket: my-backup-bucket
       region: us-east-1
@@ -132,31 +217,37 @@ postgresHA: # durable HA: 3-replica Patroni store with an HAProxy leader endpoin
       prefix: umami/backups
 
 publicAccess:
-  enabled: true # HTTPS dashboard + tracking endpoint via the canonical *.cpln.app endpoint
+  # false = nothing reaches Umami from the internet. Change the hardcoded admin
+  # password over a port forward first, then set this true — tracking needs it.
+  enabled: false
 
 internalAccess:
   type: same-gvc # options: none, same-gvc, same-org, workload-list
-  workloads: [] # only used with same-gvc / workload-list
+  workloads: []  # only used when type is same-gvc or workload-list
 ```
 
 ### Application
 
 - `image` — The Umami open-source container image.
-- `replicas` — Number of stateless app-tier replicas. `1` is the proven single-instance shape; `2` or more gives an always-on tier where rolling restarts cycle one replica at a time with no downtime. Replicas are independent and share only the database and `app.appSecret`.
-- `resources` — CPU and memory per replica.
-- `app.appSecret` — Signs auth tokens and secures sessions. It **must** be unique per installation, identical across replicas, and stable across restarts — changing it logs every user out. Generate one with `openssl rand -base64 32` and set it before installing.
+- `replicas` — Number of stateless app-tier replicas. `1` is the proven single-instance shape; `2` or more gives an always-on tier where rolling restarts cycle one replica at a time with no downtime. Replicas are independent and share only the database and the app secret.
+- `resources` — CPU and memory per replica: `minCpu`/`minMemory` are the reservation, `maxCpu`/`maxMemory` the limit.
+- `app.appSecretName` — Name of the prerequisite [opaque secret](/guides/create-secret/opaque) holding the app secret. It must exist before you install, and its value must stay stable — see [Prerequisites](#prerequisites).
 - `app.disableTelemetry` — When `true` (default), opts out of Umami's anonymous usage telemetry.
 
 ### Tracker
 
-- `tracker.scriptName` — Serve the tracking script under a custom path (e.g. `s.js` → `/s.js`) instead of the default `/script.js`. Useful for reducing ad-blocker interception.
-- `tracker.collectEndpoint` — Have the tracker POST events to a custom path (e.g. `/api/track`) instead of the default `/api/send`.
+- `tracker.scriptName` — Also serve the tracking script under a custom path (e.g. `s.js` → `/s.js`) instead of only the default `/script.js`. Useful for reducing ad-blocker interception.
+- `tracker.collectEndpoint` — Have the tracker POST events to a custom path (e.g. `/api/track`) instead of the default `/api/send`. The custom path is baked into the script Umami serves, so the snippet you embed uses it automatically.
 
 Both default to `""` (standard paths). Custom paths take effect once a replica has fully booted with the new setting; a mid-rollout replica still serves the old path until it cycles.
 
+<Note>
+**Custom tracker paths are aliases, not replacements.** With `scriptName` and `collectEndpoint` set, the default `/script.js` still returns the tracker and the default `/api/send` still accepts and records events. Custom paths help because *your site* loads the unblocked path — they do not close the defaults off.
+</Note>
+
 ### Access
 
-- `publicAccess.enabled` — Serve the dashboard and tracking endpoint on the canonical `*.cpln.app` HTTPS endpoint (default). **Keep this enabled for tracking to work** — browsers must reach `/script.js` and `/api/send`. Set to `false` for an internal-only instance (external requests are blocked at the edge; in-GVC callers still reach it per `internalAccess`), which stops all public data collection.
+- `publicAccess.enabled` — Serve the dashboard and tracking endpoint on the canonical `*.cpln.app` HTTPS endpoint. **Defaults to `false`**, which blocks external requests at the edge; in-GVC callers still reach it per `internalAccess`. **Tracking collects nothing while it is off**, so turn it on once the admin password is changed — see [First Run](#first-run-sequence).
 - `internalAccess.type` — Internal firewall scope of the Umami workload:
 
 | Type | Description |
@@ -165,6 +256,10 @@ Both default to `""` (standard paths). Custom paths take effect once a replica h
 | `same-gvc` | Allow access from all workloads in the same GVC (default). |
 | `same-org` | Allow access from all workloads in the same organization. |
 | `workload-list` | Allow access only from workloads listed in `internalAccess.workloads`. |
+
+<Note>
+Access changes take up to a couple of minutes to propagate — every measured transition returned the **stale** value for the first 25–50 seconds. Re-poll before concluding a knob is broken.
+</Note>
 
 ### Backing Store
 
@@ -178,18 +273,20 @@ Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA)
 
 | What | Value |
 |---|---|
-| Public URL | `status.canonicalEndpoint` of `{release}-umami` (`cpln workload get {release}-umami -o yaml`) |
+| Local access (public access off) | `cpln port-forward {release}-umami 3000:3000 --gvc {gvc}`, then `http://localhost:3000` |
+| Public URL | `status.canonicalEndpoint` of `{release}-umami` (`cpln workload get {release}-umami -o yaml`) — only when `publicAccess.enabled` is `true` |
 | Dashboard / login | `https://<canonical>.cpln.app/login` |
 | Tracking script | `https://<canonical>.cpln.app/script.js` (embed on your site) |
 | Collect endpoint | `https://<canonical>.cpln.app/api/send` (where the tracker POSTs events) |
 | Internal (same GVC) | `http://{release}-umami.{gvc}.cpln.local:3000` |
-| Default admin | `admin` / `umami` — hardcoded; change it immediately (see [Important Notes](#important-notes)) |
+| Default admin | `admin` / `umami` — hardcoded; change it before publishing (see [First Run](#first-run-sequence)) |
+| App secret | The payload of your `app.appSecretName` secret; never stored in the Helm release |
 
 To start collecting data, log in, add a website in the dashboard, then paste the generated `<script>` tag — which loads the tracking script and POSTs to the collect endpoint — into your site's HTML.
 
 ## Backing Up
 
-Database backups are optional and disabled by default. They cover the analytics database — the users, websites, sessions, and events that make up your Umami instance. Enable them with `postgres.backup.enabled` or `postgresHA.backup.enabled` (matching your database mode), and complete the storage setup for your provider **before** installing. The backup runs as a scheduled job in the backing PostgreSQL store, so this is the same setup as that template.
+Database backups are optional and disabled by default. They cover the analytics database — the users, websites, sessions, and events that make up your Umami instance. Enable them with `postgres.backup.enabled` or `postgresHA.backup.enabled` (matching your database mode), and complete the storage setup for your provider **before** installing. These values are a pass-through to the backing database template, which owns and documents the backup itself; the backup runs as a scheduled job in that store.
 
 <Tabs>
   <Tab title="AWS S3">
@@ -231,11 +328,14 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 
 ## Important Notes
 
-- **Change the default admin password immediately after first login.** The bootstrap admin is a hardcoded `admin` / `umami`, seeded by the first database migration — there is no way to override it at install time. Change it in **Settings → Profile** right after installing.
-- **Set your own `app.appSecret` before installing.** It signs auth tokens; changing it later logs every user out. Generate one with `openssl rand -base64 32`.
-- **Keep `publicAccess` enabled for tracking to work** — browsers must reach the tracking script and collect endpoint. Disabling it silently stops all public data collection.
-- **Ad blockers block the default `/script.js` and `/api/send`** — set `tracker.scriptName` / `tracker.collectEndpoint` to custom paths to reduce blocking.
-- **`replicas` ≥ 2 is recommended for production** — replicas are independent and share the database and `appSecret`; rolling restarts cycle one at a time with no downtime.
+- **Create the app secret before installing.** A missing prerequisite secret does not fail the install — `helm install` reports success and the workload then sits at zero replicas with no container logs at all. Creating the secret afterwards needs a `cpln workload force-redeployment` to take effect; see [Prerequisites](#prerequisites).
+- **Change the hardcoded `admin` / `umami` password before you make the install public.** It is seeded by the first database migration and cannot be overridden at install time. This is why `publicAccess.enabled` defaults to `false` — follow [First Run](#first-run-sequence) in order.
+- **Tracking collects nothing until `publicAccess.enabled` is `true`** — browsers on the sites you track must reach the tracking script and the collect endpoint. Publishing is a required step, not an optional one.
+- **The upgrade that publishes the install bounces the bundled database for roughly two minutes**, because it is the first upgrade after the install. `/api/heartbeat` stays `200` throughout and is not the signal to watch — it never touches the database.
+- **Upgrading from `1.0.1` fails at render if you carry `app.appSecret`, `resources.cpu`, or `resources.memory` forward.** Each guard names its replacement and leaves the running release untouched — see [Upgrading From 1.0.1](#upgrading-from-1-0-1).
+- **The app secret must stay stable for the life of the install** — changing its payload logs every user out. Back it up outside Control Plane. It is yours, not the release's: it survives `helm uninstall` and must be deleted manually.
+- **Custom tracker paths are aliases** — `/script.js` and `/api/send` stay live and keep recording even when `tracker.scriptName` / `tracker.collectEndpoint` are set.
+- **`replicas` ≥ 2 is recommended for production** — replicas are independent and share the database and the app secret, so a session opened against one is honored by the others; rolling restarts cycle one at a time with no downtime.
 - **Database volumes survive reinstalls under the same release name; uninstalling deletes them** — all analytics data is lost. Use `postgresHA` and/or enable backups for durable production data.
 
 ## External References


### PR DESCRIPTION
Docs for the **eight** tier-1 security releases, all merged on templates `main` (PRs #416, #418, #420, #421, #422, #423, #424). Changelog entries are in templates PR #425.

**This PR now includes dbeaver and tyk, previously PR #266** — same cycle, same reason, disjoint files, and the convention is one combined docs PR per cycle. #266 is closed in favour of this one; its content is preserved here unchanged and had already passed docs review.

Eight existing pages updated. **No `overview.mdx`, `docs.json` or icon changes** — every page already existed, so cards and nav entries are unchanged and correct.

| Page | Version | What the release changed |
|---|---|---|
| `dbeaver` | 1.3.0 | admin password → prerequisite secret; console no longer public by default |
| `tyk` | 1.3.0 | admin key → prerequisite secret; gateway private; master keys off |
| `mysql` | 1.5.0 | DB + root credentials → two prerequisite secrets; phpMyAdmin off and private, image pinned |
| `mariadb` | 1.4.0 | same, plus the backup job now receives `MYSQL_DATABASE` |
| `umami` | 1.1.0 | dashboard private by default; app secret → prerequisite secret; resource keys renamed |
| `langfuse` | 1.1.0 | three live keys + GCS credentials → prerequisite secrets; signup closed with headless admin; `Secure` cookies |
| `open-webui` | 1.1.0 | UI private, signup closed; signing key → prerequisite secret; `customDomain` guard |
| `manticore` | 2.1.0 | agent token → prerequisite secret; UI private; org-wide policy grant removed; backup fixed |

The recurring theme, and what every upgrade section leads with: a working credential shipped as a values default, so every install that did not override it shared one publicly-known secret — and in several cases the thing it guarded was public by default too.

**Merging this is what makes the docs stop contradicting the shipped charts.** Until it lands, the live dbeaver and tyk pages still instruct users to set `adminSecret: mysecret` and `password: Password123` — the exact credentials those releases removed.

## Verification

Written by five parallel writers in isolated worktrees, two pages carried over from #266, and one written directly. Mechanically re-verified across the batch before opening:

- **YAML blocks vs shipped `values.yaml`** — every documented scalar matched (36/36/41/20/126/114 on the six newer pages; dbeaver and tyk were diffed byte-identical during #266's review). This caught five real errors on the manticore page, including a documented `rolloutOptions.maxUnavailableReplicas` that 2.1.0 **removed** — the API silently drops it on a stateful workload, so documenting it advertised a rollout limit that was never in force.
- **A sweep for reproduced credentials.** The manticore page still carried the live agent token verbatim in a config example — the very credential that release exists to remove. Removed. Every remaining match across the batch is either a secret *name* or a retired value quoted inside an upgrade warning or before/after table, which is where it belongs.
- **In-page anchors resolve on all eight**, with no linked heading containing punctuation.
- External URLs 200, excepting two known-good cases: `dev.mysql.com/doc/` returns 403 to curl (`AkamaiGHost` bot-blocking; canonical URL, also used by the template README), and `streamlinehq.com` returns 429 rate-limited — an SVG attribution present on all 81 catalog pages.

## Two Mintlify traps found this cycle

Both let a page pass validation while broken; both are now in the docs-writer guidance.

1. **`mintlify dev` uses a shared global `~/.mintlify/mint` cache across worktrees.** With writers running concurrently a dev server can serve a *sibling's* file and still return 200 — measured, with a stale 640 KB page served in place of the real 808 KB one. Render checks must grep for a content marker unique to the page, not trust the status code.
2. **Mintlify keeps colons and commas in heading ids.** `## First Run: Secure the Admin Account, Then Publish` yields an id needing URL-encoding, which left five anchors dead while `broken-links` passed. Caught and fixed on the umami page by renaming the heading.

## Honest gaps

- **langfuse's 1.0.x → 1.1.0 upgrade was never run end to end** — every test round installed fresh. Its upgrade steps lead with "back up PostgreSQL" rather than promising accounts survive.
- **manticore's page states two limitations rather than resolving them**: a restore can land unevenly across replicas *while every node reports `synced`*, and multi-segment / `clusterMain: true` is unverified at the shipped resource sizes — written as untested rather than broken, because the failing run was under-resourced.
- **umami's two renamed resource keys** are documented from source; they were added after its test round, with the render byte-identical.
- **dbeaver and tyk carry unclosed upstream behaviours by design** — dbeaver's admin password cannot be rotated and CloudBeaver logs a replayable hash; tyk serves its demo API when no definitions are supplied. Documented as limitations, not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
