### PR TITLE
docs: tier-2 security cycle — six templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .claude
 .idea
 CLAUDE.md
+.worktrees/

--- a/template-catalog/templates/minio.mdx
+++ b/template-catalog/templates/minio.mdx
@@ -1,27 +1,123 @@
 ---
 title: MinIO
-description: Deploy MinIO on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and distributed S3-compatible object storage with erasure coding.
-keywords: ['s3 alternative', 'self-hosted s3', 'aws s3 alt', 'mc client', 'on-prem storage', 'bucket', 'blob storage', 'minio template', 'storage template']
+description: Deploy MinIO on Control Plane using the Template Catalog. Covers the prerequisite root credentials secret, distributed erasure-coded storage, volumes, the S3 endpoint, console access, and rotating the access and secret keys.
+keywords: ['s3 alternative', 'self-hosted s3', 'aws s3 alt', 'mc client', 'on-prem storage', 'bucket', 'blob storage', 'access key', 'secret key', 'erasure coding', 'minio template', 'storage template']
 ---
 
 ## Overview
 
 MinIO is a high-performance, S3-compatible object storage system. This template deploys a distributed MinIO cluster with erasure coding across multiple replicas for durability and fault tolerance, backed by persistent storage and an optional autoscaling volume set.
 
+The root credentials are not template values. They come from a secret you create before installing, so the access key and secret key never pass through Helm and never land in the release.
+
+<Warning>
+**Template version 1.3.0 is a breaking security change.** `admin.username` and `admin.password` were removed. An install or upgrade that still sets either one now fails at render instead of falling back to a published default. If you are running 1.2.1 or earlier, read [Upgrading From Earlier Versions](#upgrading-from-earlier-versions) before you touch the release.
+</Warning>
+
 ### What Gets Created
 
-- **Stateful Workload** — A distributed MinIO cluster with a configurable number of replicas (minimum 4, must be even).
-- **Volume Set** — Persistent storage per replica with optional autoscaling.
-- **Secrets** — An opaque startup script secret that configures the distributed server list and handles node initialization, and a dictionary secret storing the admin username and password.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to both secrets.
+- **Stateful Workload** — (`RELEASE_NAME-minio`): a distributed MinIO cluster of `replicas` nodes forming one erasure-coded pool. S3 API on port `9000`, web console on port `9001`. Per-replica addressing is enabled so each node reaches its peers at a stable `replica-{index}` address.
+- **Volume Set** — (`RELEASE_NAME-minio-vs`): one `ext4` general-purpose SSD volume per replica, mounted at `/data`, with a final snapshot and 7-day retention, and optional autoscaling.
+- **Startup Secret** — (`RELEASE_NAME-minio-startup`): an opaque secret holding the boot script each node runs. It derives the peer list from the replica index and holds no credentials.
+- **Identity & Policy** — (`RELEASE_NAME-minio-identity`, `RELEASE_NAME-minio-policy`): an identity bound to the workload, and a policy granting it `reveal` on exactly two secrets — the startup script and the credentials secret you created.
+
+The template creates **no credential secret of its own**. The root user and password live only in the prerequisite secret described below.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Upgrading From Earlier Versions
+
+Template version 1.2.1 and earlier took the MinIO root credentials as plain Helm values and shipped a working default username and password. Those defaults were published in the public template repository, so every install that kept them shares one publicly known credential — and because these are the S3 access key and secret key, that credential is not merely a console login. It is what every client, and every other template configured to back up to this MinIO, authenticates with.
+
+| | 1.2.1 and earlier | 1.3.0 |
+|---|---|---|
+| Root credentials | `admin.username` and `admin.password` values | `admin.credentialsSecretName` → a dictionary secret you create |
+| Where they live | Rendered by the chart into a `RELEASE_NAME-minio-admin` secret, and recorded in the Helm release | Created by you, referenced by name, never in the release |
+
+The chart-created `RELEASE_NAME-minio-admin` secret no longer exists in 1.3.0. The secret you create is yours: the chart never writes to it, and uninstalling the release leaves it in place.
+
+<Warning>
+**Treat a pre-1.3.0 cluster's root credentials as compromised, not merely outdated.** Upgrading moves them out of Helm values but does not change the values themselves. If the install kept the published defaults, those keys remain publicly known after the upgrade — rotate them, as described in [Rotating the Root Credentials](#rotating-the-root-credentials).
+</Warning>
+
+<Warning>
+**Carrying old values forward stops the upgrade.** Three guards reject the removed keys at render time, so the upgrade fails and the existing release is left untouched and running rather than quietly restarting with different credentials:
+
+```text
+Error: execution error at (minio/templates/workload.yaml:1:4): admin.username was REMOVED in minio
+1.3.0. The MinIO root credentials are no longer values: create a `dictionary` secret holding the
+keys `username` and `password`, and set admin.credentialsSecretName to its name. See Prerequisites
+in the README.
+```
+
+`admin.password` is rejected with the same message. An empty `admin.credentialsSecretName` gets its own: `admin.credentialsSecretName is required — it names the dictionary secret holding the username and password keys. Create that secret BEFORE installing.`
+</Warning>
+
+<Steps>
+  <Step title="Read the credentials the cluster already uses">
+    MinIO reads its root credentials from the environment on every start, and version 1.2.1 stored them in a secret the chart created. Read them back from there:
+
+    ```bash
+    cpln secret reveal RELEASE_NAME-minio-admin -o yaml
+    ```
+
+    Failing that, they are in the values file the release was installed with.
+  </Step>
+  <Step title="Create the prerequisite secret">
+    Follow [Prerequisites](#prerequisites), using the existing username and password, so the upgrade itself is not also a credential change. Give the secret a name of your own, such as `my-minio-credentials` — do not reuse `RELEASE_NAME-minio-admin`, which the upgrade removes.
+  </Step>
+  <Step title="Remove the old keys from your values">
+    Delete `admin.username` and `admin.password`, and set `admin.credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Rotate afterwards, in a maintenance window">
+    Once the upgrade is in, rotate any credential that came from a published default. Rotation is not a quick restart — see [Rotating the Root Credentials](#rotating-the-root-credentials) for the procedure and the roughly eleven-minute window it takes.
+  </Step>
+</Steps>
+
+## Prerequisites
+
+**One secret must exist before you install.** Its value never passes through Helm values, so it never lands in the release. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the root credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly two keys — `username` and `password`. These become `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`: the S3 access key and secret key every client will use.
+
+    ```bash
+    cpln secret create-dictionary --name my-minio-credentials \
+      --entry username=minioadmin \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    MinIO requires a username of at least 3 characters and a password of at least 8. Set `admin.credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Read the secret back later">
+    The `-o yaml` is required — plain `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-minio-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**Create the secret before installing.** The template refuses to render when the name is blank, but a name pointing at a secret that does not exist installs "successfully" and then wedges: the install reports every resource created, the workload never becomes ready, and **`cpln logs` returns zero lines** because no container ever starts. The only diagnostic is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-minio --gvc GVC_NAME -o yaml
+```
+
+It names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` The command is `get-deployments` — plain `cpln workload get` has no `versions` key at all. Creating the secret recovers the workload on its own in about **5.5 to 8.5 minutes** (measured 5 minutes 39 seconds), or in roughly 90 seconds if you force a redeployment of the workload.
+</Warning>
+
+### Replica Quota
+
+The built-in `replicas-per-workload` quota is **6**, so the shipped default `replicas: 6` installs with no action needed. Request a quota increase only if you raise `replicas` above 6.
+
 ## Installation
 
-This template has no external prerequisites. To install, follow the instructions for your preferred method:
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -54,9 +150,15 @@ image: minio/minio:RELEASE.2025-09-07T16-13-09Z
 
 replicas: 6 # Must be at least 4 and an even number
 
-admin: # MinIO admin credentials
-  username: myuser
-  password: mypassword123
+admin:
+  # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL.
+  # A `dictionary` secret holding exactly two keys: `username` and `password`.
+  # These are the MinIO root credentials, i.e. the S3 access key and secret key
+  # every client and every other template will use. If the secret does not exist
+  # at install time the deployment WEDGES silently — `cpln logs` returns nothing
+  # at all. See Prerequisites in the README for the exact
+  # `cpln secret create-dictionary` command.
+  credentialsSecretName: my-minio-credentials
 
 resources: # Defaults are set for minimal production usage
   minCpu: 1
@@ -67,38 +169,40 @@ resources: # Defaults are set for minimal production usage
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
   autoscaling:
-    enabled: false
-    maxCapacity: 100 # Maximum capacity in GiB
-    minFreePercentage: 10 # Trigger scaling when free space drops below this percentage
-    scalingFactor: 1.2 # Multiply current capacity by this factor when scaling up
+    enabled: false # Set to true to enable autoscaling
+    maxCapacity: 100 # Maximum capacity in GiB when autoscaling is enabled
+    minFreePercentage: 10 # Minimum free percentage to trigger scaling when autoscaling is enabled
+    scalingFactor: 1.2 # Scaling factor to determine how much to scale up when autoscaling is triggered
 
-internalAccess:
+internalAccess: # Sets the internal firewall scope - if set to none, replicas will not be able to reach each other
   type: same-gvc # options: none, same-gvc, same-org, workload-list
-  workloads: # Note: can only be used if type is same-gvc or workload-list
+  workloads:  # Note: can only be used if type is same-gvc or workload-list
+    #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
     #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
 ```
 
 ### Credentials
 
-- `admin.username` — MinIO admin username. **Change before deploying to production.**
-- `admin.password` — MinIO admin password. **Change before deploying to production.**
+- `admin.credentialsSecretName` — Name of the dictionary secret holding the `username` and `password` keys. The secret must exist before you install; see [Prerequisites](#prerequisites).
 
 ### Replicas
 
-- `replicas` — Number of MinIO instances in the distributed cluster (minimum 4, must be even).
+- `replicas` — Number of MinIO nodes in the distributed cluster. Must be **an even number, minimum 4**; 6 or more is recommended for production.
+
+MinIO stripes each object into data and parity blocks across every node in the pool, so the replica count sets both the usable capacity ratio and how many nodes may be lost while the cluster keeps serving. A six-replica install forms one erasure set with three parity blocks; a four-replica install forms one with two.
 
 <Note>
-MinIO requires at least 4 replicas to form a distributed cluster with erasure coding. For production workloads, 6 or more replicas are recommended. Depending on your organization's default quotas, you may need to request higher limits.
+**Treat `replicas` as fixed at install time.** MinIO grows by adding server pools, which this template does not model. Changing the value rewrites every node's peer list for the existing pool.
 </Note>
 
 ### Resources
 
-- `resources.minCpu` / `resources.minMemory` — Minimum CPU and memory guaranteed to each replica.
-- `resources.maxCpu` / `resources.maxMemory` — Maximum CPU and memory each replica can use.
+- `resources.minCpu` / `resources.minMemory` — Reserved CPU and memory per replica.
+- `resources.maxCpu` / `resources.maxMemory` — Limits per replica.
 
 ### Storage
 
-- `volumeset.capacity` — Initial volume size in GiB per replica (minimum 10).
+- `volumeset.capacity` — Initial volume size in GiB **per replica** (minimum 10). Usable space is roughly `replicas × capacity ÷ 2` after erasure-coding parity.
 - `volumeset.autoscaling.enabled` — Automatically expand each volume as it fills. When enabled:
   - `maxCapacity` — Maximum volume size in GiB.
   - `minFreePercentage` — Trigger a scale-up when free space drops below this percentage.
@@ -106,32 +210,81 @@ MinIO requires at least 4 replicas to form a distributed cluster with erasure co
 
 ### Internal Access
 
-- `internalAccess.type` — Controls which workloads can connect to MinIO on ports `9000` and `9001`:
+- `internalAccess.type` — Controls which workloads can reach MinIO on ports `9000` and `9001`:
 
 | Type | Description |
 |------|-------------|
 | `none` | No internal access allowed |
 | `same-gvc` | Allow access from all workloads in the same GVC |
-| `same-org` | Allow access from all workloads in the same organization |
-| `workload-list` | Allow access only from specific workloads listed in `workloads` |
+| `same-org` | Allow access from all workloads in the same org |
+| `workload-list` | Allow access only from the workloads listed in `internalAccess.workloads` |
+
+<Warning>
+**Do not set `internalAccess.type` to `none`.** MinIO nodes discover and reach each other over internal GVC traffic, so cutting it off breaks the cluster rather than merely isolating it from clients.
+</Warning>
 
 <Note>
-Do not set `internalAccess.type` to `none`. MinIO replicas must be able to communicate with each other for distributed mode to function.
+A firewall change takes roughly **30 seconds to 5 minutes** to propagate. After changing `internalAccess`, re-test rather than trusting the first response.
 </Note>
 
-### Connecting to MinIO
+## Connecting to MinIO
 
-Once deployed, connect to the MinIO S3 API from within the same GVC using the MinIO client:
+This template exposes **no public endpoint**: there is no `publicAccess` knob and no load balancer, and the workload's canonical endpoint returns `403`. Everything below is reached from inside the GVC or through a tunnel.
+
+| What | Where |
+|---|---|
+| S3 API | `RELEASE_NAME-minio.GVC_NAME.cpln.local:9000` — the short name `RELEASE_NAME-minio` also resolves inside the same GVC |
+| Web console | port `9001` on the same host, reached with `cpln port-forward` |
+| Individual node | `replica-INDEX.RELEASE_NAME-minio.LOCATION.GVC_NAME.cpln.local` |
+| Credentials | the dictionary secret named by `admin.credentialsSecretName` |
+
+From another workload in the same GVC, using the MinIO client:
 
 ```bash
 mc alias set minio http://RELEASE_NAME-minio:9000 USERNAME PASSWORD
 ```
 
-The web console is available on port `9001` at:
+Other templates in this catalog that back up to MinIO take the same two values as their access key and secret key.
 
-```text
-https://RELEASE_NAME-minio.GVC_NAME.cpln.app
+To open the web console in a browser, tunnel to it — no public exposure required:
+
+```bash
+cpln port-forward RELEASE_NAME-minio 9001:9001 --gvc GVC_NAME
+# then browse http://localhost:9001
 ```
+
+Give the tunnel a few seconds before the first request; a request issued immediately after the command starts may not connect. Log in with the `username` and `password` from your credentials secret.
+
+## Rotating the Root Credentials
+
+The root credentials are the S3 access key and secret key, so rotating them is a fleet-wide change: every client and every other template configured with these keys has to be updated in the same window.
+
+<Warning>
+**`cpln secret update` cannot rotate the value.** That command only edits a secret's description and tags. Update the value with `cpln apply -f <secret.yaml>`, then restart the workload so the nodes pick it up:
+
+```bash
+cpln apply -f rotate.yaml
+cpln workload force-redeployment RELEASE_NAME-minio --gvc GVC_NAME
+```
+
+Updating the secret alone changes nothing: running containers keep the credentials they started with.
+</Warning>
+
+<Warning>
+**Plan rotation as a maintenance window of about 11 minutes, not a restart.** MinIO reads the root credentials from the environment on every start, and they are per-node, so the rollout restarts one replica at a time. For the whole rollout some nodes hold the old credential and some hold the new one, and a client using the service DNS sees **intermittent authentication failures with both keys** — measured mid-rollout, the new credential succeeded 15 times out of 20 while the old one failed all 20.
+
+It does converge cleanly: once every replica has cycled, the new credential is accepted on every request and the old one is refused everywhere. No re-encryption of MinIO's internal identity data is required, and existing buckets and objects are readable with the new credential.
+</Warning>
+
+## Important Notes
+
+- The credentials secret must exist **before** you install. Without it the workload wedges with no log output at all; see [Prerequisites](#prerequisites) for the one diagnostic that shows it.
+- Rotating the root credentials is an ~11-minute window of split old/new state, not a cutover — see [Rotating the Root Credentials](#rotating-the-root-credentials).
+- `replicas` must be even and at least 4, and is effectively fixed at install time.
+- Do not set `internalAccess.type` to `none` — the cluster needs internal GVC traffic to form.
+- The workload has no outbound internet access, so bucket replication to a remote S3 and external notification targets will not work.
+- Uninstalling the release deletes the volume sets, so stored objects do not survive a reinstall. The credentials secret is yours and is left alone.
+- The first upgrade after an install re-applies resources even when values are identical, which restarts the pool. Nothing limits the rollout on a stateful workload, so treat it as a planned restart.
 
 ## External References
 
@@ -139,8 +292,11 @@ https://RELEASE_NAME-minio.GVC_NAME.cpln.app
     <Card title="MinIO Documentation" icon="book" href="https://min.io/docs/minio/linux/index.html">
     Official MinIO documentation
     </Card>
-    <Card title="Distributed Deployment" icon="server" href="https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html">
-    MinIO distributed deployment quickstart
+    <Card title="Erasure Coding" icon="shield-halved" href="https://min.io/docs/minio/linux/operations/concepts/erasure-coding.html">
+    How MinIO stripes data and parity across nodes
+    </Card>
+    <Card title="MinIO Client (mc)" icon="terminal" href="https://min.io/docs/minio/linux/reference/minio-mc.html">
+    Command-line client for the S3 API
     </Card>
     <Card title="MinIO Template" icon="github" href="https://github.com/controlplane-com/templates/tree/main/minio">
     View the source files, default values, and chart definition

--- a/template-catalog/templates/minio.mdx
+++ b/template-catalog/templates/minio.mdx
@@ -113,7 +113,7 @@ It names the missing secret: `The secret <name> no longer exists. Workload updat
 
 ### Replica Quota
 
-The built-in `replicas-per-workload` quota is **6**, so the shipped default `replicas: 6` installs with no action needed. Request a quota increase only if you raise `replicas` above 6.
+The default `replicas-per-workload` quota is **5**, and this template's default is `replicas: 6`, so **request a quota increase before installing**. Check your org's current limit with `cpln quota get` and look at `replicas-per-workload` — the value shown is your org's, which may already have been raised above the default.
 
 ## Installation
 

--- a/template-catalog/templates/mongodb-cluster.mdx
+++ b/template-catalog/templates/mongodb-cluster.mdx
@@ -69,13 +69,20 @@ openssl rand -base64 756 | cpln secret create-opaque --name my-mongodb-keyfile -
 </Warning>
 
 <Steps>
-  <Step title="Read the credentials the cluster already uses">
-    The admin user is created the first time the data directory is initialized, so an existing cluster keeps whatever it was bootstrapped with. Recover the username, password, database name and the `replicaSetKey` from the values file you installed 1.0.0 with.
+  <Step title="Read the credentials and keyfile the cluster already uses">
+    The admin user is created the first time the data directory is initialized, so an existing cluster keeps whatever it was bootstrapped with, and its members keep authenticating with the key they started on. Version 1.0.0 stored both in secrets it created, so read them back from there:
+
+    ```bash
+    cpln secret reveal RELEASE_NAME-mongo-config -o yaml
+    cpln secret reveal RELEASE_NAME-mongo-keyfile -o yaml
+    ```
+
+    The credential keys are `username`, `password` and `database`; the keyfile secret holds the key as its payload. Failing that, both are in the values file you installed 1.0.0 with.
   </Step>
   <Step title="Create the two prerequisite secrets with those same values">
-    Follow [Prerequisites](#prerequisites), using the existing username, password and database name, and putting the **existing** `replicaSetKey` into the keyfile secret. Different values here do not change the cluster — they just leave the members unable to authenticate.
+    Follow [Prerequisites](#prerequisites), using the existing username, password and database name, and putting the **existing** key into the keyfile secret. Different values here do not change the cluster — they just leave the workload unable to authenticate.
 
-    The keyfile in particular cannot be changed as part of this upgrade: it is what members use to authenticate to each other, and rotating it needs the separate procedure in the last step.
+    Give the new secrets names of your own, such as `my-mongodb-credentials` and `my-mongodb-keyfile`. Do not reuse `RELEASE_NAME-mongo-config` or `RELEASE_NAME-mongo-keyfile`: those belong to the old release, and the upgrade removes the secrets 1.0.0 created.
   </Step>
   <Step title="Remove the old keys from your values">
     Delete `mongodb.username`, `mongodb.password`, `mongodb.database` and `mongodb.replicaSetKey`, then set `mongodb.credentialsSecretName` and `mongodb.keyfileSecretName` to the two secret names.
@@ -91,10 +98,10 @@ openssl rand -base64 756 | cpln secret create-opaque --name my-mongodb-keyfile -
     printf 'data:\n  password: NEW-STRONG-PASSWORD\n' | cpln secret patch my-mongodb-credentials -f -
     ```
   </Step>
-  <Step title="Rotate the keyfile">
-    A published keyfile lets anyone who has it join a member to your replica set, so a cluster that ran on the 1.0.0 default needs a new one. The keyfile cannot be changed on a running cluster — every member must restart with the same new key, which means planned downtime. Generate a new key, replace the contents of the opaque secret, and restart the MongoDB workload so all members pick it up at once.
+  <Step title="Plan a keyfile rotation">
+    A published keyfile lets anyone holding it join a member to your replica set, so a cluster that ran on the 1.0.0 default still needs a new key even after the upgrade. The key cannot be swapped on a running cluster: members that disagree on it cannot authenticate to each other, so rotation means bringing the replica set down and back up on the new key, and it is planned downtime rather than a values change. Budget time for it — a plain rolling restart of a three-replica tier already takes about **7 minutes**.
 
-    Expect the restart to take time: a rolling restart of a three-replica tier was measured at roughly **7 minutes** end to end.
+    If rotating is not possible right now, the next best step is to restrict who can reach the cluster with [Firewall](#firewall) and to rotate the database password, which you can do online.
   </Step>
 </Steps>
 
@@ -173,7 +180,6 @@ This template **creates its own GVC**, named by `gvc.name` (default `mongodb-gvc
 - For backups: an AWS or GCP [cloud account](/guides/create-cloud-account) and a storage bucket — see [AWS S3](#aws-s3) or [GCS](#gcs).
 
 ## Installation
-
 
 To install, follow the instructions for your preferred method:
 

--- a/template-catalog/templates/mongodb-cluster.mdx
+++ b/template-catalog/templates/mongodb-cluster.mdx
@@ -445,7 +445,15 @@ Two backup modes are available:
 
 Set `backup.enabled: true`, choose a `mode`, set `backup.provider`, and fill in the corresponding provider block.
 
-The backup job region determines where the backup cron workload runs. For AWS, the Control Plane location is automatically derived from `backup.aws.region` (e.g., `us-east-1` → `aws-us-east-1`). For GCP, the job runs in the first location listed in `gvc.locations`.
+The backup job region determines where the backup cron workload runs. For AWS, the Control Plane location is automatically derived from `backup.aws.region` (e.g., `us-east-1` → `aws-us-east-1`), and that derived location must be one of your `gvc.locations` — the template refuses to render otherwise. For GCP, the job runs in the first location listed in `gvc.locations`.
+
+Both modes connect to `replica-0` directly rather than through the proxy, so `proxy.enabled: false` does not affect them.
+
+<Note>
+**Logical backups are verified end to end**, including the scheduled `mongodump` and the upload to S3 using the workload identity's Cloud Account binding. **Physical (PBM) mode is not verified** on this template — it renders and installs, but no backup or restore has been proven through it. Prefer `logical` unless you are prepared to validate `physical` yourself.
+</Note>
+
+Enabling `physical` mode adds a `pbm-agent` sidecar to every MongoDB replica, which restarts the whole stateful tier — allow roughly 7 minutes for a three-replica cluster.
 
 ### AWS S3
 
@@ -510,17 +518,17 @@ You must add the `Storage Admin` role to the GCP service account created for the
 Run the following from a client with network access to the cluster and access to the bucket. Connect to the **proxy** workload so writes land on the current primary.
 
 **AWS S3:**
-```sh
+```bash
 mongorestore \
-  --uri="mongodb://USERNAME:PASSWORD@{release-name}-mongo-proxy.{gvc}.cpln.local:27017/?authSource=admin" \
+  --uri="mongodb://USERNAME:PASSWORD@RELEASE_NAME-mongo-proxy.GVC_NAME.cpln.local:27017/?authSource=admin" \
   --gzip \
   --archive=<(aws s3 cp s3://BUCKET_NAME/PREFIX/BACKUP_FILE.gz -)
 ```
 
 **GCS:**
-```sh
+```bash
 mongorestore \
-  --uri="mongodb://USERNAME:PASSWORD@{release-name}-mongo-proxy.{gvc}.cpln.local:27017/?authSource=admin" \
+  --uri="mongodb://USERNAME:PASSWORD@RELEASE_NAME-mongo-proxy.GVC_NAME.cpln.local:27017/?authSource=admin" \
   --gzip \
   --archive=<(gsutil cp gs://BUCKET_NAME/PREFIX/BACKUP_FILE.gz -)
 ```
@@ -529,14 +537,18 @@ mongorestore \
 
 Physical restores require stopping the MongoDB workload and restoring data files directly. All replicas must participate.
 
+<Warning>
+Physical backup and restore have not been verified on this template. Treat the steps below as PBM's documented procedure rather than a proven path, and rehearse them on a throwaway cluster before relying on them.
+</Warning>
+
 <Steps>
   <Step title="Exec into a pbm-agent container">
-    ```sh
-    cpln workload exec {release-name}-mongo --gvc {gvc} --location {location} --replica 0 --container pbm-agent -- /bin/sh
+    ```bash
+    cpln workload exec RELEASE_NAME-mongo --gvc GVC_NAME --location LOCATION --replica RELEASE_NAME-mongo-0 --container pbm-agent -- /bin/sh
     ```
   </Step>
   <Step title="List available backups">
-    ```sh
+    ```bash
     MONGO_URI="mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@localhost:27017/admin?replicaSet=rs0&authSource=admin&authMechanism=SCRAM-SHA-256"
     pbm list --mongodb-uri="${MONGO_URI}"
     ```
@@ -545,7 +557,7 @@ Physical restores require stopping the MongoDB workload and restoring data files
     Stop the workload via the Control Plane console or CLI before restoring.
   </Step>
   <Step title="Run the restore">
-    ```sh
+    ```bash
     pbm restore BACKUP_NAME --mongodb-uri="${MONGO_URI}"
     ```
   </Step>
@@ -569,18 +581,25 @@ Scaling down requires manually removing departing replicas from the replica set 
 Before reducing the replica count, connect to the primary and remove each departing replica:
 
 ```js
-rs.remove("replica-{N}.{release-name}-mongo.{location}.{gvc}.cpln.local:27017")
+rs.remove("replica-N.RELEASE_NAME-mongo.LOCATION.GVC_NAME.cpln.local:27017")
 ```
 
 After all departing replicas are removed from the config, apply the template upgrade to reduce the count.
 
 ## Important Notes
 
+- **Both prerequisite secrets must exist before you install.** A missing one wedges the deployment with no log output at all; the only diagnostic is `status.versions[].message` on the workload. See [Prerequisites](#prerequisites).
+- **Generate the keyfile, never invent one.** It must be 6-1024 characters from the base64 alphabet (`A-Z a-z 0-9 + / =`) — a `change-me-...` style placeholder will not boot. Use `openssl rand -base64 756`.
+- **The keyfile cannot be changed after the cluster is initialized.** Replacing it requires restarting every member with the new key at the same time.
+- **`gvc.name` must not match an existing GVC.** Helm adopts an existing GVC and deletes it on uninstall, taking every unrelated workload with it.
+- **The default is nine members across three regions.** Cross-region traffic is billed — reduce `gvc.locations` for a single-region deployment.
+- **Never reorder `gvc.locations` after install**, only append. The first entry is the bootstrap location that initializes the replica set.
 - **Minimum replicas**: Use at least 3 replicas per location for HA. A 2-replica cluster cannot maintain quorum if one replica fails.
-- **Replica set key**: The `replicaSetKey` must be generated before deployment and must not be changed after the cluster is initialized. Changing it requires a full cluster restart.
 - **Odd total replica count**: Aim for an odd total number of replicas across all locations (3, 5, 7, 9) to guarantee a clear majority in all failover scenarios.
+- **Any upgrade rolls the MongoDB tier** — about 7 minutes for three replicas. Avoid other maintenance during that window.
+- **Physical (PBM) backups are unverified** on this template; logical backups are verified end to end.
 - **Read from secondaries**: To offload reads from the primary, use `readPreference=secondaryPreferred` in your connection string. Secondary reads may be slightly stale due to replication lag.
-- **Connection pooling**: Configure `maxPoolSize` in your MongoDB driver to prevent connection exhaustion. A per-app-replica pool of 10–50 is a reasonable starting point.
+- **Connection pooling**: Configure `maxPoolSize` in your MongoDB driver to prevent connection exhaustion. A per-app-replica pool of 10-50 is a reasonable starting point.
 
 ## External References
 

--- a/template-catalog/templates/mongodb-cluster.mdx
+++ b/template-catalog/templates/mongodb-cluster.mdx
@@ -1,12 +1,18 @@
 ---
 title: MongoDB Cluster
-description: Deploy a highly available MongoDB replica set cluster on Control Plane using Percona Server for MongoDB. Covers single and multi-location topologies, HAProxy write routing, logical and physical backups, and scaling.
-keywords: ['mongodb', 'percona', 'replica set', 'nosql', 'document database', 'haproxy', 'mongodump', 'pbm', 'percona backup', 'multi-location', 'mongo cluster', 'database template']
+description: Deploy a highly available MongoDB replica set on Control Plane using Percona Server for MongoDB. Covers the prerequisite credential and keyfile secrets, single and multi-location topologies, HAProxy write routing, failover, backups, and migrating from template version 1.0.0.
+keywords: ['mongodb', 'percona', 'replica set', 'nosql', 'document database', 'haproxy', 'mongodump', 'pbm', 'percona backup', 'multi-location', 'mongo cluster', 'keyfile', 'failover', 'database template']
 ---
 
 ## Overview
 
-MongoDB Cluster deploys a highly available MongoDB replica set using Percona Server for MongoDB 8.0. The cluster provides automatic leader election, self-healing replica membership, and seamless failover across one or more locations. An optional HAProxy sidecar provides a stable write endpoint that always routes to the current primary.
+MongoDB Cluster deploys a highly available MongoDB replica set using Percona Server for MongoDB 8.0. The cluster provides automatic leader election, self-healing replica membership, and failover across one or more locations. An optional HAProxy workload provides a stable write endpoint that always routes to the current primary.
+
+Neither the database credentials nor the replica set keyfile are template values. Both come from secrets you create before installing, so no credential passes through Helm or lands in the release.
+
+<Warning>
+**Template version 1.1.0 is a breaking security change.** `mongodb.username`, `mongodb.password`, `mongodb.database` and `mongodb.replicaSetKey` were removed, and an install or upgrade that still sets any of them now fails at render instead of silently falling back to a published default. If you are running 1.0.0, read [Upgrading From 1.0.0](#upgrading-from-1-0-0) before you touch the release.
+</Warning>
 
 ### Architecture
 
@@ -16,26 +22,158 @@ MongoDB Cluster deploys a highly available MongoDB replica set using Percona Ser
 
 ### What Gets Created
 
-- **Stateful MongoDB Workload** — A multi-replica MongoDB container per configured location with persistent storage per replica.
-- **Standard HAProxy Proxy Workload** *(optional, enabled by default)* — Routes write traffic to the current primary replica.
-- **Volume Set** — One persistent volume per MongoDB replica for data storage.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to the credential secrets, and cloud storage access when backup is enabled.
-- **Secrets** — A dictionary secret holding admin credentials injected at startup.
-- **Cron Backup Workload** *(optional, logical mode)* — A scheduled `mongodump` job that writes compressed archives to AWS S3 or GCS.
-- **PBM Agent Sidecar + Cron Trigger** *(optional, physical mode)* — A continuously-running `pbm-agent` sidecar on each MongoDB replica, plus a lightweight cron workload that triggers the backup on schedule.
-- **GVC** — A GVC spanning all configured locations.
+- **GVC** — (`gvc.name`, default `mongodb-gvc`): a GVC spanning every location listed in `gvc.locations`. This template creates it; see the [GVC warning](#the-gvc-this-template-creates) below.
+- **Stateful MongoDB Workload** — (`RELEASE_NAME-mongo`): a MongoDB container per replica per configured location, serving TCP on port `27017` with per-replica DNS for peer discovery.
+- **Volume Set** — (`RELEASE_NAME-mongo-vs`): one persistent volume per replica, mounted at `/data/db`, with optional autoscaling.
+- **Identity & Policy** — (`RELEASE_NAME-mongo-identity`, `RELEASE_NAME-mongo-policy`): an identity bound to the MongoDB and backup workloads, and a policy granting it `reveal` on exactly the two secrets you created plus the chart's own startup-script secrets — nothing else. When backups are enabled, the identity also carries the Cloud Account binding the backup job uses to reach your bucket.
+- **Startup Secrets** — (`RELEASE_NAME-mongo-startup`, and `RELEASE_NAME-mongo-proxy-startup` / `RELEASE_NAME-mongo-pbm-startup` when those components are enabled): the chart's own boot scripts. They hold no credentials.
+- **HAProxy Workload** *(optional, enabled by default)* — (`RELEASE_NAME-mongo-proxy`): a standard workload routing writes to the current primary.
+- **Cron Backup Workload** *(optional, logical mode)* — (`RELEASE_NAME-mongo-backup`): a scheduled `mongodump` that writes compressed archives to AWS S3 or GCS.
+- **PBM Agent Sidecar + Cron Trigger** *(optional, physical mode)* — a `pbm-agent` sidecar on each MongoDB replica, plus a cron workload (`RELEASE_NAME-mongo-physical-backup`) that triggers the backup on schedule.
 
-<Note>
-This template creates its own GVC. Configure `gvc.locations` in `values.yaml` before installing.
-</Note>
+The template creates **no credential secret of its own**. The database password and the replica set keyfile live only in the prerequisite secrets described below.
+
+## Upgrading From 1.0.0
+
+Template version 1.0.0 took the database credentials as plain Helm values and shipped a working default password, and it shipped a **working replica set keyfile** as a default too. Both were published in the public template repository, which means every 1.0.0 install that kept the defaults shares one publicly known password and one publicly known keyfile. The keyfile is what replica set members authenticate to each other with, so anyone holding it can join a member to your cluster.
+
+| | 1.0.0 | 1.1.0 |
+|---|---|---|
+| Database credentials | `mongodb.username`, `mongodb.password`, `mongodb.database` values | `mongodb.credentialsSecretName` → a dictionary secret you create |
+| Replica set keyfile | `mongodb.replicaSetKey` value, with a working default | `mongodb.keyfileSecretName` → an opaque secret you create |
+| Where the secrets live | Rendered into the release by the chart | Created by you, referenced by name, never in the release |
+
+The two are deliberately **separate** secrets: granting an application `reveal` on the database credentials must not also hand it the key that lets a member join your replica set.
+
+<Warning>
+**Treat a 1.0.0 cluster's password and keyfile as compromised, not merely outdated.** Upgrading moves them out of Helm values, but it does not change the values themselves — an unchanged default password (`mypassword`) and the default `replicaSetKey` remain publicly known after the upgrade. Rotate both, as described in the steps below.
+</Warning>
+
+<Warning>
+**Carrying old values forward stops the upgrade.** All four removed keys are rejected at render, so `cpln helm upgrade` fails and your existing release is left untouched and running rather than quietly restarting with different credentials:
+
+```text
+Error: execution error at (mongodb-cluster/templates/policy.yaml:1:4): mongodb-cluster:
+`mongodb.password` was removed in 1.1.0 — the database credentials are no longer values. Create a
+`dictionary` secret holding `username`, `password` and `database`, and set
+`mongodb.credentialsSecretName` to its name. See Prerequisites in the README.
+```
+
+```text
+Error: ... mongodb-cluster: `mongodb.replicaSetKey` was removed in 1.1.0 — the replica set keyfile
+is now an `opaque` secret you create, named by `mongodb.keyfileSecretName`. Create it with:
+openssl rand -base64 756 | cpln secret create-opaque --name my-mongodb-keyfile --encoding plain -f -
+```
+
+`mongodb.username` and `mongodb.database` fail the same way.
+</Warning>
+
+<Steps>
+  <Step title="Read the credentials the cluster already uses">
+    The admin user is created the first time the data directory is initialized, so an existing cluster keeps whatever it was bootstrapped with. Recover the username, password, database name and the `replicaSetKey` from the values file you installed 1.0.0 with.
+  </Step>
+  <Step title="Create the two prerequisite secrets with those same values">
+    Follow [Prerequisites](#prerequisites), using the existing username, password and database name, and putting the **existing** `replicaSetKey` into the keyfile secret. Different values here do not change the cluster — they just leave the members unable to authenticate.
+
+    The keyfile in particular cannot be changed as part of this upgrade: it is what members use to authenticate to each other, and rotating it needs the separate procedure in the last step.
+  </Step>
+  <Step title="Remove the old keys from your values">
+    Delete `mongodb.username`, `mongodb.password`, `mongodb.database` and `mongodb.replicaSetKey`, then set `mongodb.credentialsSecretName` and `mongodb.keyfileSecretName` to the two secret names.
+  </Step>
+  <Step title="Upgrade, then rotate the password">
+    Rotate any password that came from the 1.0.0 default. Connect through the proxy and change it inside MongoDB, then update the dictionary secret to match:
+
+    ```js
+    db.getSiblingDB("admin").changeUserPassword("admin", "NEW-STRONG-PASSWORD")
+    ```
+
+    ```bash
+    printf 'data:\n  password: NEW-STRONG-PASSWORD\n' | cpln secret patch my-mongodb-credentials -f -
+    ```
+  </Step>
+  <Step title="Rotate the keyfile">
+    A published keyfile lets anyone who has it join a member to your replica set, so a cluster that ran on the 1.0.0 default needs a new one. The keyfile cannot be changed on a running cluster — every member must restart with the same new key, which means planned downtime. Generate a new key, replace the contents of the opaque secret, and restart the MongoDB workload so all members pick it up at once.
+
+    Expect the restart to take time: a rolling restart of a three-replica tier was measured at roughly **7 minutes** end to end.
+  </Step>
+</Steps>
 
 ## Prerequisites
 
-- At least one Control Plane [location](/reference/location) to deploy into.
-- A unique `replicaSetKey` generated before deploying: `openssl rand -base64 32`
-- For backup: an AWS or GCP [cloud account](/guides/create-cloud-account) and a storage bucket.
+**Two secrets must exist before you install.** Neither value passes through Helm values, so neither lands in the release. Secrets are org-level, so no GVC flag is involved.
 
-### Installation
+<Steps>
+  <Step title="Create the database credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly three keys — `username`, `password` and `database`. MongoDB is bootstrapped with this user, and this is the credential your applications put in their connection strings:
+
+    ```bash
+    cpln secret create-dictionary --name my-mongodb-credentials \
+      --entry username=admin \
+      --entry password='YOUR-STRONG-PASSWORD' \
+      --entry database=mydatabase
+    ```
+
+    Set `mongodb.credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Create the replica set keyfile secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain` holding the key that replica set members authenticate to each other with. **Generate it — do not invent a passphrase:**
+
+    ```bash
+    openssl rand -base64 756 | cpln secret create-opaque --name my-mongodb-keyfile --encoding plain -f -
+    ```
+
+    Set `mongodb.keyfileSecretName` to the name you used.
+  </Step>
+  <Step title="Read either secret back later">
+    ```bash
+    cpln secret reveal my-mongodb-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**The keyfile must be valid base64, or the cluster will not start.** MongoDB accepts **6–1024 characters from the base64 alphabet only** — `A-Z`, `a-z`, `0-9`, `+`, `/` and `=`. A hand-written passphrase such as `change-me-mongodb-key` **will not boot**, because hyphens are outside that alphabet. `openssl rand -base64 756` produces 1008 characters, which is the largest generator that still fits under the 1024 limit.
+
+The container checks the key at boot and fails with an explicit message naming your secret, before MongoDB is ever started:
+
+```text
+FATAL: the keyfile in secret 'my-mongodb-keyfile' contains characters outside the base64 alphabet
+(A-Z a-z 0-9 + / =). A passphrase with hyphens or punctuation will NOT work. Regenerate it with:
+openssl rand -base64 756
+```
+
+A key that is too short gets its own message: `the keyfile in secret 'my-mongodb-keyfile' is 3 characters; mongod requires 6-1024`. Both appear in `cpln logs` only — the workload status shows just `Error: exitCode: 1`.
+</Warning>
+
+<Warning>
+**Create both secrets before installing.** The template refuses to render when either name is blank, but a name pointing at a secret that does not exist installs "successfully" and then wedges: `cpln helm install` reports every resource created, the workload never becomes ready, and **`cpln logs` shows nothing at all** because no container ever starts. The only diagnostic is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-mongo --gvc GVC_NAME -o json
+```
+
+It names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` Creating the secret does recover the workload on its own — measured at about **6 minutes**, so a user who waits only five will wrongly conclude the install is broken.
+</Warning>
+
+### The GVC This Template Creates
+
+This template **creates its own GVC**, named by `gvc.name` (default `mongodb-gvc`), spanning every location in `gvc.locations`.
+
+<Warning>
+**Never set `gvc.name` to a GVC that already exists.** Helm adopts a GVC whose name matches, and `helm uninstall` then **deletes it**, taking every unrelated workload in it — and it does so even when the GVC carries a `helm.sh/resource-policy: keep` annotation. Adoption also permanently pins the release name: a later install under a different name is rejected. Always pick a GVC name no other release uses.
+</Warning>
+
+<Note>
+**Mind the default cost shape.** The shipped default is three locations × 3 replicas — **nine members across three regions** — and cross-region traffic is billed. Reduce `gvc.locations` to a single entry for a single-region deployment.
+</Note>
+
+### Other Prerequisites
+
+- At least one Control Plane [location](/reference/location) to deploy into.
+- For backups: an AWS or GCP [cloud account](/guides/create-cloud-account) and a storage bucket — see [AWS S3](#aws-s3) or [GCS](#gcs).
+
+## Installation
+
 
 To install, follow the instructions for your preferred method:
 

--- a/template-catalog/templates/mongodb-cluster.mdx
+++ b/template-catalog/templates/mongodb-cluster.mdx
@@ -222,12 +222,24 @@ resources:
   cpu: 1
   memory: 2Gi
 
+# ─── Credentials (prerequisite secrets) ───────────────────────────────────────
+# BOTH SECRETS MUST EXIST BEFORE YOU INSTALL — the deployment wedges waiting on a
+# secret that does not exist. Neither value passes through Helm values, so neither
+# lands in the release. See Prerequisites in the README for the exact commands.
 mongodb:
-  username: admin
-  password: mypassword
-  database: mydatabase
-  # REQUIRED: Generate with `openssl rand -base64 32`
-  replicaSetKey: "Ol0GnqpqntkcnjprS+Pu/1Ji8fcSEKb8f4zkF5c+dEQ="
+  # `dictionary` secret holding exactly three keys: `username`, `password`,
+  # `database`. This is the credential you put in your applications' connection
+  # strings, and the root user the cluster is bootstrapped with.
+  credentialsSecretName: my-mongodb-credentials
+
+  # `opaque` secret (encoding: plain) holding the replica set keyfile — the shared
+  # key cluster members authenticate to each other with. Anyone holding it can join
+  # a member to the replica set, so it is kept SEPARATE from the credentials above.
+  # CONTENT RULES (mongod rejects anything else): 6-1024 characters from the base64
+  # alphabet only — A-Z a-z 0-9 + / = — after whitespace is stripped. Generate with
+  # `openssl rand -base64 756`; do NOT invent a passphrase, hyphens alone break it.
+  # It CANNOT be changed after the cluster is initialized.
+  keyfileSecretName: my-mongodb-keyfile
 
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
@@ -254,22 +266,26 @@ proxy:
 backup:
   enabled: false
   mode: logical # options: logical, physical
+
   schedule: "0 2 * * *" # daily at 2am UTC
+
   provider: aws # options: aws or gcp
 
+  # Logical backup (mongodump)
   logical:
     image: ghcr.io/controlplane-com/backup-images/mongo-backup:8.0
     resources:
       cpu: 100m
       memory: 128Mi
 
+  # Physical backup (Percona Backup for MongoDB)
   physical:
     image: percona/percona-backup-mongodb:2.14.0
-    resources:      # pbm-agent sidecar (runs continuously)
+    resources:
       cpu: 100m
       memory: 128Mi
     cron:
-      resources:    # backup trigger job (runs briefly on schedule)
+      resources:
         cpu: 50m
         memory: 64Mi
 
@@ -286,9 +302,11 @@ backup:
     prefix: mongodb-cluster/backups
 ```
 
-### Locations
+### GVC and Locations
 
-Configure which Control Plane locations to deploy into and how many replicas to run per location. Each entry in `gvc.locations` creates a set of MongoDB replicas at that location.
+`gvc.name` names the GVC this template **creates** — it must not match an existing GVC, as explained in [The GVC This Template Creates](#the-gvc-this-template-creates).
+
+`gvc.locations` sets which Control Plane locations to deploy into and how many replicas to run per location. Each entry creates a set of MongoDB replicas at that location.
 
 **Single Location** — all replicas in one location. A minimum of 3 replicas is required for majority quorum:
 
@@ -316,17 +334,32 @@ gvc:
 Aim for an odd total replica count (3, 5, 7, 9) across all locations to guarantee a clear majority in all split-brain scenarios.
 </Note>
 
+Adding a location to an existing cluster works without any manual step: new members discover the primary through the seed list and register themselves into the replica set. This was verified across `aws-us-east-1` and `aws-eu-central-1` in a single replica set.
+
+<Warning>
+**Never reorder `gvc.locations` after installing — only append.** The first entry is the bootstrap location: replica 0 there is the member that initializes the replica set. Moving a different location into first position points that logic at a replica with an empty data directory, which can initialize a second, independent replica set.
+</Warning>
+
 ### Multi-Zone
 
 Set `multiZone: true` to spread replicas across availability zones within each location, protecting against zone-level failures. Verify your selected location(s) support multi-zone before enabling.
 
 ### MongoDB Settings
 
-- `mongodb.username` / `mongodb.password` — Admin credentials. Change these before deploying to production.
-- `mongodb.database` — Default database name created at startup.
-- `mongodb.replicaSetKey` — Shared secret used to authenticate replica set members to each other. **Must be generated before deploying** with `openssl rand -base64 32`. This value must not be changed after the cluster is initialized — doing so requires a full cluster restart.
+- `mongodb.credentialsSecretName` — Name of the dictionary secret holding `username`, `password` and `database`. The cluster is bootstrapped with this user on first start, and this is the credential your applications use. Must exist before install — see [Prerequisites](#prerequisites).
+- `mongodb.keyfileSecretName` — Name of the opaque secret holding the replica set keyfile. Must exist before install, and its contents must be generated with `openssl rand -base64 756`.
 - `resources.cpu` / `resources.memory` — Resource limits applied to each MongoDB replica.
 - `image` — MongoDB image. Defaults to `percona/percona-server-mongodb:8.0`.
+
+Neither credential is a Helm value, so neither appears in the release. The two secrets stay separate so that an application granted `reveal` on the database credentials cannot also read the key that lets a member join the replica set.
+
+<Warning>
+**The keyfile cannot be changed after the cluster is initialized.** It authenticates replica set members to each other; replacing it requires every member to restart with the new key at the same time, which means planned downtime.
+</Warning>
+
+<Note>
+The `database` entry of the credentials secret is for your own connection strings — the cluster is bootstrapped with the admin user, and MongoDB creates a database the first time you write to it.
+</Note>
 
 ### HAProxy Proxy
 
@@ -337,7 +370,7 @@ HAProxy is enabled by default and strongly recommended. In a MongoDB replica set
 - `proxy.resources` — CPU and memory limits for the proxy workload.
 
 <Note>
-HAProxy is required when using logical backups (`backup.mode: logical`). Physical (PBM) backups connect directly to replicas and do not require the proxy.
+**Backups do not use the proxy.** Both the logical and the physical backup jobs connect to `replica-0` directly, so disabling the proxy does not affect them. The proxy matters for clients that cannot track the primary themselves.
 </Note>
 
 ### Storage
@@ -362,19 +395,25 @@ Connect using the appropriate endpoint depending on your setup:
 
 | Setup | Hostname | Port |
 |-------|----------|------|
-| Via HAProxy (writes + reads) | `{release-name}-mongo-proxy.{gvc}.cpln.local` | `27017` |
-| Direct per-replica (read-only or internal) | `replica-{N}.{release-name}-mongo.{location}.{gvc}.cpln.local` | `27017` |
+| Via HAProxy (writes + reads) | `RELEASE_NAME-mongo-proxy.GVC_NAME.cpln.local` | `27017` |
+| Direct per-replica (read-only or internal) | `replica-N.RELEASE_NAME-mongo.LOCATION.GVC_NAME.cpln.local` | `27017` |
 
-Example connection string via proxy:
+The username, password and database name are the three entries of your credentials secret. Read them back with:
 
+```bash
+cpln secret reveal my-mongodb-credentials -o yaml
 ```
-mongodb://admin:mypassword@{release-name}-mongo-proxy.{gvc}.cpln.local:27017/mydatabase?authSource=admin
+
+Example connection string via the proxy:
+
+```text
+mongodb://USERNAME:PASSWORD@RELEASE_NAME-mongo-proxy.GVC_NAME.cpln.local:27017/DATABASE?authSource=admin
 ```
 
 To offload reads from the primary, add `readPreference=secondaryPreferred` to your connection string and connect directly to a replica:
 
-```
-mongodb://admin:mypassword@replica-0.{release-name}-mongo.{location}.{gvc}.cpln.local:27017/mydatabase?authSource=admin&readPreference=secondaryPreferred
+```text
+mongodb://USERNAME:PASSWORD@replica-0.RELEASE_NAME-mongo.LOCATION.GVC_NAME.cpln.local:27017/DATABASE?authSource=admin&readPreference=secondaryPreferred
 ```
 
 <Note>
@@ -382,6 +421,18 @@ Secondary reads may be slightly stale due to replication lag. Use `readPreferenc
 </Note>
 
 Configure `maxPoolSize` in your MongoDB driver to prevent connection exhaustion. A per-app-replica pool of 10–50 connections is a reasonable starting point for most workloads.
+
+The cluster has no public endpoint — it is reachable only from inside the org, subject to [Firewall](#firewall).
+
+### Failover Behavior
+
+When the primary goes away, the remaining members elect a new one and the proxy re-routes to it. Clients connected through the proxy keep the same connection string and need no change.
+
+In testing, stopping the primary replica of a three-member cluster restored write availability in **5 seconds or less**, with data written before the failover intact and writes after it landing on the new primary. The stopped replica was rescheduled and rejoined as a secondary about **3 minutes** later. That timing reflects a graceful handover — the container steps down the primary before it exits — so an abrupt node loss takes longer, bounded by MongoDB's election timeout.
+
+<Warning>
+**Do not lose a replica while an upgrade is rolling.** Any `helm upgrade` restarts the MongoDB tier one replica at a time, which takes roughly **7 minutes** for three replicas. Losing another member during that window can leave a three-member cluster with one live member and no quorum. Wait for the rollout to finish before performing any maintenance.
+</Warning>
 
 ## Backing Up
 

--- a/template-catalog/templates/pgdog.mdx
+++ b/template-catalog/templates/pgdog.mdx
@@ -1,26 +1,38 @@
 ---
 title: PgDog
-description: Deploy PgDog on Control Plane — a high-performance PostgreSQL connection pooler, load balancer, and sharding proxy written in Rust. Sits transparently in front of any PostgreSQL deployment and provides transaction or session pooling, automatic read/write splitting, and multi-replica load balancing.
-keywords: ['pgdog', 'postgresql proxy', 'connection pooler', 'pgbouncer alternative', 'read write splitting', 'postgres load balancer', 'postgres sharding', 'rust postgres proxy', 'scram authentication']
+description: Deploy PgDog on Control Plane using the Template Catalog — a high-performance PostgreSQL connection pooler, load balancer, and query router written in Rust. Covers the prerequisite credential secrets, transaction and session pooling, automatic read/write splitting, and the admin database.
+keywords: ['pgdog', 'postgresql proxy', 'connection pooler', 'pgbouncer alternative', 'read write splitting', 'postgres load balancer', 'postgres sharding', 'rust postgres proxy', 'scram authentication', 'prerequisite secret', 'connection pooling']
 ---
 
 ## Overview
 
-PgDog is a high-performance PostgreSQL connection pooler, load balancer, and sharding proxy written in Rust. It sits transparently in front of one or more PostgreSQL instances and appears to clients as a standard PostgreSQL server — no application code changes required, only a connection string update.
+PgDog is a high-performance PostgreSQL connection pooler, load balancer, and query router written in Rust. It sits transparently in front of one or more PostgreSQL instances and appears to clients as a standard PostgreSQL server — no application code changes required, only a connection string update.
 
-PgDog parses SQL queries to automatically route writes (`INSERT`, `UPDATE`, `DELETE`, DDL) to a primary backend and distribute `SELECT` queries across replicas. Works with any PostgreSQL-compatible backend including the Control Plane [PostgreSQL](/template-catalog/templates/postgres) and [PostgreSQL Highly Available](/template-catalog/templates/postgres-highly-available) templates, or any external PostgreSQL endpoint.
+PgDog parses SQL queries to automatically route writes (`INSERT`, `UPDATE`, `DELETE`, DDL) to a primary backend and distribute `SELECT` queries across replicas. It works with any PostgreSQL-compatible backend, including the Control Plane [PostgreSQL](/template-catalog/templates/postgres) and [PostgreSQL Highly Available](/template-catalog/templates/postgres-highly-available) templates, or any external PostgreSQL endpoint.
+
+Every credential comes from a secret you create **before** installing. Nothing sensitive passes through Helm values, so no password lands in the release, the rendered manifest, the stored workload spec, or the logs.
+
+<Warning>
+**Upgrading an install created with `1.0.0` is a breaking change.** `users[].name`, `users[].password` and `admin.password` no longer exist, and an upgrade that still sets any of them stops with an error naming its replacement rather than silently falling back to a default password. See [Upgrading From 1.0.0](#upgrading-from-1-0-0).
+</Warning>
 
 ### Architecture
 
-- **PgDog workload** — Stateless proxy that multiplexes client connections into a smaller pool of real backend connections. Scales horizontally; each replica maintains its own connection pool.
-- **pgdog.toml** — Main configuration rendered as a secret and mounted at startup. Defines backend databases, pool settings, timeouts, and load balancing strategy.
-- **users.toml** — Credentials configuration rendered as a separate secret. Defines which users can connect to PgDog and which backend databases they map to.
+- **PgDog workload** — Stateless proxy that multiplexes client connections into a smaller pool of real backend connections, routes writes to a primary, and distributes reads across replicas. Listens on port `6432`.
+- **Config secret** — The static half of `pgdog.toml`: general settings and the `[[databases]]` backends, rendered by the chart and mounted read-only. It holds no credentials.
+- **Startup script secret** — PgDog reads credentials only from files on disk and has no environment-variable interpolation, so a startup script assembles the final `pgdog.toml` and `users.toml` inside the container at boot from your prerequisite secrets, then execs PgDog. That is what keeps the credentials out of the Helm release.
+- **Identity & policy** — Grants the workload `reveal` on exactly the secrets it needs: the two chart-created ones, the admin password secret, and each pooled user's credentials secret.
 
 ### What Gets Created
 
-- **Standard PgDog Workload** — Stateless proxy workload listening on port 6432.
-- **Identity & Policy** — Identity for the workload with access to credential secrets.
-- **Secrets** — Two opaque secrets: one for `pgdog.toml` (database and pooling config) and one for `users.toml` (user credentials).
+- **Standard PgDog Workload** — `RELEASE_NAME-pgdog`, a stateless proxy serving TCP on port `6432`.
+- **Config Secret** — `RELEASE_NAME-pgdog-config`, an opaque secret holding the credential-free base `pgdog.toml`.
+- **Startup Script Secret** — `RELEASE_NAME-pgdog-startup`, an opaque secret holding the script that assembles the config at container start.
+- **Identity & Policy** — `RELEASE_NAME-pgdog-identity` and `RELEASE_NAME-pgdog-policy`, granting `reveal` on the two chart secrets plus every prerequisite secret you referenced, and nothing else.
+
+<Note>
+This template creates no secret that contains a credential. Your pooled-user and admin secrets are yours, which means uninstalling the release never destroys them.
+</Note>
 
 <Note>
 This template does not create a GVC or a PostgreSQL instance. Deploy it into an existing GVC and point it at an existing PostgreSQL backend.
@@ -28,7 +40,59 @@ This template does not create a GVC or a PostgreSQL instance. Deploy it into an 
 
 ## Prerequisites
 
-This template has no external prerequisites. To install, follow the instructions for your preferred method:
+**Every secret you reference must exist before you install.** Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create one credentials secret per pooled user">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly two keys — `username` and `password`. PgDog authenticates incoming clients with this pair *and* opens backend connections with it, so it must be a real PostgreSQL role on the backend:
+
+    ```bash
+    cpln secret create-dictionary --name my-pgdog-user-credentials \
+      --entry username=appuser \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `users[0].credentialsSecretName` to the name you used. Because the username travels inside the secret, you can point this straight at the secret your backend already uses — see [Pooled Users](#pooled-users).
+  </Step>
+  <Step title="Create the admin password secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain`, whose payload is the password for PgDog's admin database:
+
+    ```bash
+    printf '%s' "$(openssl rand -hex 32)" | cpln secret create-opaque --name my-pgdog-admin-password --encoding plain -f -
+    ```
+
+    Set `admin.passwordSecretName` to the name you used. Use `printf`, not `echo` — `echo` appends a newline, which cannot be carried in a TOML value. The startup script detects a trailing newline and fails at boot with that message rather than starting a proxy that rejects every admin login.
+  </Step>
+  <Step title="Read a secret back later">
+    `-o yaml` is required. Without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-pgdog-admin-password -o yaml
+    cpln secret reveal my-pgdog-user-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, every resource is created, and the workload then never starts — it sits at zero replicas. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-pgdog --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-pgdog-admin-password no longer exists. Workload updates are paused
+until the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery was measured at **7 minutes 37 seconds** here, inside the 5.5–8.5 minute range seen across the catalog. A forced redeployment shortcuts it to roughly 90 seconds.
+</Warning>
+
+## Installation
+
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -52,6 +116,51 @@ This template has no external prerequisites. To install, follow the instructions
     </Card>
 </CardGroup>
 
+The proxy reaches `ready` roughly 25 seconds after install, once the startup script has assembled the config from your secrets and PgDog is listening on port `6432`.
+
+## Upgrading From 1.0.0
+
+Version `1.1.0` moved every credential out of Helm values. `1.0.0` shipped working defaults — a pooled-user password and an admin password published in the public template repository — and PgDog is precisely the thing applications put in their connection strings, so those values were the product rather than internal plumbing.
+
+| | `1.0.0` | `1.1.0` |
+|---|---|---|
+| Pooled-user name | `users[].name` value | `username` key of a dictionary secret you create |
+| Pooled-user password | `users[].password` value | `password` key of that same secret |
+| Which secret | — | `users[].credentialsSecretName`, one per entry |
+| Admin password | `admin.password` value | `admin.passwordSecretName` — an opaque secret you create |
+| Rendered `users.toml` | Chart-rendered secret containing every password | Assembled in-container at boot; no credential in the release |
+| CPU and memory limits | `resources.cpu`, `resources.memory` | `resources.maxCpu`, `resources.maxMemory` |
+
+<Warning>
+**A `helm upgrade` that still carries the old values is rejected before anything is applied.** Seven guard conditions stop the render, each naming its replacement. All of them were exercised against a real `cpln helm upgrade`, which failed client-side and left the running release untouched and healthy — no failed revision was created.
+
+| Value you still set | What the render says |
+|---|---|
+| `users[].password` | `users[0].password was REMOVED in pgdog 1.1.0. Pooled-user credentials are no longer values: create a dictionary secret holding the keys username and password, and set users[0].credentialsSecretName to its name.` |
+| `users[].name` | `users[0].name was REMOVED in pgdog 1.1.0. The username now comes from the username key of the dictionary secret named by users[0].credentialsSecretName, so that it travels with the password it belongs to.` |
+| `admin.password` | `admin.password was REMOVED in pgdog 1.1.0. The admin password is no longer a value: create an opaque secret (encoding: plain) holding it, and set admin.passwordSecretName to its name.` |
+| `resources.cpu` | `resources.cpu was RENAMED to resources.maxCpu in pgdog 1.1.0.` |
+| `resources.memory` | `resources.memory was RENAMED to resources.maxMemory in pgdog 1.1.0.` |
+| `users[].credentialsSecretName` empty | `users[0].credentialsSecretName is required - it names the dictionary secret holding that pooled user's username and password keys. Create that secret BEFORE installing.` |
+| `admin.passwordSecretName` empty | `admin.passwordSecretName is required - it names the opaque secret holding the PgDog admin password. Create that secret BEFORE installing.` |
+
+This is deliberate: a silently ignored `admin.password` would leave you believing you had set a password you had not.
+</Warning>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the secrets">
+    Follow [Prerequisites](#prerequisites). Put the credentials your applications **already use** into the pooled-user secret so existing connection strings keep working, and pick a fresh admin password — the old one was a published default.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `users[].name`, `users[].password` and `admin.password`. Set `users[].credentialsSecretName` and `admin.passwordSecretName` instead, and rename `resources.cpu` and `resources.memory` to `resources.maxCpu` and `resources.maxMemory` if you had overridden them.
+  </Step>
+  <Step title="Upgrade">
+    The upgrade replaces the single stateless replica. Client connections are dropped and reconnect against the new one; there is no data to migrate.
+  </Step>
+</Steps>
+
 ## Configuration
 
 The default `values.yaml` for this template:
@@ -60,10 +169,10 @@ The default `values.yaml` for this template:
 image: ghcr.io/pgdogdev/pgdog:v0.1.45
 
 resources:
-  cpu: 500m
-  memory: 256Mi
   minCpu: 100m
   minMemory: 128Mi
+  maxCpu: 500m
+  maxMemory: 256Mi
 
 replicas: 1
 
@@ -71,12 +180,12 @@ pooling:
   mode: transaction          # options: transaction, session
   defaultPoolSize: 10        # max server connections per pool
   minPoolSize: 1             # minimum idle connections kept open
-  workers: 2                 # async threads; recommend 2× vCPU count
+  workers: 2                 # tokio async threads; recommend 2× vCPU count
 
-timeouts:
-  connect: 5000              # time to establish a backend connection (ms)
-  checkout: 5000             # max time a client waits for a free connection (ms)
-  idle: 60000                # idle server connections closed after this (ms)
+timeouts:                    # milliseconds
+  connect: 5000              # time to establish a backend connection
+  checkout: 5000             # max time a client waits for a free connection
+  idle: 60000                # idle server connections closed after this
   query: 0                   # per-query timeout; 0 = disabled
 
 loadBalancing:
@@ -84,35 +193,40 @@ loadBalancing:
   readWriteSplit: include_primary
 
 databases:
-  - name: mydb
-    host: postgres.example.com
+  - name: my-pgdog-database  # logical name clients connect to; must be a real database on the backend
+    host: my-postgres-workload  # e.g. WORKLOAD_NAME for an in-GVC Postgres, or an external hostname
     port: 5432
     role: primary            # options: primary, replica, auto
 
+# Each entry needs ITS OWN prerequisite `dictionary` secret holding `username`
+# and `password`. THE SECRET MUST EXIST BEFORE YOU INSTALL.
 users:
-  - name: myuser
-    password: mypassword
-    database: mydb
+  - credentialsSecretName: my-pgdog-user-credentials
+    database: my-pgdog-database   # must match a `name` from the databases list above
 
 admin:
   database: admin
   user: admin
-  password: changeme
+  # REQUIRED PREREQUISITE SECRET — an `opaque` secret (encoding: plain) whose
+  # payload is the admin password. Kept SEPARATE from the pooled-user credentials.
+  passwordSecretName: my-pgdog-admin-password
 
 auth:
   type: scram
 
 logging:
   format: text               # options: text, json, json_flattened
-  level: info
+  level: info                # RUST_LOG syntax; e.g. info, debug, pgdog=debug
 
 publicAccess:
   enabled: false
-  # address: pgdog.example.com
+  # address: my-pgdog-domain.example.com  # name of an existing cpln domain resource
 
 internalAccess:
   type: same-gvc             # options: none, same-gvc, same-org, workload-list
   workloads: []
+  # workloads:
+  #   - //gvc/my-gvc/workload/my-app
 ```
 
 ### Backend Databases
@@ -121,18 +235,13 @@ The `databases` list defines the PostgreSQL backends PgDog proxies. Each entry m
 
 ```yaml
 databases:
-  - name: mydb
-    host: my-postgres.my-gvc.cpln.local
+  - name: appdb
+    host: my-postgres-postgres.GVC_NAME.cpln.local
     port: 5432
     role: primary
 
-  - name: mydb
-    host: replica-1.my-patroni-postgres.aws-us-east-1.my-gvc.cpln.local
-    port: 5432
-    role: replica
-
-  - name: mydb
-    host: replica-2.my-patroni-postgres.aws-us-east-1.my-gvc.cpln.local
+  - name: appdb
+    host: replica-1.my-patroni-postgres.aws-us-east-1.GVC_NAME.cpln.local
     port: 5432
     role: replica
 ```
@@ -143,46 +252,61 @@ databases:
 | `replica` | Receives read queries (`SELECT`) distributed by the load balancing strategy |
 | `auto` | PgDog detects the role via `pg_is_in_recovery()` at connection time |
 
-**Using with the PostgreSQL template** — Set `host` to `{release-name}-postgres.{gvc}.cpln.local`.
+**Using with the PostgreSQL template** — Set `host` to `RELEASE_NAME-postgres`. That workload is `stateful`, so its short name resolves inside the GVC; the fully qualified `RELEASE_NAME-postgres.GVC_NAME.cpln.local` works too.
 
-**Using with the PostgreSQL Highly Available template** — Point the `primary` entry at the HA proxy (`{release-name}-postgres-ha-proxy.{gvc}.cpln.local`) and add `replica` entries using the replicaDirect hostnames (`replica-{n}.{release-name}-postgres-ha.{location}.{gvc}.cpln.local`).
+**Using with the PostgreSQL Highly Available template** — Point the `primary` entry at the HA proxy (`RELEASE_NAME-postgres-ha-proxy`) and add `replica` entries using the replicaDirect hostnames (`replica-N.RELEASE_NAME-postgres-ha.LOCATION.GVC_NAME.cpln.local`).
 
-### Users
+### Pooled Users
 
-The `users` list defines which clients can connect to PgDog. Each entry maps to a `[[users]]` block in `users.toml`. The `database` field must match a `name` from the `databases` list.
+Each entry in `users` maps to a `[[users]]` block in `users.toml`. Only the routing target is a value — the username and password both come from the dictionary secret named by `credentialsSecretName`:
 
 ```yaml
 users:
-  - name: myuser
-    password: mypassword
-    database: mydb
+  - credentialsSecretName: my-pgdog-user-credentials
+    database: appdb   # must match a `name` from the databases list
 ```
 
-PgDog uses the `name` and `password` to authenticate incoming clients, then uses the same credentials to connect to the backend PostgreSQL server.
+Because the username lives inside the secret rather than beside it, **a user entry can point at the secret your PostgreSQL install already uses.** PgDog authenticates the client with that pair and then opens its backend connections with the same pair, so it has to be a real PostgreSQL role — which is exactly what the [PostgreSQL](/template-catalog/templates/postgres) template's own `credentialsSecretName` secret holds. Pointing both templates at one secret was tested end to end: PgDog reads only the `username` and `password` keys and ignores the extra `database` key that PostgreSQL stores alongside them.
+
+**To pool a second user**, create a second dictionary secret and add a second entry — one secret per entry:
+
+```bash
+cpln secret create-dictionary --name my-pgdog-reporting-credentials \
+  --entry username=reporting \
+  --entry password="$(openssl rand -hex 24)"
+```
+
+```yaml
+users:
+  - credentialsSecretName: my-pgdog-user-credentials
+    database: appdb
+  - credentialsSecretName: my-pgdog-reporting-credentials
+    database: reporting
+```
+
+The chart adds a policy target for each secret automatically, so nothing else needs changing.
+
+<Note>
+**Two entries may name the same secret**, which is how you route one PostgreSQL role to two backend databases. The duplicate is deduplicated in the policy, so the secret appears as a single `reveal` target. There is deliberately no way to put two users in one secret — a secret holds one `username`/`password` pair.
+</Note>
 
 ### Connection Pooling
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `pooling.mode` | `transaction` | Pool mode: `transaction` or `session` |
-| `pooling.defaultPoolSize` | `10` | Maximum real Postgres connections per pool |
+| `pooling.defaultPoolSize` | `10` | Maximum real PostgreSQL connections per pool |
 | `pooling.minPoolSize` | `1` | Minimum idle connections kept open |
 | `pooling.workers` | `2` | Async threads; recommended value is 2× vCPU count |
 
 | Pool Mode | Description |
 |-----------|-------------|
 | `transaction` | Backend connection held only for the duration of a transaction, then returned to the pool. Best for most web and API workloads. Not compatible with `SET` variables, temporary tables, or advisory locks. |
-| `session` | Backend connection held for the entire client session. Compatible with all Postgres features. Increase `defaultPoolSize` to match expected concurrent client count. |
+| `session` | Backend connection held for the entire client session. Compatible with all PostgreSQL features, and reuses connections less — raise `defaultPoolSize` to match expected concurrent client count. |
 
-### Load Balancing
-
-| Strategy | Description |
-|----------|-------------|
-| `least_active_connections` | Routes reads to the replica with the fewest active connections. Recommended for most workloads. |
-| `round_robin` | Distributes reads evenly across all replicas in rotation. |
-| `random` | Selects a replica at random for each read query. |
-
-`readWriteSplit: include_primary` allows the primary to also serve reads when no replicas are available.
+<Note>
+The chart's validation also accepts a third value, `statement`, which upstream PgDog documents but which has not been verified end to end on this platform. Stay on `transaction` or `session` unless you are prepared to test it yourself.
+</Note>
 
 ### Timeouts
 
@@ -195,40 +319,51 @@ All timeout values are in milliseconds.
 | `timeouts.idle` | `60000` | Idle backend connections closed after this duration |
 | `timeouts.query` | `0` | Per-query timeout; `0` disables it |
 
+### Load Balancing
+
+| Strategy | Description |
+|----------|-------------|
+| `least_active_connections` | Routes reads to the replica with the fewest active connections. Recommended for most workloads. |
+| `round_robin` | Distributes reads evenly across all replicas in rotation. |
+| `random` | Selects a replica at random for each read query. |
+
+`readWriteSplit: include_primary` allows the primary to also serve reads.
+
 ### Admin Database
 
-PgDog exposes an internal admin database for stats and introspection.
+PgDog exposes an internal admin database for stats and introspection. The names are ordinary values; the password is a prerequisite secret:
 
 ```yaml
 admin:
   database: admin
   user: admin
-  password: changeme
+  passwordSecretName: my-pgdog-admin-password
 ```
 
-<Warning>
-Always set `admin.password` explicitly. If omitted, PgDog generates a random password at each startup, making the admin database inaccessible across restarts.
-</Warning>
+Keeping it in its own secret is the point of the split: an application granted `reveal` on a pooled user's credentials cannot also reach the admin database. Both directions were verified — the pooled user's password is refused on the `admin` database, and the admin password is refused on a pooled database.
 
-Connect to the admin database with any PostgreSQL client:
+Connect from a workload inside the GVC with any PostgreSQL client:
 
 ```bash
-PGPASSWORD=<admin.password> psql \
-  -h {release-name}-pgdog.{gvc}.cpln.local \
-  -p 6432 \
-  -U admin \
-  -d admin
+PGPASSWORD="$(cpln secret reveal my-pgdog-admin-password -o yaml | awk '/^  payload:/ {print $2}')" \
+  psql -h RELEASE_NAME-pgdog.GVC_NAME.cpln.local -p 6432 -U admin -d admin
 ```
+
+`SHOW CLIENTS`, `SHOW POOLS` and the other PgDog admin commands are available on that session.
 
 ### Access
 
-- `internalAccess.type` — Controls which workloads can reach PgDog internally: `same-gvc`, `same-org`, `workload-list`, or `none`.
-- `publicAccess.enabled` — When `true`, Control Plane provisions a public TCP load balancer. The assigned hostname (e.g. `pgdog-name-hash.cpln.app:6432`) is visible in the Control Plane console or via `cpln workload get <name> -o yaml`.
-- `publicAccess.address` — Optional custom domain to attach when public access is enabled.
+- `internalAccess.type` — Controls which workloads can reach PgDog internally: `same-gvc` (default), `same-org`, `workload-list`, or `none`. With `workload-list`, name each caller in `internalAccess.workloads` as `//gvc/GVC_NAME/workload/WORKLOAD_NAME`.
+- `publicAccess.enabled` — When `true`, Control Plane provisions a public TCP load balancer on port `6432` and assigns a canonical `*.cpln.app` hostname automatically. Read it from `status.canonicalEndpoint` in `cpln workload get RELEASE_NAME-pgdog --gvc GVC_NAME -o yaml`.
+- `publicAccess.address` — Optional custom domain to attach when public access is enabled. It names an existing Control Plane domain resource.
+
+<Note>
+**Give the public endpoint time to come up.** Flipping `publicAccess.enabled` on took **255 seconds** to accept its first external connection in testing — longer than the 30–150 seconds most templates take. Budget anywhere from 30 seconds to about 5 minutes, and do not read a refused connection in the first few minutes as a broken setting.
+</Note>
 
 ### Scaling
 
-PgDog is stateless and scales horizontally by increasing `replicas`. Each replica maintains its own connection pool — scale `pooling.defaultPoolSize` down proportionally when adding replicas to avoid overloading the backend with too many open connections.
+PgDog is stateless and scales horizontally by raising `replicas`. Each replica keeps its own connection pool, so reduce `pooling.defaultPoolSize` proportionally when adding replicas — otherwise the backend sees `replicas × defaultPoolSize` connections. The template ships and was tested at a single replica.
 
 ### Logging
 
@@ -244,25 +379,35 @@ Applications connect to PgDog exactly as they would connect to PostgreSQL — Pg
 
 | Setting | Value |
 |---------|-------|
-| Host | `{release-name}-pgdog.{gvc}.cpln.local` |
+| Host (in-GVC) | `RELEASE_NAME-pgdog.GVC_NAME.cpln.local` |
+| Host (public) | The workload's `status.canonicalEndpoint`, when `publicAccess.enabled` is `true` |
 | Port | `6432` |
 | Database | A `name` from your `databases` list |
-| Username | A `name` from your `users` list |
-| Password | The matching `password` from your `users` list |
+| Username | The `username` key of that user's credentials secret |
+| Password | The `password` key of that user's credentials secret |
+| Admin database | `admin.database` on the same host and port, as `admin.user`, with the payload of `admin.passwordSecretName` |
 
-Example connection string:
+<Warning>
+**The in-GVC host must be fully qualified.** The bare short name `RELEASE_NAME-pgdog` does **not** resolve — that shortcut only applies to `stateful` workloads, and PgDog runs as a `standard` one. A client using the short name fails with `could not translate host name "RELEASE_NAME-pgdog" to address: Name or service not known`, from anywhere in the GVC. Always use `RELEASE_NAME-pgdog.GVC_NAME.cpln.local`.
+</Warning>
 
-```
-postgresql://myuser:mypassword@{release-name}-pgdog.{gvc}.cpln.local:6432/mydb
+Example connection string, with the username and password taken from your credentials secret:
+
+```text
+postgresql://USERNAME:PASSWORD@RELEASE_NAME-pgdog.GVC_NAME.cpln.local:6432/DATABASE
 ```
 
 ## Important Notes
 
-- **PgDog does not manage PostgreSQL** — it is a proxy only. Deploy a PostgreSQL backend separately before pointing PgDog at it.
-- **Port 6432, not 5432** — PgDog listens on port 6432. Update application connection strings accordingly.
-- **Transaction mode and session features** — If your application uses `SET` variables, prepared statements, temporary tables, or advisory locks, use `pooling.mode: session` instead of `transaction`.
-- **Admin password** — Always set `admin.password` explicitly. Omitting it causes PgDog to generate a random password at each restart, making the admin database unreachable across restarts.
-- **Scaling and pool sizing** — Each PgDog replica maintains its own pool. When scaling `replicas`, reduce `pooling.defaultPoolSize` proportionally to avoid opening too many total connections to the backend.
+- **Create the prerequisite secrets before installing.** A missing one wedges the deployment with no log output at all — [Prerequisites](#prerequisites) gives the one command that diagnoses it.
+- **PgDog does not manage PostgreSQL** — it is a proxy only. Deploy a backend before pointing PgDog at it.
+- **Port 6432, not 5432** — update application connection strings accordingly.
+- **The in-GVC hostname must be fully qualified** — `RELEASE_NAME-pgdog.GVC_NAME.cpln.local`. The short name does not resolve for this workload.
+- **Transaction mode drops session state** — if your application relies on `SET` variables, temporary tables, or advisory locks, use `pooling.mode: session`.
+- **Each replica keeps its own pool** — when raising `replicas`, lower `pooling.defaultPoolSize` proportionally, or the backend sees `replicas × defaultPoolSize` connections.
+- **Rotating a credential needs a restart** — the config files are assembled once at container start, so run `cpln workload force-redeployment RELEASE_NAME-pgdog --gvc GVC_NAME` after changing a secret's contents.
+- **Enabling public access can take several minutes to take effect** — measured at 255 seconds. Re-test before concluding the knob is broken.
+- **Uninstall leaves your secrets in place** — they are yours, created outside the release. Only the two chart-created config secrets are removed.
 
 ## External References
 
@@ -270,13 +415,19 @@ postgresql://myuser:mypassword@{release-name}-pgdog.{gvc}.cpln.local:6432/mydb
   <Card title="PgDog Documentation" href="https://docs.pgdog.dev/" icon="dog">
     Official PgDog configuration and architecture reference
   </Card>
+  <Card title="users.toml Reference" href="https://docs.pgdog.dev/configuration/users.toml/users/" icon="users">
+    How PgDog maps pooled users onto backend databases
+  </Card>
   <Card title="PgDog GitHub" href="https://github.com/pgdogdev/pgdog" icon="github">
     Source code and issue tracker
+  </Card>
+  <Card title="PgDog Template" href="https://github.com/controlplane-com/templates/tree/main/pgdog" icon="github">
+    View the source files, default values, and chart definition
   </Card>
   <Card title="PostgreSQL Template" href="/template-catalog/templates/postgres" icon="database">
     Single-instance PostgreSQL template for use with PgDog
   </Card>
   <Card title="PostgreSQL Highly Available Template" href="/template-catalog/templates/postgres-highly-available" icon="database">
-    HA PostgreSQL with Patroni — primary + replicas for PgDog read/write splitting
+    HA PostgreSQL with Patroni — primary and replicas for PgDog read/write splitting
   </Card>
 </CardGroup>

--- a/template-catalog/templates/rabbitmq.mdx
+++ b/template-catalog/templates/rabbitmq.mdx
@@ -1,23 +1,107 @@
 ---
 title: RabbitMQ
-description: Deploy RabbitMQ on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and single-replica message broker with built-in management UI.
-keywords: ['amqp', 'message queue', 'mq', 'task queue', 'kafka alternative', 'sqs alternative', 'pubsub', 'work queue', 'erlang broker', 'exchange', 'binding']
+description: Deploy RabbitMQ on Control Plane using the Template Catalog. Covers the prerequisite credentials secret, AMQP connections, the management UI over a port-forward, storage, internal firewall scope, and upgrading from template version 1.1.1.
+keywords: ['amqp', 'message queue', 'mq', 'task queue', 'kafka alternative', 'sqs alternative', 'pubsub', 'work queue', 'erlang broker', 'exchange', 'binding', 'rabbitmqctl', 'management plugin']
 ---
 
 ## Overview
 
-RabbitMQ is a widely-used open-source message broker supporting AMQP and other messaging protocols. This template deploys a single-replica RabbitMQ instance with persistent storage and a built-in management UI.
+RabbitMQ is a widely-used open-source message broker supporting AMQP 0-9-1 and other messaging protocols. This template deploys a single-replica broker with the management plugin enabled, backed by a persistent volume so queues, messages and the user database survive a restart.
+
+The broker's default user is not a template value. It comes from a secret you create before installing, so the credentials your producers and consumers connect with never pass through Helm and never land in the release.
+
+<Warning>
+**Template version 1.2.0 is a breaking change.** `rabbitmq_conf.default_user`, `rabbitmq_conf.default_pass`, the `firewall` block and `diskCapacity` were all removed or replaced, and an install or upgrade that still sets any of them now fails at render. If you are running 1.1.1 or earlier, read [Upgrading From Earlier Versions](#upgrading-from-earlier-versions) before you touch the release.
+</Warning>
+
+### What Gets Created
+
+- **Stateful Workload** — (`RELEASE_NAME-rabbitmq`): a single-replica RabbitMQ container running the official `rabbitmq:3-management` image, serving AMQP on `5672`, the management UI on `15672` and Prometheus metrics on `15692`.
+- **Volume Set** — (`RELEASE_NAME-rabbitmq-vs`): persistent storage mounted at `/var/lib/rabbitmq` holding the message store, queue definitions, the user database and the Erlang cookie.
+- **Config Secret** — (`RELEASE_NAME-rabbitmq-config`): an opaque secret rendered into `/etc/rabbitmq/rabbitmq.conf`. It carries the AMQP listener port and nothing else.
+- **Identity & Policy** — (`RELEASE_NAME-rabbitmq-identity`, `RELEASE_NAME-rabbitmq-policy`): an identity bound to the workload, and a policy granting it `reveal` on exactly two secrets — the config secret and the credentials secret you created.
+
+The template creates **no credential secret of its own**, and the Erlang cookie is never a value either: the broker generates it on first boot onto the volume set.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
-### What Gets Created
+## Upgrading From Earlier Versions
 
-- **Stateful Workload** — A single-replica RabbitMQ container with the management plugin enabled.
-- **Volume Set** — Persistent storage for RabbitMQ node data at `/var/lib/rabbitmq`.
-- **Secret** — An opaque secret containing the `rabbitmq.conf` configuration file, mounted into the container at startup.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to the config secret.
+Template version 1.1.1 and earlier took the RabbitMQ default user as plain Helm values and shipped a working default username and password, published in the public template repository. Those are not merely a management-UI login: they are the **AMQP credentials every producer and consumer puts in its connection string**. In 1.1.1 they were also written in plaintext into the mounted `rabbitmq.conf` secret, so the credential was readable from the release and from the config secret alike.
+
+| | 1.1.1 and earlier | 1.2.0 |
+|---|---|---|
+| Default user | `rabbitmq_conf.default_user` and `rabbitmq_conf.default_pass` values | `credentialsSecretName` → a dictionary secret you create |
+| How it reaches the broker | Written into the mounted `rabbitmq.conf` | `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` environment variables, resolved from the secret |
+| Internal firewall | `firewall.internal_inboundAllowType` | `internalAccess.type` |
+| Volume size | `diskCapacity` — read by nothing, so setting it had no effect | `volumeset.volume.initialCapacity` |
+| Request timeout | `timeoutSeconds` — read by nothing; the workload was hardcoded to 5 | `timeoutSeconds`, now actually applied |
+
+The delivery path changed because a `cpln://secret/...` reference is only interpolated in an environment variable. Inside a mounted config-file secret it lands as that literal string, and the broker would boot with a username of `cpln://secret/...`. RabbitMQ reads `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` natively, so 1.2.0 passes them that way and leaves only the listener port in `rabbitmq.conf`.
+
+<Warning>
+**Treat a pre-1.2.0 broker's credentials as compromised, not merely outdated.** Upgrading moves them out of Helm values but does not change the values themselves, and it does not change the broker either: the default user is written into the RabbitMQ database on **first boot only**. An existing broker keeps whatever user it was bootstrapped with. Rotate it in place with `rabbitmqctl change_password`, or uninstall and reinstall — which deletes the volume set and every message on it.
+</Warning>
+
+<Warning>
+**Carrying old values forward stops the upgrade.** Seven conditions are rejected at render time, so the upgrade fails and the existing release is left untouched and running:
+
+| Value you set | Result |
+|---|---|
+| `rabbitmq_conf.default_user` | `was REMOVED in rabbitmq 1.2.0 … create a dictionary secret holding the keys username and password, and set credentialsSecretName to its name` |
+| `rabbitmq_conf.default_pass` | the same message |
+| `credentialsSecretName` empty | `credentialsSecretName is required — it names the dictionary secret holding the username and password keys` |
+| any `firewall.*` key | `The firewall block was REPLACED in rabbitmq 1.2.0 by internalAccess. Set internalAccess.type to none, same-gvc or same-org` |
+| `diskCapacity` | `was REMOVED in rabbitmq 1.2.0 — it was never read by any template and setting it had no effect on disk size. Use volumeset.volume.initialCapacity instead` |
+| `internalAccess.type` unset | `internalAccess.type is required — set it to none, same-gvc or same-org` |
+| `internalAccess.type` not one of the three | `internalAccess.type must be one of: none, same-gvc, same-org` |
+</Warning>
+
+<Note>
+**The replaced `firewall` block is a clarity fix, not the closing of an open door.** The `external_*` keys in 1.1.1 were commented out, so the chart rendered no external firewall block at all — and a live 1.1.1 broker probed from the internet returned `403` on every attempt, with no external block backfilled by the API. External inbound was already closed. Version 1.2.0 states the closed configuration explicitly so the rendered and stored specs agree; the security fix in this release is the credential move.
+</Note>
+
+### Two Settings That Previously Did Nothing
+
+- **`diskCapacity` was ignored.** No template read it, so a user who asked for 100 GiB silently got a 10 GiB volume. It is removed and guarded; the live knob is `volumeset.volume.initialCapacity`, and a non-default value there provisions a volume of that size.
+- **`timeoutSeconds` was ignored.** The value existed but the workload hardcoded a 5-second request timeout. In 1.2.0 the knob reaches the API as you set it, so the shipped default of 30 is genuinely 30. Raising it does not disturb AMQP connections — an idle connection held for three minutes stayed open and still published and consumed afterwards.
+
+## Prerequisites
+
+**One secret must exist before you install.** Its value never passes through Helm values, so it never lands in the release. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly two keys — `username` and `password`. These become the RabbitMQ default user: the management-UI login **and** the AMQP credentials in every producer's and consumer's connection string.
+
+    ```bash
+    cpln secret create-dictionary --name my-rabbitmq-credentials \
+      --entry username=rabbitmq \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `credentialsSecretName` to the name you used. Nothing else is required for a default install.
+  </Step>
+  <Step title="Read the secret back later">
+    The `-o yaml` is required — plain `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-rabbitmq-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**Create the secret before installing.** The template refuses to render when the name is blank, but a name pointing at a secret that does not exist installs "successfully" and then wedges: the install reports every resource created, the workload never becomes ready, and **`cpln logs` returns zero lines** because no container ever starts. The only diagnostic is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-rabbitmq --gvc GVC_NAME -o yaml
+```
+
+It names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` The command is `get-deployments` — plain `cpln workload get` has no `versions` key at all. Creating the secret recovers the workload on its own in about **5.5 to 8.5 minutes** (measured 8 minutes 16 seconds), or in roughly 90 seconds if you force a redeployment of the workload.
+</Warning>
 
 ## Installation
 
@@ -53,84 +137,137 @@ The default `values.yaml` for this template:
 image:
   repository: rabbitmq:3-management
 
+# ─── Credentials ──────────────────────────────────────────────────────────────
+# REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL.
+# A `dictionary` secret holding exactly two keys: `username` and `password`.
+# These are the RabbitMQ default user: the management-UI login AND the AMQP
+# credentials every producer and consumer puts in its connection string.
+# If the secret does not exist at install time the deployment WEDGES silently —
+# `cpln logs` returns nothing at all. See Prerequisites in the README for the
+# exact `cpln secret create-dictionary` command.
+credentialsSecretName: my-rabbitmq-credentials
+
+# ─── Resources ────────────────────────────────────────────────────────────────
 memory: 250Mi
 cpu: 200m
 
-firewall:
-  internal_inboundAllowType: same-gvc # Options: same-gvc, same-org
-  # external_inboundAllowCIDR: 0.0.0.0/0
-  # external_outboundAllowCIDR: 0.0.0.0/0
+timeoutSeconds: 30 # inbound request timeout in seconds
 
+# ─── Networking ───────────────────────────────────────────────────────────────
+# External inbound is always closed: RabbitMQ is reachable from inside the GVC
+# only. Use `cpln port-forward` to reach the management UI from a browser.
+internalAccess:
+  type: same-gvc # options: none, same-gvc (recommended), same-org
+
+# ─── RabbitMQ configuration ───────────────────────────────────────────────────
 rabbitmq_conf:
-  listeners_tcp_default: 5672
-  default_user: user
-  default_pass: changeMe
+  listeners_tcp_default: 5672 # AMQP listener port
 
 env:
   RABBITMQ_CONFIG_FILE: /etc/rabbitmq/rabbitmq.conf
 
+# ─── Storage ──────────────────────────────────────────────────────────────────
 volumeset:
   volume:
-    initialCapacity: 10 # In GiB. For high-throughput-ssd minimum is 1000
-    fileSystemType: ext4 # ext4 / xfs
-    performanceClass: general-purpose-ssd # general-purpose-ssd / high-throughput-ssd
+      initialCapacity: 10 # In Gigabytes. For high-throughput-ssd minimum is '1000'
+      fileSystemType: ext4 # ext4 / xfs
+      performanceClass: general-purpose-ssd # high-throughput-ssd / general-purpose-ssd
 ```
 
 ### Credentials
 
-- `rabbitmq_conf.default_user` — RabbitMQ admin username. **Change before deploying to production.**
-- `rabbitmq_conf.default_pass` — RabbitMQ admin password. **Change before deploying to production.**
+- `credentialsSecretName` — Name of the dictionary secret holding the `username` and `password` keys. The secret must exist before you install; see [Prerequisites](#prerequisites).
 
 <Note>
-These values are only applied on first startup when there is no existing node data. Updating them after the initial deployment will have no effect on the running instance. To change credentials on an existing instance, use RabbitMQ's management commands (e.g. `rabbitmqctl change_password`).
+The default user is written into the RabbitMQ database on **first boot only**. Changing the secret afterwards does not change the broker's credentials — rotate with `rabbitmqctl change_password`, or uninstall (which deletes the volume set and all messages) and reinstall.
 </Note>
+
+### Image
+
+- `image.repository` — The broker image, tag included. The shipped value tracks the floating `3-management` tag, so a fresh install picks up the current 3.x management-enabled image rather than a pinned patch release.
 
 ### Resources
 
-- `cpu` — CPU allocated to the RabbitMQ workload.
-- `memory` — Memory allocated to the RabbitMQ workload.
+- `cpu` — CPU limit for the broker.
+- `memory` — Memory limit for the broker.
+- `timeoutSeconds` — Inbound request timeout in seconds, applied to the workload. This value was ignored before 1.2.0; it is now applied as set.
 
-### Storage
+### Internal Access
 
-- `volumeset.volume.initialCapacity` — Initial volume size in GiB. For `high-throughput-ssd`, the minimum is 1000 GiB.
-- `volumeset.volume.fileSystemType` — `ext4` or `xfs`.
-- `volumeset.volume.performanceClass` — `general-purpose-ssd` or `high-throughput-ssd`.
-
-### Firewall
-
-- `firewall.internal_inboundAllowType` — Controls which workloads can connect to RabbitMQ internally:
+- `internalAccess.type` — Controls which workloads can reach the broker. External inbound is always closed; there is no public-access knob.
 
 | Value | Description |
 |-------|-------------|
+| `none` | No workload may connect |
 | `same-gvc` | Allow access from all workloads in the same GVC (recommended) |
-| `same-org` | Allow access from all workloads in the same organization |
+| `same-org` | Allow access from all workloads in the same org |
 
-- `firewall.external_inboundAllowCIDR` — Optional. Comma-separated list of CIDR ranges allowed to reach RabbitMQ from the internet (e.g. `0.0.0.0/0`).
-- `firewall.external_outboundAllowCIDR` — Optional. Comma-separated list of CIDR ranges RabbitMQ is allowed to reach externally.
+<Note>
+A change to `internalAccess.type` takes roughly **30 seconds to 5 minutes** to propagate — closing access settles faster than reopening it, and every transition passes through a blocked window first. Re-test rather than concluding the change did not apply.
 
-### Connecting to RabbitMQ
+Under `none`, a raw TCP connection to `5672` still appears to succeed while the AMQP handshake is reset, so a `nc -z` style check will wrongly suggest the setting does nothing. Test with a real client connection.
+</Note>
 
-Once deployed, connect to RabbitMQ from within the same GVC using:
+### RabbitMQ Configuration
 
-```text
-RELEASE_NAME-rabbitmq.GVC_NAME.cpln.local:5672
+- `rabbitmq_conf.listeners_tcp_default` — The AMQP listener port, rendered into `/etc/rabbitmq/rabbitmq.conf`. It is the only setting that file carries.
+- `env.RABBITMQ_CONFIG_FILE` — Path the broker reads that config file from. The credentials are delivered separately, as `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` environment variables resolved from your secret.
+
+### Storage
+
+- `volumeset.volume.initialCapacity` — Volume size in GiB backing `/var/lib/rabbitmq`. For `high-throughput-ssd` the minimum is 1000.
+- `volumeset.volume.fileSystemType` — `ext4` or `xfs`.
+- `volumeset.volume.performanceClass` — `general-purpose-ssd` or `high-throughput-ssd`.
+
+## Connecting to RabbitMQ
+
+The broker is reachable from inside the GVC only. There is no public-access knob, and the workload's canonical endpoint returns `403`.
+
+| What | Where | Credentials |
+|---|---|---|
+| AMQP | `amqp://USERNAME:PASSWORD@RELEASE_NAME-rabbitmq.GVC_NAME.cpln.local:5672/` | `username` / `password` from your credentials secret |
+| Management UI | `http://RELEASE_NAME-rabbitmq.GVC_NAME.cpln.local:15672` | same |
+| Prometheus metrics | `http://RELEASE_NAME-rabbitmq.GVC_NAME.cpln.local:15692/metrics` | none |
+
+The short name `RELEASE_NAME-rabbitmq` also resolves inside the same GVC.
+
+To open the management UI in a browser from your laptop, tunnel to it — no public exposure required:
+
+```bash
+cpln port-forward RELEASE_NAME-rabbitmq 15672:15672 --gvc GVC_NAME
+# then browse http://localhost:15672
 ```
 
-The management UI is available on port `15672` via the workload's external endpoint (requires `firewall.external_inboundAllowCIDR` to be set).
+Log in with the `username` and `password` from your credentials secret; the management API rejects any other password with `401`.
 
 ### Ports
 
 | Port | Protocol | Description |
 |------|----------|-------------|
 | `5672` | AMQP | Primary messaging port (configurable via `rabbitmq_conf.listeners_tcp_default`) |
-| `15672` | HTTP | Management UI |
+| `15672` | HTTP | Management UI and HTTP API |
 | `15692` | HTTP | Prometheus metrics |
+
+## Important Notes
+
+- The credentials secret must exist **before** you install. Without it the workload wedges with no log output at all; see [Prerequisites](#prerequisites) for the one diagnostic that shows it.
+- The default user is created on first boot only, so changing the secret on a running broker does not change its credentials.
+- Single node, single replica: an upgrade or a reschedule is a short outage for every connected client, so give your producers and consumers a reconnect policy.
+- The first upgrade after an install re-applies resources even when values are identical, which bounces the broker. Later upgrades are clean.
+- Queues, messages and the user database live on the volume set and survive a redeploy; uninstalling the release deletes them.
+- The broker is GVC-internal only — use `cpln port-forward` for the management UI rather than looking for a public endpoint.
 
 ## External References
 
 <CardGroup cols={2}>
     <Card title="RabbitMQ Documentation" icon="book" href="https://www.rabbitmq.com/docs">
     Official RabbitMQ documentation
+    </Card>
+    <Card title="Configuration Reference" icon="sliders" href="https://www.rabbitmq.com/docs/configure">
+    How rabbitmq.conf and the environment variables are read
+    </Card>
+    <Card title="Management Plugin" icon="gauge" href="https://www.rabbitmq.com/docs/management">
+    The management UI and HTTP API
     </Card>
     <Card title="RabbitMQ Template" icon="github" href="https://github.com/controlplane-com/templates/tree/main/rabbitmq">
     View the source files, default values, and chart definition

--- a/template-catalog/templates/seaweedfs.mdx
+++ b/template-catalog/templates/seaweedfs.mdx
@@ -1,7 +1,7 @@
 ---
 title: SeaweedFS
-description: Deploy SeaweedFS on Control Plane using the Template Catalog. A single all-in-one node providing S3-compatible object storage with SigV4 authentication, persistent volume storage, startup bucket creation, and an admin UI — the in-org storage target for any template that speaks S3.
-keywords: ['seaweedfs', 'weed mini', 's3 alternative', 'self-hosted s3', 'minio alternative', 'object store', 'blob storage', 'bucket', 'sigv4', 'path-style addressing', 'filer', 'backup target', 'aws cli endpoint-url', 'storage template']
+description: Deploy SeaweedFS on Control Plane using the Template Catalog. A single all-in-one node providing S3-compatible object storage with SigV4 authentication, persistent volume storage, startup bucket creation, and an admin UI — the in-org storage target for any template that speaks S3. Covers the two prerequisite credential secrets.
+keywords: ['seaweedfs', 'weed mini', 's3 alternative', 'self-hosted s3', 'minio alternative', 'object store', 'blob storage', 'bucket', 'sigv4', 'path-style addressing', 'filer', 'backup target', 'aws cli endpoint-url', 'storage template', 'prerequisite secret']
 ---
 
 ## Overview
@@ -10,19 +10,29 @@ SeaweedFS is a distributed object store with an S3-compatible API. This template
 
 Its main use is as an in-org storage target: any workload or template that accepts an S3-compatible endpoint and a static access key pair can point at it without leaving your organization. Backing up [postgres-highly-available](/template-catalog/templates/postgres-highly-available) into SeaweedFS, and restoring from it, was verified end to end with no changes on the consumer side. See [Using SeaweedFS as an S3 backend](#using-seaweedfs-as-an-s3-backend).
 
+Both sets of credentials — the S3 keys and the admin UI login — come from secrets you create **before** installing. Nothing sensitive passes through Helm values, and as of `1.1.0` the template creates no secret of its own at all.
+
+<Warning>
+**Upgrading an install created with `1.0.0` is a breaking change.** `adminUI.username` and `adminUI.password` no longer exist, and an upgrade that still sets either one stops with an error naming its replacement — even when `adminUI.enabled` is `false`. See [Upgrading From 1.0.0](#upgrading-from-1-0-0). The S3 half is unchanged: `s3.credentialsSecretName` worked exactly this way in `1.0.0` and needs no edit.
+</Warning>
+
 ### Architecture
 
 - **All-in-one node** — A single `stateful` workload running `weed mini`, which starts the master, volume server, filer, S3 gateway, and admin UI in one process. The S3 API is served on port `8333`; the admin UI on port `23646`.
 - **One disk for everything** — Object data, filer metadata (leveldb), and master metadata all live on one persistent volume set mounted at `/data`.
 - **Authenticated by default** — S3 credentials come from a dictionary secret you create before installing. SeaweedFS serves S3 with *no authentication at all* when credentials are absent, so the chart refuses to render without one.
+- **The admin login is a prerequisite too** — The admin UI's `username` and `password` come from a second dictionary secret you create. The template creates no secrets, so no credential ever lands in the Helm release.
 - **Private by default** — External access is off (`publicAccess.enabled: false`); the S3 API is reachable only from inside the GVC until you turn it on. The admin UI is never publicly routed.
 
 ### What Gets Created
 
 - **Stateful SeaweedFS Workload** — One replica serving the S3 API on port `8333`, plus the admin UI on port `23646` when enabled.
 - **Volume Set** — Persistent storage at `/data` for objects and all metadata, with optional autoscaling. A final snapshot is retained for 7 days when the volume set is deleted.
-- **Admin Secret** *(optional)* — A dictionary secret holding the admin UI username and password. Created only when `adminUI.enabled` is `true`.
-- **Identity & Policy** — An identity bound to the workload with `reveal` on exactly the secrets it mounts: your S3 credentials secret, plus the admin secret when the admin UI is enabled.
+- **Identity & Policy** — An identity bound to the workload with `reveal` on exactly the secrets it mounts: your S3 credentials secret, plus your admin credentials secret when the admin UI is enabled. Nothing else, and no cloud access at all.
+
+<Note>
+This template creates **no secrets**. Both credentials live in secrets you own, which means uninstalling the release never destroys them — verified on a real uninstall, where both survived with their contents intact.
+</Note>
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -30,19 +40,62 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-**Create the S3 credentials secret before installing.** The workload references it by name (`s3.credentialsSecretName`, default `my-seaweedfs-s3-credentials`), and the deployment waits on a missing secret indefinitely rather than starting up unauthenticated. Create it as a **dictionary** secret containing exactly these two keys:
+**Two secrets must exist before you install.** They are deliberately separate: the S3 keys are handed to every client application, while the admin login reaches the bucket browser and maintenance tools. Secrets are org-level, so no GVC flag is involved.
 
-```bash
-cpln secret create-dictionary --name my-seaweedfs-s3-credentials \
-  --entry AWS_ACCESS_KEY_ID=<your-access-key> \
-  --entry AWS_SECRET_ACCESS_KEY=<your-secret-key>
-```
+<Steps>
+  <Step title="Create the S3 credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. These are the credentials every S3 client uses, and SeaweedFS serves S3 with *no authentication at all* without them:
 
-These are the credentials every S3 client uses. The secret is yours, not the release's — `helm uninstall` leaves it in place.
+    ```bash
+    cpln secret create-dictionary --name my-seaweedfs-s3-credentials \
+      --entry AWS_ACCESS_KEY_ID="$(openssl rand -hex 10)" \
+      --entry AWS_SECRET_ACCESS_KEY="$(openssl rand -hex 24)"
+    ```
+
+    Set `s3.credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Create the admin UI credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `username` and `password`, guarding the admin login form. Required whenever `adminUI.enabled` is `true`, which is the default:
+
+    ```bash
+    cpln secret create-dictionary --name my-seaweedfs-admin-credentials \
+      --entry username=admin \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `adminUI.credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Read either secret back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-seaweedfs-admin-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Note>
+**The S3 half is unchanged from `1.0.0`.** `s3.credentialsSecretName` was already a prerequisite secret, so anything already backing up into SeaweedFS — [postgres-highly-available](/template-catalog/templates/postgres-highly-available), [thanos](/template-catalog/templates/thanos), [mimir](/template-catalog/templates/mimir) — needs no change whatsoever.
+</Note>
 
 <Warning>
-Also change `adminUI.password` before installing. The shipped default is an obvious placeholder, not a working credential.
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, all four resources are created, and the workload then never starts — it sits at zero replicas. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-seaweedfs --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-seaweedfs-admin-credentials no longer exists. Workload updates are
+paused until the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery was measured at **7 minutes 15 seconds** here, inside the 5.5–8.5 minute range seen across the catalog. A forced redeployment shortcuts it to roughly 90 seconds.
 </Warning>
+
+## Installation
 
 Install the template using your preferred method:
 
@@ -67,6 +120,44 @@ Install the template using your preferred method:
     Declare templates in your Pulumi programs
     </Card>
 </CardGroup>
+
+The node reaches `ready` about **52 seconds** after install, with the master, volume server, filer, S3 gateway, and admin UI all up in the one process.
+
+## Upgrading From 1.0.0
+
+Version `1.1.0` moved the admin UI login out of Helm values. `1.0.0` shipped a working username and password as values, used exactly as written, guarding the bucket browser and maintenance tools — a published default sitting in the release for the life of the install.
+
+| | `1.0.0` | `1.1.0` |
+|---|---|---|
+| Admin UI login | `adminUI.username` and `adminUI.password` values | `adminUI.credentialsSecretName` — a dictionary secret you create with `username` and `password` |
+| Chart-created secret | Held the admin credentials | None; the template creates no secrets at all |
+| S3 credentials | `s3.credentialsSecretName` prerequisite secret | Unchanged |
+
+<Warning>
+**A `helm upgrade` that still carries either removed key is rejected before anything is applied**, and the guard deliberately fires **even when `adminUI.enabled` is `false`** — otherwise a stale `password:` in your values would be silently accepted while you believed a credential was still in force. A real `cpln helm upgrade` carrying the old keys failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+adminUI.username and adminUI.password were removed in seaweedfs 1.1.0 — the admin UI login form is
+now guarded by a REQUIRED prerequisite dictionary secret. Create one holding the keys 'username' and
+'password', then set adminUI.credentialsSecretName to its name.
+```
+
+Leaving `adminUI.credentialsSecretName` empty while the UI is enabled is refused the same way. With `adminUI.enabled: false` an empty name renders fine — the feature is simply off, with no admin port, no credential environment, and no admin secret in the policy.
+</Warning>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    Follow [Prerequisites](#prerequisites). Put your existing username and password into it if you want current logins to keep working; otherwise choose new ones — the shipped `1.0.0` default was public.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `adminUI.username` and `adminUI.password`, and set `adminUI.credentialsSecretName` instead. Leave `s3.credentialsSecretName` exactly as it is.
+  </Step>
+  <Step title="Upgrade">
+    The single replica restarts and the store is briefly unavailable — see the outage window in [Important Notes](#important-notes). Stored objects on the volume set are untouched.
+  </Step>
+</Steps>
 
 ## Configuration
 
@@ -106,8 +197,11 @@ s3:
 # Admin UI (port 23646, reachable inside the GVC only)
 adminUI:
   enabled: true # cluster status, bucket browser, user and maintenance management
-  username: admin
-  password: change-me-seaweedfs-admin # CHANGE THIS before install
+  # REQUIRED PREREQUISITE SECRET when adminUI.enabled is true — CREATE IT BEFORE
+  # YOU INSTALL. A `dictionary` secret holding exactly two keys, `username` and
+  # `password`, guarding the admin login form. If it does not exist at install
+  # time the deployment WEDGES silently — `cpln logs` returns nothing at all.
+  credentialsSecretName: my-seaweedfs-admin-credentials
 
 publicAccess:
   enabled: false # true = S3 API on the auto *.cpln.app HTTPS endpoint (path-style addressing)
@@ -145,9 +239,17 @@ Rotating the credentials secret and redeploying genuinely rotates the keys: the 
 ### Admin UI
 
 - `adminUI.enabled` — Cluster status, bucket browser, user, and maintenance management on port `23646`. Reachable from inside the GVC only.
-- `adminUI.username` / `adminUI.password` — Login credentials, stored in a dictionary secret the template creates. Required when the admin UI is enabled.
+- `adminUI.credentialsSecretName` — Name of the prerequisite dictionary secret holding the `username` and `password` that guard the login form. Required whenever the admin UI is enabled; the chart fails to render if it is empty.
 
-Setting `adminUI.enabled: false` removes the port, the credentials, and the secret, and narrows the policy to the S3 credentials secret alone. The admin routes then return `404`.
+Setting `adminUI.enabled: false` removes the port and the credential references, and narrows the policy to the S3 credentials secret alone. The admin routes then return `404`.
+
+Reach the UI from your laptop with a tunnel — it is never publicly routed, and the tunnel works even when the workload is closed to both the internet and the GVC:
+
+```bash
+cpln port-forward RELEASE_NAME-seaweedfs 23646:23646 --gvc GVC_NAME
+```
+
+Then open `http://localhost:23646` and log in with the two values from your admin secret. Authentication is genuinely enforced against that secret: an unauthenticated request redirects to `/login`, the protected API returns `401`, and a wrong username or password is refused with `Invalid credentials`.
 
 <Note>
 Upstream `weed mini` still starts the admin component in-process when the UI is disabled — only its routes are unregistered. Because the port is not declared on the workload and no credentials are injected, nothing is reachable from outside the container.
@@ -156,6 +258,10 @@ Upstream `weed mini` still starts the admin component in-process when the UI is 
 ### Access
 
 - `publicAccess.enabled` — `false` by default. When set to `true`, the S3 API is served over HTTPS on the automatically assigned `*.cpln.app` canonical endpoint, using path-style addressing. Only port `8333` is exposed this way; the admin UI is never publicly routed.
+
+<Note>
+**Port 23646 is not reachable from outside, even with `publicAccess.enabled: true`.** The workload declares `8333` first, so the canonical endpoint binds to the S3 gateway and there is no public route to the admin port at all. Requesting `/login` on the public endpoint returns S3 XML that parses the path as a bucket name — `<BucketName>login</BucketName>` — which proves the request reached the S3 gateway rather than the admin server.
+</Note>
 - `internalAccess.type` — Internal firewall scope of the workload:
 
 | Type | Description |
@@ -166,7 +272,7 @@ Upstream `weed mini` still starts the admin component in-process when the UI is 
 | `workload-list` | Allow access only from workloads listed in `internalAccess.workloads`, e.g. `//gvc/GVC_NAME/workload/WORKLOAD_NAME`. |
 
 <Note>
-Firewall changes take 60–90 seconds to propagate, and a client that cached a negative DNS answer can lag an allow by roughly another 30 seconds.
+**Firewall changes take a minute or two to take effect.** Turning `publicAccess.enabled` on was measured at **132 seconds** end to end, stepping through `403` (closed) and `503` (routing not yet up) before serving `200`. A client that cached a negative DNS answer can lag an allow by another 30 seconds or so. Re-test before concluding a knob is broken.
 </Note>
 
 ## Using SeaweedFS as an S3 Backend
@@ -212,7 +318,7 @@ Templates whose object-storage support is limited to named providers — [ghost]
 | S3 API, same GVC (FQDN) | `http://RELEASE_NAME-seaweedfs.GVC_NAME.cpln.local:8333` | Same host, fully qualified. |
 | S3 API, host:port form | `RELEASE_NAME-seaweedfs.GVC_NAME.cpln.local:8333` | For clients that take a bare host:port, such as Thanos and Mimir. Pair with `insecure: true`. |
 | S3 API, public *(if enabled)* | `https://<canonical>.cpln.app` | Port 443, no port suffix. Requires `publicAccess.enabled: true`. |
-| Admin UI | `http://RELEASE_NAME-seaweedfs.GVC_NAME.cpln.local:23646` | Inside the GVC only. Log in with `adminUI.username` / `adminUI.password`. |
+| Admin UI | `http://RELEASE_NAME-seaweedfs.GVC_NAME.cpln.local:23646` | Inside the GVC only, never publicly routed. From a laptop, tunnel with `cpln port-forward RELEASE_NAME-seaweedfs 23646:23646 --gvc GVC_NAME`. Log in with the `username` / `password` from your admin credentials secret. |
 | Health check | `GET /healthz` on port `8333` | Unauthenticated by design. |
 
 Same-GVC clients use plain `http://` over the mesh's mTLS; external clients use `https://`, with TLS terminated at the platform edge. The canonical hostname appears under `status.canonicalEndpoint` in `cpln workload get RELEASE_NAME-seaweedfs --gvc GVC_NAME -o yaml`.
@@ -221,15 +327,16 @@ Requests without a valid signature are rejected: unsigned requests get `403`, an
 
 ## Important Notes
 
-- **Create the S3 credentials secret before installing.** A missing secret leaves the deployment waiting indefinitely, and omitting credentials entirely would make SeaweedFS serve S3 unauthenticated.
-- **Change `adminUI.password` before installing** — the shipped default is a placeholder, not a working credential.
+- **Create both prerequisite secrets before installing.** A missing one wedges the deployment with no log output at all; [Prerequisites](#prerequisites) gives the one command that diagnoses it.
+- **The template creates no secrets** — both credentials are yours, so `helm uninstall` leaves them in place.
+- **Install to ready takes about 52 seconds** on the shipped defaults.
 - **The template deploys a single replica by design.** `weed mini` runs one master, one filer, and one volume server in a single process, so raising the replica count would create separate, divergent object stores. Multi-node clustering is a planned follow-up.
 - **A redeploy or upgrade is a full S3 outage.** Measured at **337 failed requests over an 80.8 second gap** (at roughly 5 requests/second), with the store serving again about 128 seconds after the redeploy was triggered. Almost all of that is platform teardown and reschedule — SeaweedFS itself boots in about 1.5 seconds. Schedule upgrades accordingly, and expect the same window whenever the platform reschedules the replica.
 - **Clients must use path-style addressing**; virtual-host style is not served.
-- **Only the S3 API is publicly routable.** `publicAccess` exposes port `8333` alone — reach the admin UI from inside the GVC.
+- **Only the S3 API is publicly routable.** `publicAccess` exposes port `8333` alone — reach the admin UI from inside the GVC or through `cpln port-forward`.
 - **Rotating the credentials secret and redeploying rotates the keys**, leaving stored data untouched. Update every consumer at the same time.
 - **Data survives restarts and upgrades; uninstall deletes the volume set** and every stored object, keeping a final snapshot for 7 days.
-- **Uninstall does not delete your S3 credentials secret** — it is your resource, created outside the release, and it stays until you remove it.
+- **Uninstall does not delete either credentials secret** — both are your resources, created outside the release, and they stay until you remove them.
 
 ## External References
 

--- a/template-catalog/templates/weaviate.mdx
+++ b/template-catalog/templates/weaviate.mdx
@@ -1,20 +1,29 @@
 ---
 title: Weaviate
-description: Deploy a Weaviate vector database cluster on Control Plane. Covers Raft-consensus clustering, AI module configuration for vectorization and generative search, authentication, and scheduled backups to S3 or GCS.
-keywords: ['weaviate', 'vector database', 'vector search', 'hybrid search', 'ai database', 'embeddings', 'rag', 'retrieval augmented generation', 'semantic search', 'openai', 'anthropic', 'cohere', 'huggingface', 'text2vec', 'generative ai']
+description: Deploy a Weaviate vector database cluster on Control Plane. Covers the prerequisite API key secret, Raft clustering and its restart limitation, AI provider modules, internal-only access, and scheduled backups to S3 or GCS.
+keywords: ['weaviate', 'vector search', 'hybrid search', 'embeddings', 'rag', 'semantic search', 'pinecone alternative', 'qdrant alternative', 'milvus alternative', 'text2vec', 'openai', 'anthropic', 'cohere', 'huggingface', 'nearvector']
 ---
 
 ## Overview
 
-Weaviate is an AI-native vector database designed for storing, indexing, and querying vector embeddings alongside structured object data. This template deploys a multi-node Weaviate 1.38 cluster using Raft consensus for schema and cluster state management, with optional AI module support for vectorization and generative search, and optional scheduled backups to AWS S3 or GCS.
+<Warning>
+**Upgrading from 1.0.1 or earlier?** The Weaviate API key and every AI provider key are now prerequisite secrets you create, and the old values keys stop the render — see [Upgrading From 1.0.1 or Earlier](#upgrading-from-1-0-1-or-earlier).
+
+1.0.1 and earlier shipped a **working 64-character API key** as a values default, published in this repository and shared by every install that did not override it. It is the only authentication Weaviate has, so anyone holding it can read and write every collection. Treat the key on any earlier install as **compromised**: rotate it rather than simply upgrading.
+</Warning>
+
+Weaviate is an AI-native vector database for storing, indexing, and querying vector embeddings alongside structured object data. This template deploys a Weaviate 1.38 cluster of `replicas` nodes in a single location, using Raft consensus for schema and cluster state, with one persistent volume per node, optional AI provider modules, and optional scheduled backups to AWS S3 or GCS.
+
+The cluster has **no public endpoint by design** — it is reachable only from inside Control Plane, scoped by `internalAccess.type`.
 
 ### What Gets Created
 
-- **Stateful Weaviate Workload** — A multi-replica cluster with one persistent volume per node for vector and object data.
-- **Volume Set** — Persistent storage per replica with optional autoscaling.
-- **Cron Backup Workload** *(optional)* — Triggers Weaviate's built-in backup API on a schedule to write full snapshots to cloud storage.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to credential secrets, and cloud storage access when backup is enabled.
-- **Secrets** — An opaque secret holding the API key, user, and all AI module API keys.
+- **Weaviate Workload** — A `stateful` workload of `replicas` nodes forming a Raft cluster, serving REST and GraphQL on port `8080` and gRPC on `50051`.
+- **Volume Set** — One volume per replica holding that node's objects and vector indexes, with autoscaling.
+- **Credentials Secret** — Template-managed `dictionary` secret holding the non-sensitive `api-user` value, plus the backup bucket coordinates when backups are enabled. No credential passes through it.
+- **Start Script Secret** — The boot script mounted into each container.
+- **Identity & Policy** — An identity bound to the workloads, and a policy granting it `reveal` on exactly four things at most: the two template secrets, your API key secret, and each AI provider secret you name. Cloud storage access is added to the identity only when backups are enabled.
+- **Backup Cron Workload** *(optional)* — Calls Weaviate's backup API on a schedule to write a full snapshot to cloud storage.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -22,7 +31,50 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-This template has no external prerequisites unless backup is enabled. To install, follow the instructions for your preferred method:
+### API Key
+
+Weaviate has no anonymous access in this template. The API key is a **required prerequisite `opaque` secret that must exist before you install** — the key never enters the Helm release, and the template only ever refers to it by name.
+
+```bash
+printf '%s' "$(openssl rand -hex 32)" | \
+  cpln secret create-opaque --name my-weaviate-api-key --encoding plain -f -
+```
+
+Set `apiKeySecretName` to that name, and set `apiUser` to the username the key maps to. Keep your own copy of the key: the platform is the only place it is stored, and every client authenticates with it.
+
+<Warning>
+**Installing without the secret looks like a platform fault, not a missing step.** `cpln helm install` reports complete success and creates every resource, then the workload simply never becomes ready. `cpln logs` returns **zero lines** — there is no container to produce output — and the only diagnostic is in `status.versions[].message`:
+
+```text
+The secret my-weaviate-api-key no longer exists. Workload updates are paused until
+the secret is added or the reference to the secret removed.
+```
+
+Read it with `cpln workload get-deployments {release}-weaviate --gvc {gvc} -o yaml`. Creating the secret afterwards does **not** release the deployment on its own — it stayed wedged for a full five minutes of polling in testing. Run `cpln workload force-redeployment {release}-weaviate --gvc {gvc}`, which cleared it in about 90 seconds.
+</Warning>
+
+### AI Provider Keys
+
+Only needed if you want Weaviate to call a provider for embeddings or generative search. Create one `opaque` secret per provider, holding just that provider's key:
+
+```bash
+printf '%s' "sk-..." | \
+  cpln secret create-opaque --name my-weaviate-openai-key --encoding plain -f -
+```
+
+Set `modules.openai.apiKeySecretName` (or the `anthropic`, `cohere`, `huggingface` equivalent) to that name. Leaving a provider's `apiKeySecretName` empty means the provider is genuinely off: no environment variable, no `reveal` grant, and no outbound internet access on the workload. All three were confirmed against the live resources on a default install, where the container could not reach `api.openai.com` at all.
+
+<Warning>
+**Naming a provider secret gives you a live, billable integration.** It is not inert configuration held in reserve — see [Provider Modules Load Regardless of modules.enabled](#provider-modules-load-regardless-of-modules-enabled). Only supply a provider key when you intend that provider to be used.
+</Warning>
+
+### Cloud Storage
+
+Only needed if you set `backup.enabled: true`. See [Backing Up](#backing-up) for the bucket, Cloud Account, and IAM steps.
+
+## Installation
+
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -44,275 +96,4 @@ This template has no external prerequisites unless backup is enabled. To install
         </svg>}>
     Declare templates in your Pulumi programs
     </Card>
-</CardGroup>
-
-## Configuration
-
-The default `values.yaml` for this template:
-
-```yaml
-replicas: 3
-
-image: semitechnologies/weaviate:1.38.0
-
-clusterName: my-weaviate
-
-# IMPORTANT: Change all credentials before deploying to production
-apiKey: changeme           # Bearer token for authenticating with Weaviate
-apiUser: admin@example.com # Username associated with the API key
-
-queryDefaultsLimit: 25
-
-# Default vectorizer applied to new collections
-# Options: none, text2vec-openai, text2vec-cohere, text2vec-huggingface, text2vec-aws
-defaultVectorizerModule: none
-
-modules:
-  enabled: []
-  # - generative-anthropic
-  # - generative-openai
-  # - generative-cohere
-  # - text2vec-openai
-  # - text2vec-cohere
-  # - text2vec-huggingface
-
-  openai:
-    apiKey: ""
-  anthropic:
-    apiKey: ""
-  cohere:
-    apiKey: ""
-  huggingface:
-    apiKey: ""
-
-cpu: 2
-memory: 4Gi
-
-volumes:
-  data:
-    initialCapacity: 20  # GiB
-    autoscaling:
-      maxCapacity: 200
-      minFreePercentage: 20
-      scalingFactor: 1.5
-
-multiZone:
-  enabled: false
-
-internal_access:
-  type: same-gvc  # Options: same-gvc, same-org, workload-list
-  workloads:
-    # - //gvc/GVC_NAME/workload/WORKLOAD_NAME
-
-backup:
-  enabled: false
-  provider: aws   # options: aws or gcp
-  schedule: "0 2 * * *"  # daily at 2am UTC
-
-  resources:
-    cpu: 250m
-    memory: 256Mi
-
-  aws:
-    bucket: my-backup-bucket
-    region: us-east-1
-    cloudAccountName: my-s3-cloudaccount
-    policyName: my-backup-policy
-    path: weaviate/backups
-
-  gcp:
-    bucket: my-backup-bucket
-    cloudAccountName: my-gcs-cloudaccount
-    path: weaviate/backups
-```
-
-### Core Settings
-
-- `replicas` — Number of Weaviate nodes. A minimum of 3 is recommended for production — the Raft consensus layer requires a quorum (2 of 3) to elect a leader and process schema changes.
-- `clusterName` — Internal cluster identifier used in Raft coordination.
-- `apiKey` — Bearer token that controls all access to the Weaviate instance, including schema management and data. **Change before deploying to production.**
-- `apiUser` — Username associated with the API key, used for authorization and the admin list.
-- `queryDefaultsLimit` — Default result limit applied to queries that do not specify one.
-- `defaultVectorizerModule` — The vectorizer Weaviate calls automatically on insert and query for new collections. Set to `none` if you are providing your own vectors.
-- `cpu` / `memory` — Resource limits applied to each Weaviate replica.
-
-### Storage
-
-- `volumes.data.initialCapacity` — Initial volume size in GiB per replica (minimum 10). Defaults to 20.
-- `volumes.data.autoscaling.maxCapacity` — Maximum volume size in GiB when autoscaling is enabled.
-- `volumes.data.autoscaling.minFreePercentage` — Percentage of free space that triggers a scale-up.
-- `volumes.data.autoscaling.scalingFactor` — Multiplier applied to the current capacity when scaling up.
-
-### Multi-Zone
-
-Set `multiZone.enabled: true` to spread replicas across availability zones within the location. Verify your selected location supports multi-zone before enabling.
-
-### Firewall
-
-- `internal_access.type` — Controls which workloads can reach Weaviate:
-  - `same-gvc` — All workloads in the same GVC (default).
-  - `same-org` — All workloads in the org.
-  - `workload-list` — Only workloads listed in `internal_access.workloads`.
-
-## AI Modules
-
-Weaviate supports pluggable AI modules for automatic vectorization and generative search. Modules are disabled by default.
-
-<Warning>
-Adding an API key alone does not activate a module. Every module you intend to use must also be listed in `modules.enabled`.
-</Warning>
-
-### Supported Modules
-
-| Module | Type | Provider | API Key Field |
-|--------|------|----------|---------------|
-| `text2vec-openai` | Vectorizer | OpenAI | `modules.openai.apiKey` |
-| `text2vec-cohere` | Vectorizer | Cohere | `modules.cohere.apiKey` |
-| `text2vec-huggingface` | Vectorizer | Hugging Face | `modules.huggingface.apiKey` |
-| `generative-openai` | Generative | OpenAI | `modules.openai.apiKey` |
-| `generative-anthropic` | Generative | Anthropic | `modules.anthropic.apiKey` |
-| `generative-cohere` | Generative | Cohere | `modules.cohere.apiKey` |
-
-### Example — Automatic Vectorization with OpenAI
-
-```yaml
-defaultVectorizerModule: text2vec-openai
-
-modules:
-  enabled:
-    - text2vec-openai
-  openai:
-    apiKey: "sk-..."
-```
-
-With this configuration, Weaviate automatically calls OpenAI's embedding API when objects are inserted and when vector searches are run — no client-side embedding step required.
-
-### Example — Generative Search with Anthropic
-
-```yaml
-modules:
-  enabled:
-    - generative-anthropic
-  anthropic:
-    apiKey: "sk-ant-..."
-```
-
-Enabling any module with an API key automatically adds outbound internet access to the Weaviate workload's firewall so it can reach the provider's API.
-
-## Connecting
-
-Weaviate is accessible internally from any workload in the same GVC:
-
-| Access | Hostname | Port |
-|--------|----------|------|
-| Load-balanced (any replica) | `{release-name}-weaviate.{gvc}.cpln.local` | `8080` (REST), `50051` (gRPC) |
-| Specific replica | `{release-name}-weaviate-{n}.{gvc}.cpln.local` | `8080` (REST), `50051` (gRPC) |
-
-Authenticate using the Bearer token set in `apiKey`:
-
-```bash
-curl -H "Authorization: Bearer YOUR_API_KEY" \
-     http://{release-name}-weaviate.{gvc}.cpln.local:8080/v1/meta
-```
-
-## Backing Up
-
-When enabled, a cron workload triggers Weaviate's built-in backup API on schedule to write a full snapshot to cloud storage. Each backup is stored at `{path}/{backup-id}/` and includes all collections and their data.
-
-### AWS S3
-
-<Steps>
-  <Step title="Create a bucket">
-    Create an S3 bucket. Set `backup.aws.bucket` and `backup.aws.region` to match.
-  </Step>
-  <Step title="Set up a Cloud Account">
-    If you do not have one, [create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
-  </Step>
-  <Step title="Create an IAM policy">
-    Create an IAM policy with the following JSON (replace `YOUR_BUCKET_NAME`) and set `backup.aws.policyName` to its name:
-
-    ```json
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "s3:GetObject",
-                    "s3:PutObject",
-                    "s3:DeleteObject",
-                    "s3:ListBucket",
-                    "s3:GetObjectVersion",
-                    "s3:DeleteObjectVersion"
-                ],
-                "Resource": [
-                    "arn:aws:s3:::YOUR_BUCKET_NAME",
-                    "arn:aws:s3:::YOUR_BUCKET_NAME/*"
-                ]
-            }
-        ]
-    }
-    ```
-  </Step>
-</Steps>
-
-### GCS
-
-<Steps>
-  <Step title="Create a bucket">
-    Create a GCS bucket. Set `backup.gcp.bucket` to its name.
-  </Step>
-  <Step title="Set up a Cloud Account">
-    If you do not have one, [create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account). Set `backup.gcp.cloudAccountName` to its name.
-  </Step>
-</Steps>
-
-<Warning>
-You must add the `Storage Admin` role to the GCP service account created for the Cloud Account.
-</Warning>
-
-## Restoring a Backup
-
-Exec into any Weaviate replica and POST to the restore endpoint. Replace `s3` with `gcs` for GCP backups, and `BACKUP_ID` with the backup name from your bucket (e.g. `weaviate-backup-20260610-020000`):
-
-```bash
-# Trigger restore
-wget -qO- \
-  --header='Authorization: Bearer YOUR_API_KEY' \
-  --header='Content-Type: application/json' \
-  --post-data='{}' \
-  'http://localhost:8080/v1/backups/s3/BACKUP_ID/restore'
-
-# Poll for completion
-wget -qO- \
-  --header='Authorization: Bearer YOUR_API_KEY' \
-  'http://localhost:8080/v1/backups/s3/BACKUP_ID/restore'
-```
-
-<Warning>
-Restore will fail if a collection from the backup already exists on the cluster. Drop existing collections first or restore to a fresh deployment.
-</Warning>
-
-## Important Notes
-
-- **Minimum 3 replicas for production** — Raft requires a quorum (2 of 3) to elect a leader and process schema changes. A 2-node cluster cannot reach quorum if one node fails.
-- **API key security** — Change `apiKey` before deploying to production. This key controls all access to the instance including schema management and data.
-- **Modules must be declared** — Adding an API key alone does not activate a module. Every module you intend to use must be listed in `modules.enabled`.
-- **Multi-zone** — Verify your selected location supports multi-zone before enabling.
-
-## External References
-
-<CardGroup cols={2}>
-  <Card title="Weaviate Documentation" href="https://weaviate.io/developers/weaviate" icon="book">
-    Official Weaviate documentation
-  </Card>
-  <Card title="Weaviate REST API" href="https://weaviate.io/developers/weaviate/api/rest" icon="code">
-    REST API reference including backup and restore endpoints
-  </Card>
-  <Card title="Weaviate Modules" href="https://weaviate.io/developers/weaviate/modules" icon="puzzle-piece">
-    Documentation for vectorizer and generative AI modules
-  </Card>
-  <Card title="Weaviate GraphQL API" href="https://weaviate.io/developers/weaviate/api/graphql" icon="brackets-curly">
-    GraphQL API reference for querying vector and object data
-  </Card>
 </CardGroup>

--- a/template-catalog/templates/weaviate.mdx
+++ b/template-catalog/templates/weaviate.mdx
@@ -97,3 +97,174 @@ To install, follow the instructions for your preferred method:
     Declare templates in your Pulumi programs
     </Card>
 </CardGroup>
+
+## Configuration
+
+The default `values.yaml` for this template:
+
+```yaml
+# ─── Cluster ──────────────────────────────────────────────────────────────────
+replicas: 3
+
+image: semitechnologies/weaviate:1.38.0
+
+# ─── Authentication ───────────────────────────────────────────────────────────
+# REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL.
+# An `opaque` secret (encoding: plain) whose entire payload is the API key:
+#   printf '%s' "$(openssl rand -hex 32)" | \
+#     cpln secret create-opaque --name my-weaviate-api-key --encoding plain -f -
+# If it does not exist at install time the deployment WEDGES waiting on it and
+# looks broken. See Prerequisites in the README.
+apiKeySecretName: my-weaviate-api-key
+
+# Username the API key maps to. Not a secret — it is the admin-list identity.
+apiUser: admin@example.com
+
+# ─── Query Behavior ───────────────────────────────────────────────────────────
+# Default result limit for queries
+queryDefaultsLimit: 25
+
+# Default vectorizer module applied to new collections
+# Options: none, text2vec-openai, text2vec-cohere, text2vec-huggingface, text2vec-aws
+defaultVectorizerModule: none
+
+# ─── AI Modules ───────────────────────────────────────────────────────────────
+modules:
+  # Every module you intend to use must be listed here — supplying a key alone
+  # does not activate it.
+  # Common options: text2vec-openai, text2vec-cohere, text2vec-huggingface,
+  #                 generative-openai, generative-cohere, generative-anthropic,
+  #                 qna-openai, ref2vec-centroid
+  enabled: []
+
+  # OPTIONAL PREREQUISITE SECRETS — one `opaque` secret (encoding: plain) per
+  # provider, holding only that provider's key. Empty = provider off: no env
+  # var, no reveal grant, no outbound egress opened.
+  #   printf '%s' "sk-..." | \
+  #     cpln secret create-opaque --name my-weaviate-openai-key --encoding plain -f -
+  openai:
+    apiKeySecretName: "" # e.g. my-weaviate-openai-key
+  anthropic:
+    apiKeySecretName: "" # e.g. my-weaviate-anthropic-key
+  cohere:
+    apiKeySecretName: "" # e.g. my-weaviate-cohere-key
+  huggingface:
+    apiKeySecretName: "" # e.g. my-weaviate-huggingface-key
+
+# ─── Resources ────────────────────────────────────────────────────────────────
+# HNSW vector indexes are RAM-resident. Rough sizing:
+#   memory ≈ vectors × dimensions × 4 bytes × 1.5
+cpu: 2
+memory: 4Gi
+
+# ─── Storage ──────────────────────────────────────────────────────────────────
+volumes:
+  data:
+    initialCapacity: 20 # GiB per replica (platform minimum 10)
+    autoscaling:
+      maxCapacity: 200
+      minFreePercentage: 20
+      scalingFactor: 1.5
+
+# ─── Placement ────────────────────────────────────────────────────────────────
+multiZone:
+  enabled: false # true = spread replicas across AZs (location must support it)
+
+# ─── Access ───────────────────────────────────────────────────────────────────
+# Weaviate is reachable only from inside Control Plane — there is no public
+# endpoint, by design. See Important Notes in the README.
+internalAccess:
+  type: same-gvc # none | same-gvc | same-org | workload-list
+  workloads: [] # used only with workload-list
+  # workloads:
+  #   - //gvc/GVC_NAME/workload/WORKLOAD_NAME
+
+# ─── Backup ───────────────────────────────────────────────────────────────────
+backup:
+  enabled: false
+  provider: aws # aws | gcp
+  schedule: "0 2 * * *" # cron in UTC — daily at 02:00
+
+  resources:
+    cpu: 250m
+    memory: 256Mi
+
+  aws:
+    bucket: my-weaviate-backup-bucket
+    region: us-east-1
+    cloudAccountName: my-s3-cloud-account
+    policyName: my-weaviate-backup-policy
+    path: weaviate/backups
+
+  gcp:
+    bucket: my-weaviate-backup-bucket
+    cloudAccountName: my-gcs-cloud-account
+    path: weaviate/backups
+```
+
+### Cluster
+
+- `replicas` — Number of Weaviate nodes. Three is the default and the practical minimum for Raft, which needs a quorum (2 of 3) to elect a leader and accept schema changes. Read [Rolling Restarts Can Split a Replica Out of the Cluster](#rolling-restarts-can-split-a-replica-out-of-the-cluster) before running a multi-replica cluster in production.
+- `image` — The Weaviate image and tag. The template is tested on `semitechnologies/weaviate:1.38.0`.
+
+A first install of three replicas took about **165 seconds** to reach all-ready in testing: the first replica is ready at roughly 60 seconds and the ordered rollout paces the remaining two.
+
+### Authentication
+
+- `apiKeySecretName` — Name of the pre-created `opaque` secret whose entire payload is the API key. Required; see [Prerequisites](#prerequisites). The key is read straight from the secret into `AUTHENTICATION_APIKEY_ALLOWED_KEYS` and never appears in the Helm release, the rendered manifest, or the stored workload spec.
+- `apiUser` — The username the API key maps to, and the entry in Weaviate's admin list. This is an identity, not a credential, so it is an ordinary value and is stored in the template's own dictionary secret.
+
+Anonymous access is disabled unconditionally. In testing, an unauthenticated request and a request with a wrong key both returned `401 Unauthorized`, and only the exact key from the secret returned `200`.
+
+### Query Behavior
+
+- `queryDefaultsLimit` — Default result limit applied to queries that do not specify one.
+- `defaultVectorizerModule` — The vectorizer applied to new collections. Leave it at `none` when your application supplies its own vectors; set it to a provider module to have Weaviate call that provider's embedding API on insert and query.
+
+### AI Modules
+
+- `modules.enabled` — List of modules written to Weaviate's `ENABLE_MODULES` variable. When backups are enabled the template appends `backup-s3` or `backup-gcs` to this list for you.
+- `modules.openai.apiKeySecretName`, `modules.anthropic.apiKeySecretName`, `modules.cohere.apiKeySecretName`, `modules.huggingface.apiKeySecretName` — Name of the `opaque` secret holding that provider's key. Empty means the provider is off.
+
+| Module | Type | Provider | Secret knob |
+|--------|------|----------|-------------|
+| `text2vec-openai`, `generative-openai`, `qna-openai` | Vectorizer / Generative | OpenAI | `modules.openai.apiKeySecretName` |
+| `generative-anthropic` | Generative | Anthropic | `modules.anthropic.apiKeySecretName` |
+| `text2vec-cohere`, `generative-cohere` | Vectorizer / Generative | Cohere | `modules.cohere.apiKeySecretName` |
+| `text2vec-huggingface` | Vectorizer | Hugging Face | `modules.huggingface.apiKeySecretName` |
+
+Naming any provider secret, or enabling backups, opens outbound internet access on the Weaviate workload so it can reach that API. With neither, the workload has no egress at all.
+
+<Warning>
+The comment in `values.yaml` — "supplying a key alone does not activate it" — **overstates what `modules.enabled` does** on Weaviate 1.38. See [Provider Modules Load Regardless of modules.enabled](#provider-modules-load-regardless-of-modules-enabled).
+</Warning>
+
+### Resources
+
+- `cpu` / `memory` — Limits applied to each Weaviate replica.
+
+Memory is the sizing constraint, not CPU: HNSW vector indexes are held in RAM. Size roughly as `vectors × dimensions × 4 bytes × 1.5`. Under-provisioning surfaces as an out-of-memory restart rather than slow queries.
+
+### Storage
+
+- `volumes.data.initialCapacity` — Initial volume size in GiB per replica. The platform minimum is 10.
+- `volumes.data.autoscaling.maxCapacity` — Maximum volume size in GiB.
+- `volumes.data.autoscaling.minFreePercentage` — Free-space percentage that triggers a scale-up.
+- `volumes.data.autoscaling.scalingFactor` — Multiplier applied to current capacity when scaling up.
+
+Volume data survives a redeploy. After a full restart in testing, all objects written beforehand were still present and byte-identical, including their original write timestamps.
+
+### Placement
+
+Set `multiZone.enabled: true` to spread replicas across availability zones within the location. Verify the location supports multi-zone before enabling.
+
+### Access
+
+- `internalAccess.type` — Which workloads may reach Weaviate: `none`, `same-gvc` (default), `same-org`, or `workload-list`.
+- `internalAccess.workloads` — Used only with `workload-list`. Full workload links, for example `//gvc/GVC_NAME/workload/WORKLOAD_NAME`.
+
+All four settings were exercised against a live cluster, including the negative case: a workload absent from `workload-list` was refused, and adding it to the list let it through.
+
+<Note>
+**A firewall change takes up to a couple of minutes to take effect.** Measured propagation was 45–95 seconds. A denial surfaces to the caller as `HTTP 503 upstream connect error`, which is indistinguishable from an unhealthy upstream — re-test after a couple of minutes before concluding a knob did not work.
+</Note>

--- a/template-catalog/templates/weaviate.mdx
+++ b/template-catalog/templates/weaviate.mdx
@@ -340,3 +340,145 @@ The risk is the **inverse** of what the values comment suggests. Supplying a pro
 </Warning>
 
 `modules.enabled` still has a job — it is the documented upstream knob and it is how the backup modules are turned on, which the template does for you when `backup.enabled: true`. It is simply not a safety gate on provider access.
+
+## Connecting
+
+Weaviate is reachable from workloads inside Control Plane, subject to `internalAccess.type`. There is no public endpoint.
+
+| What | Where |
+|---|---|
+| Cluster (load balanced) | `{release}-weaviate.{gvc}.cpln.local` |
+| A specific replica | `{release}-weaviate-{n}.{gvc}.cpln.local` |
+| REST and GraphQL port | `8080` |
+| gRPC port | `50051` |
+| Credentials | The key in the secret named by `apiKeySecretName`; username `apiUser` |
+| Public endpoint | None |
+
+Authenticate with the key as a bearer token:
+
+```bash
+curl -H "Authorization: Bearer YOUR_API_KEY" \
+     http://{release}-weaviate.{gvc}.cpln.local:8080/v1/meta
+```
+
+<Note>
+The workload is assigned a canonical `*.cpln.app` hostname like any other, but `inboundAllowCIDR` is empty unconditionally, so every request from the internet is refused at the platform edge with `403 RBAC: access denied` — **a valid API key does not help**, because the request never reaches Weaviate. If you need browser or off-platform access, put your own authenticating proxy in front of it inside the GVC.
+</Note>
+
+## Backing Up
+
+With `backup.enabled: true`, a cron workload calls Weaviate's backup API on `backup.schedule` and writes a full snapshot of every collection to `{path}/{backup-id}/` in your bucket.
+
+<Warning>
+**The backup path has not been exercised end to end.** Rendering, the chart's validation of the backup settings, and the backup job's discovery of the cluster endpoint were all checked live, but no snapshot has been written to S3 or GCS from this template — a real run needs cloud resources outside the test environment. Treat backups as unverified: run one on your own bucket and confirm the objects land before you rely on it. A misconfigured cloud binding can report a successful install while the identity is unusable, so check the objects, not the install.
+</Warning>
+
+<Warning>
+**With `internalAccess.type: workload-list`, the backup job is denied.** The cron job is a separate workload and the template does not add it to the allow-list, so its calls to Weaviate are refused like any other unlisted workload. Add `//gvc/{gvc}/workload/{release}-weaviate-backup` to `internalAccess.workloads` yourself, or use `same-gvc` or `same-org`.
+</Warning>
+
+### AWS S3
+
+<Steps>
+  <Step title="Create a bucket">
+    Create an S3 bucket. Set `backup.aws.bucket` and `backup.aws.region` to match, and `backup.aws.path` to the prefix you want snapshots written under.
+  </Step>
+  <Step title="Set up a Cloud Account">
+    If you do not have one, [create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) for the AWS account holding the bucket. Set `backup.aws.cloudAccountName` to its name.
+  </Step>
+  <Step title="Create an IAM policy">
+    Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`, and set `backup.aws.policyName` to its name:
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket",
+                    "s3:GetObjectVersion",
+                    "s3:DeleteObjectVersion"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::YOUR_BUCKET_NAME",
+                    "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+                ]
+            }
+        ]
+    }
+    ```
+  </Step>
+</Steps>
+
+### GCS
+
+<Steps>
+  <Step title="Create a bucket">
+    Create a GCS bucket. Set `backup.gcp.bucket` to its name and `backup.gcp.path` to the prefix.
+  </Step>
+  <Step title="Set up a Cloud Account">
+    If you do not have one, [create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account) for the GCP project. Set `backup.gcp.cloudAccountName` to its name.
+  </Step>
+  <Step title="Grant the bucket role">
+    Grant the Cloud Account's service account `roles/storage.objectAdmin` on that bucket. The template requests exactly that role on exactly that bucket, and nothing more.
+  </Step>
+</Steps>
+
+## Restoring a Backup
+
+Run the restore from inside any Weaviate replica. Use `gcs` in place of `s3` for GCP backups, and replace `BACKUP_ID` with the backup name from your bucket (they are written as `weaviate-backup-YYYYMMDD-HHMMSS`):
+
+```bash
+# Trigger the restore
+wget -qO- \
+  --header='Authorization: Bearer YOUR_API_KEY' \
+  --header='Content-Type: application/json' \
+  --post-data='{}' \
+  'http://localhost:8080/v1/backups/s3/BACKUP_ID/restore'
+
+# Poll for completion
+wget -qO- \
+  --header='Authorization: Bearer YOUR_API_KEY' \
+  'http://localhost:8080/v1/backups/s3/BACKUP_ID/restore'
+```
+
+<Warning>
+A restore is not a merge. It fails if a collection from the backup already exists on the cluster — drop the collection first, or restore into a fresh deployment.
+</Warning>
+
+## Important Notes
+
+- **Create the API key secret before you install.** Without it the install reports success and the deployment silently wedges, with no container and no logs. See [Prerequisites](#prerequisites).
+- **Verify cluster health after every restart.** A replica that fails to rejoin the Raft cluster still reports `ready` and still receives traffic. See [Rolling Restarts Can Split a Replica Out of the Cluster](#rolling-restarts-can-split-a-replica-out-of-the-cluster).
+- **A named provider secret is a live billable integration**, whether or not the module is listed in `modules.enabled`.
+- **Keep your own copy of the API key.** Rotating it means updating the secret and restarting the cluster; losing it locks you out of every collection.
+- **There is no public endpoint**, and that is not configurable in this template. Reachability is `internalAccess` only, and an access change takes up to a couple of minutes to settle.
+- **Size memory, not CPU.** Vector indexes are RAM-resident; an undersized cluster fails with out-of-memory restarts.
+- **Backups are unverified.** Confirm a snapshot lands in your bucket before depending on the schedule.
+
+## External References
+
+<CardGroup cols={2}>
+  <Card title="Weaviate Documentation" href="https://docs.weaviate.io/weaviate" icon="book">
+    Official Weaviate documentation
+  </Card>
+  <Card title="REST API Reference" href="https://docs.weaviate.io/weaviate/api/rest" icon="code">
+    REST API reference, including the backup and restore endpoints
+  </Card>
+  <Card title="Modules" href="https://docs.weaviate.io/weaviate/configuration/modules" icon="puzzle-piece">
+    Vectorizer and generative module configuration
+  </Card>
+  <Card title="Authentication and Authorization" href="https://docs.weaviate.io/deploy/configuration/authentication" icon="key">
+    How Weaviate API key authentication and the admin list work
+  </Card>
+  <Card title="Backups" href="https://docs.weaviate.io/deploy/configuration/backups" icon="box-archive">
+    Upstream documentation for the backup and restore API
+  </Card>
+  <Card title="Weaviate Template" href="https://github.com/controlplane-com/templates/tree/main/weaviate" icon="github">
+    View the source files, default values, and chart definition
+  </Card>
+</CardGroup>

--- a/template-catalog/templates/weaviate.mdx
+++ b/template-catalog/templates/weaviate.mdx
@@ -65,7 +65,7 @@ printf '%s' "sk-..." | \
 Set `modules.openai.apiKeySecretName` (or the `anthropic`, `cohere`, `huggingface` equivalent) to that name. Leaving a provider's `apiKeySecretName` empty means the provider is genuinely off: no environment variable, no `reveal` grant, and no outbound internet access on the workload. All three were confirmed against the live resources on a default install, where the container could not reach `api.openai.com` at all.
 
 <Warning>
-**Naming a provider secret gives you a live, billable integration.** It is not inert configuration held in reserve — see [Provider Modules Load Regardless of modules.enabled](#provider-modules-load-regardless-of-modules-enabled). Only supply a provider key when you intend that provider to be used.
+**Naming a provider secret gives you a live, billable integration.** It is not inert configuration held in reserve — see [Provider Modules Load Regardless of the Module List](#provider-modules-load-regardless-of-the-module-list). Only supply a provider key when you intend that provider to be used.
 </Warning>
 
 ### Cloud Storage
@@ -236,7 +236,7 @@ Anonymous access is disabled unconditionally. In testing, an unauthenticated req
 Naming any provider secret, or enabling backups, opens outbound internet access on the Weaviate workload so it can reach that API. With neither, the workload has no egress at all.
 
 <Warning>
-The comment in `values.yaml` — "supplying a key alone does not activate it" — **overstates what `modules.enabled` does** on Weaviate 1.38. See [Provider Modules Load Regardless of modules.enabled](#provider-modules-load-regardless-of-modules-enabled).
+The comment in `values.yaml` — "supplying a key alone does not activate it" — **overstates what `modules.enabled` does** on Weaviate 1.38. See [Provider Modules Load Regardless of the Module List](#provider-modules-load-regardless-of-the-module-list).
 </Warning>
 
 ### Resources
@@ -268,3 +268,75 @@ All four settings were exercised against a live cluster, including the negative 
 <Note>
 **A firewall change takes up to a couple of minutes to take effect.** Measured propagation was 45–95 seconds. A denial surfaces to the caller as `HTTP 503 upstream connect error`, which is indistinguishable from an unhealthy upstream — re-test after a couple of minutes before concluding a knob did not work.
 </Note>
+
+## Upgrading From 1.0.1 or Earlier
+
+`1.1.0` is a security release. Every credential the chart used to accept as a value is now a secret you create and reference by name, and carrying a `1.0.1` values file forward **fails at render** with a message naming its replacement — nothing silently falls back to a default.
+
+| `1.0.1` and earlier | `1.1.0` | Why |
+|---|---|---|
+| `apiKey` (a working 64-character key) | `apiKeySecretName` → required prerequisite `opaque` secret | The default key was published in this repository and shared by every install that did not override it. It is the only authentication Weaviate has |
+| `modules.openai.apiKey` and the `anthropic`, `cohere`, `huggingface` equivalents | `modules.{provider}.apiKeySecretName` → optional prerequisite `opaque` secrets | Your own provider billing keys were landing in the Helm release in plaintext |
+| `internal_access` | `internalAccess` | Renamed only; the fields (`type`, `workloads`) are unchanged |
+| `clusterName` | Removed | It was never rendered into any resource. Nothing replaces it |
+
+The render guard for the API key reads:
+
+```text
+weaviate: `apiKey` was removed in 1.1.0 — the API key is now a REQUIRED prerequisite
+`opaque` secret (encoding: plain). Create it, then set `apiKeySecretName` to its name.
+```
+
+<Steps>
+  <Step title="Rotate the key, do not carry it forward">
+    Generate a **new** key and create the secret as shown in [Prerequisites](#prerequisites). The old default was public, so an install that used it should be treated as having had its data readable and writable by anyone who found it. If you overrode the default with your own value, that value still travelled in the Helm release and is worth rotating too.
+  </Step>
+  <Step title="Replace the removed keys">
+    Delete `apiKey`, `clusterName`, and any `modules.{provider}.apiKey` entries from your values. Set `apiKeySecretName`, rename `internal_access` to `internalAccess`, and create a provider secret for each provider you actually use.
+  </Step>
+  <Step title="Update every client">
+    The API key changes, so every application, notebook, and client library holding the old bearer token must be updated.
+  </Step>
+  <Step title="Plan the restart">
+    A `helm upgrade` restarts the cluster one replica at a time. Read [Rolling Restarts Can Split a Replica Out of the Cluster](#rolling-restarts-can-split-a-replica-out-of-the-cluster) first and verify cluster health afterwards — the platform's ready status will not tell you if a node failed to rejoin.
+  </Step>
+</Steps>
+
+## Cluster Behavior and Known Limits
+
+Both limitations below are **pre-existing** — `1.1.0` changed no clustering configuration — and both were confirmed on a live three-replica cluster.
+
+### Rolling Restarts Can Split a Replica Out of the Cluster
+
+A single redeployment of a three-replica cluster left one node **permanently split out of the Raft cluster**. The restarted node came up as a leaderless `Candidate` — it had Raft log entries on disk but had applied none of them, so its schema state was empty. The other two replicas elected a leader without it, and it **never rejoined**: it was still in that state 31 minutes later, and it did not recover on its own.
+
+The part that makes this dangerous is what the platform reports:
+
+- **All three replicas report `ready`.** The readiness probe checks `/v1/.well-known/live`, which only proves the HTTP server is up, so the split node stays in the service-DNS rotation.
+- **Roughly a third of client requests fail silently.** A 60-sample probe against the load-balanced service DNS measured `200: 42 (70%)` and `404: 18 (30%)` — exactly one node in three. The failures are `404 Not Found`, an answered, routed response rather than a connection error, so a client sees "no such collection", not "cluster unhealthy".
+
+This is a **rejoin** defect, not a rollout-pacing one: the restart of the other two replicas was seamless, with 270 of 270 probe samples returning `200` while they cycled one at a time.
+
+<Warning>
+**`replicas: 3` is not safe across an upgrade**, and `helm upgrade` is how you will meet this. A restart is routine — an upgrade, an image bump, a platform reschedule — so **verify cluster health after any restart instead of trusting the platform's ready status.**
+</Warning>
+
+Check membership from inside any replica. A healthy cluster reports one `Leader` and two `Follower` nodes on the same term, and `/v1/nodes` lists every replica as `HEALTHY`:
+
+```bash
+cpln workload exec {release}-weaviate --gvc {gvc} --container weaviate -- \
+  /bin/sh -c "wget -qO- --header='Authorization: Bearer YOUR_API_KEY' \
+  http://localhost:8080/v1/cluster/statistics"
+```
+
+A split node reports `"state":"Candidate"` with an empty `leaderId` and `"lastContact":"never"`, and `/v1/nodes` queried from a healthy replica lists fewer nodes than you deployed. A single-replica install (`replicas: 1`) has no Raft membership to lose and is not exposed to this.
+
+### Provider Modules Load Regardless of the Module List
+
+`modules.enabled` does not gate the API-based vectorizer and generative modules. With `modules.enabled: []` and only a provider secret named, `text2vec-openai` was still loaded, a collection could be created with `"vectorizer":"text2vec-openai"`, and inserting an object with **no vector** made Weaviate call the provider and store the embedding it returned. `/v1/meta` reports the same 41 modules loaded whether `ENABLE_MODULES` is set or not — on 1.38 these modules are compiled in and always available.
+
+<Warning>
+The risk is the **inverse** of what the values comment suggests. Supplying a provider key "just to have it configured" gives you a **live, billable** provider integration that will be used the moment any collection specifies that vectorizer. Only name a provider secret when you intend that provider to be used, and remove the secret name when you stop using it.
+</Warning>
+
+`modules.enabled` still has a job — it is the documented upstream knob and it is how the backup modules are turned on, which the template does for you when `backup.enabled: true`. It is simply not a safety gate on provider access.


### PR DESCRIPTION
Docs for the six tier-2 security releases, all merged on templates `main` (PRs #426, #427, #434, #435, #436, #437). Changelog entries in templates PR #438.

Six existing pages updated. **No `overview.mdx`, `docs.json` or icon changes** — every page already existed, so cards and nav entries are unchanged.

| Page | Version | What the release changed |
|---|---|---|
| `weaviate` | 1.1.0 | API key + four provider billing keys → prerequisite secrets |
| `mongodb-cluster` | 1.1.0 | credentials → dictionary secret; replica-set keyfile → separate opaque secret |
| `minio` | 1.3.0 | root credentials → dictionary secret (these are the S3 access/secret key pair) |
| `rabbitmq` | 1.2.0 | AMQP credentials → dictionary secret, delivered as env vars |
| `pgdog` | 1.1.0 | per-pooled-user secrets + a separate admin secret |
| `seaweedfs` | 1.1.0 | admin UI credentials → dictionary secret |

Same vulnerability throughout, and the same fix: a working credential shipped as a values default, published in a public repo and shared by every install that did not override it. All six were internal-only by default, which is why the audit graded them below tier 1.

## Corrections to previously-wrong page content

These are the parts worth reviewing, because each was documented incorrectly before:

- **minio's page advertised a `https://…cpln.app` console URL that has never existed.** MinIO has no public endpoint and the canonical endpoint returns 403. Replaced with the verified `cpln port-forward` path.
- **minio's rotation guidance said "needs a restart."** Measured, it is ~**11 minutes of split credential state** — root credentials are per-node and `OrderedReady` cycles one replica at a time, so clients fail intermittently with *both* keys mid-rollout. It converges cleanly and needs no IAM re-encryption. The page also now says `cpln secret update` **cannot** rotate a value (it edits description and tags only); the working path is `cpln apply -f` then `force-redeployment`.
- **minio's quota prerequisite was wrong** — it told users to request an increase before `replicas: 6`. The built-in quota **is** 6.
- **pgdog's `psql` command did not work.** It used the short in-GVC host name, which fails with `could not translate host name`. The short name resolves for `stateful` workloads but is **NXDOMAIN for `standard` ones** — the page now shows only the fully-qualified form, and says why.
- **rabbitmq's firewall change is deliberately NOT described as closing an exposure.** 1.1.1's `external_*` keys were commented out, but a live 1.1.1 was stood up and probed: **403 from the internet every time**, with no external block backfilled. The platform default is already closed, so 1.2.0's enumerated block is a drift/clarity fix. The credential move is the security win, and the page says so.

## Verification

- **YAML blocks diffed against the shipped `values.yaml`** on all six — 13/11/43/17/33/47 documented scalars. pgdog's six apparent mismatches are a deliberate worked example of read/write splitting across a primary and replica, not the Configuration block.
- **A sweep for reproduced credentials across all six pages** returns one hit: `mypassword` in mongodb-cluster, inside a compromise warning rather than a code block, which is where a retired credential belongs.
- **Anchors resolve on all six** (2–6 each), with no linked heading carrying a colon or comma.
- **Both writers validated their renders by content marker**, not status code, because `mintlify dev` shares a global cache across worktrees and can serve a sibling's file while returning 200.
- All documented commands were executed live and the throwaway secrets deleted. External links 200 apart from the known `streamlinehq.com` 429.

## Honest gaps

- **weaviate's two pre-existing defects are documented as limitations, not fixed**: a rolling restart can permanently split a replica out of the cluster (the platform still reports all three ready while ~30% of queries 404), and `modules.enabled` gates nothing, so a supplied provider key is live and billable.
- **mongodb's physical/PBM backup is untested**, as it was at 1.0.0.
- **weaviate's backup path is untested** — it needs cloud resources outside the test blast radius.
- **minio's `internalAccess` non-default values are untested**; the page documents the options without claiming verified behaviour.
- **pgdog's `pooling.mode: statement`** is accepted by the validator and README but unverified end to end; the page documents only the two proven modes and flags the third.

## One follow-up, deliberately out of scope

Roughly eight templates — and `postgres.mdx`'s `### MinIO` backup subsection — tell users the MinIO backup credentials are its `admin.username`/`admin.password` values, which no longer exist in 1.3.0. Their *values* are unaffected (they take `my-minio-*` placeholders). That file belongs to the paused `docs/postgres-3.4.0` branch, so both writers correctly left it alone rather than reaching across worktrees. Worth one sweep when postgres docs resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
