### PR TITLE
docs: the twelve templates that close the secrets audit

### DIFF
--- a/template-catalog/templates/airflow.mdx
+++ b/template-catalog/templates/airflow.mdx
@@ -1,39 +1,117 @@
 ---
 title: Airflow
-description: Deploy Apache Airflow on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and Celery workers with Redis broker and PostgreSQL metadata store.
-keywords: ['apache airflow', 'dag scheduler', 'etl orchestrator', 'workflow engine', 'prefect alternative', 'dagster alternative', 'airflow webserver', 'celeryexecutor', 'keda autoscaling', 'fernet key', 'task queue']
+description: Deploy Apache Airflow on Control Plane using the Template Catalog. Covers the prerequisite auth secret, the Fernet key that cannot be rotated, the closed-by-default web UI reached over a port-forward, Celery workers with KEDA autoscaling, git-sync DAG delivery, and upgrading from template version 1.4.x.
+keywords: ['apache airflow', 'dag scheduler', 'etl orchestrator', 'workflow engine', 'prefect alternative', 'dagster alternative', 'airflow webserver', 'celeryexecutor', 'keda autoscaling', 'fernet key', 'task queue', 'git-sync', 'port forward']
 ---
 
 ## Overview
 
-Apache Airflow is an open-source platform for programmatically authoring, scheduling, and monitoring workflows. This template deploys a full Airflow stack using CeleryExecutor, with Redis as the task queue broker and PostgreSQL as the metadata database. Celery workers can optionally be autoscaled using KEDA based on queue depth.
+Apache Airflow is an open-source platform for programmatically authoring, scheduling, and monitoring workflows. This template deploys a full Airflow 3.x stack using the CeleryExecutor, with Redis as the task broker, PostgreSQL as the metadata database, KEDA autoscaling for the Celery workers, and optional git-sync DAG delivery.
+
+The admin login and both signing keys are not template values. They come from a dictionary secret you create before installing, so they never pass through Helm and never land in the release. The web UI ships **closed to the internet**, because it can trigger arbitrary code and decrypt every credential stored in an Airflow Connection.
+
+<Warning>
+**Template version 1.5.0 is a breaking change.** `airflow.auth.jwtSecret`, `airflow.auth.fernetKey`, `airflow.admin.password` and `gitSync.auth.token` were removed, `airflow.auth.jwtExpirationDelta` and `airflow.auth.jwtRefreshThreshold` were removed because Airflow 3.x ignores them, and the public web UI became closed by default. An install that still sets any removed key fails at render. If you are running 1.4.x or earlier, read [Upgrading From Earlier Versions](#upgrading-from-earlier-versions) first — the Fernet key change is a data migration, not an upgrade.
+</Warning>
 
 ### What Gets Created
 
-- **GVC** — A dedicated GVC across the specified locations.
-- **Airflow Webserver** — The Airflow web UI for managing DAGs, monitoring task execution, and viewing logs.
-- **Celery Workers** — Distributed task execution workers that process DAG tasks.
-- **Redis** — A Redis broker for the Celery task queue, with persistent storage.
-- **PostgreSQL** — A PostgreSQL database for Airflow metadata storage.
-- **Volume Sets** — Persistent storage for Airflow DAG data, PostgreSQL, and Redis.
-- **KEDA ScaledObject** (optional) — Automatically scales Celery workers up or down based on Redis queue length.
-- **Secret** — A dictionary secret containing the PostgreSQL credentials, JWT signing key, Fernet encryption key, and admin password, shared across all Airflow workloads.
-- **Identity & Policy** — An identity bound to the workloads with `reveal` access to the Airflow configuration secret.
+- **GVC** — This template **creates its own GVC**, named by `gvc.name`, because KEDA is a GVC-level setting.
+- **Airflow Webserver** — (`RELEASE_NAME-airflow-webserver`): a stateful, single-replica workload running the API server, scheduler, dag-processor and triggerer in one container, serving the UI and REST API on port `8080`.
+- **Celery Workers** — (`RELEASE_NAME-airflow-celery-worker`): a stateful workload executing DAG tasks, scaled by KEDA on the Redis queue length.
+- **Redis** — (`RELEASE_NAME-airflow-redis`): the Celery broker, on its own persistent volume set.
+- **PostgreSQL** — (`RELEASE_NAME-airflow-postgres`): the Airflow metadata database, on its own persistent volume set.
+- **Airflow Volume Set** — (`RELEASE_NAME-airflow-vs`): a shared-filesystem volume mounted as the Airflow home by the webserver and every worker, so they all see the same DAGs and logs.
+- **Config Secret** — (`RELEASE_NAME-airflow-config`): a dictionary secret holding the metadata database username and password. It carries no key material.
+- **Identity & Policy** — An identity bound to the workloads and a policy granting it `reveal` on exactly the secrets they mount: the database config secret, your auth secret, and your git token secret when git-sync uses one.
+- **git-sync Sidecar** *(optional)* — Polls a Git repository and syncs DAGs onto the shared volume.
 
-## Pre-Deployment Checklist
+<Warning>
+**This template creates a GVC, so point `gvc.name` at a new name.** Helm adopts a GVC that already exists, and `helm uninstall` then deletes it along with every unrelated workload in it. Never point it at a GVC that already holds other workloads.
+</Warning>
 
-Before deploying, generate and set the following required values in `values.yaml`:
+## Upgrading From Earlier Versions
 
-| Value | How to generate |
-|-------|----------------|
-| `airflow.auth.jwtSecret` | `openssl rand -base64 48` |
-| `airflow.auth.fernetKey` | `python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'` |
-| `airflow.admin.password` | Choose a strong password |
-| `postgres.config.password` | Choose a strong password |
+Template version 1.4.x and earlier carried the JWT signing secret, the Fernet key, the admin password and the git token as plain Helm values, and shipped a working `CHANGE_ME` default for the first three. All four were removed with no compatibility fallback; a values file that still sets one fails at render with a message naming its replacement.
+
+| 1.4.x and earlier | 1.5.0 |
+|---|---|
+| `airflow.auth.jwtSecret` | `jwtSecret` key in the prerequisite auth secret |
+| `airflow.auth.fernetKey` | `fernetKey` key in the same secret |
+| `airflow.admin.password` | `adminPassword` key in the same secret |
+| `gitSync.auth.token` | `gitSync.auth.secretName` — an opaque secret you create |
+| `airflow.auth.jwtExpirationDelta` | `airflow.auth.jwtExpirationTime` (seconds) |
+| `airflow.auth.jwtRefreshThreshold` | removed — Airflow 3.x has no equivalent |
+| `firewallConfig.inboundAllowCIDR` defaulting to `0.0.0.0/0` | `firewallConfig.inboundAllowCIDR: []`, closed |
+
+<Warning>
+**The Fernet key cannot be rotated, so this is a migration rather than an upgrade.** That key encrypts every Airflow Connection and Variable in the metadata database — the database passwords, cloud keys and API tokens your DAGs use. Changing it does not re-encrypt anything: it makes all of them permanently unreadable.
+
+If your 1.4.x install ran on the shipped `CHANGE_ME` default, every one of those credentials is encrypted under a value published in a public repository. There is no in-place fix. Export what you need, install 1.5.0 with a freshly generated key, re-enter the Connections and Variables by hand, and **rotate every credential they held at its source** — treat them as compromised.
+</Warning>
+
+- **The metadata database password cannot be changed in place either.** `POSTGRES_PASSWORD` is read only when the data directory is initialized, so pointing `postgres.config.password` at a new value on an existing volume leaves the database on the old one and Airflow can no longer connect. Set it at first install.
+- **The web UI now ships closed.** If you were relying on the old `0.0.0.0/0` default, put your own CIDRs in `firewallConfig.inboundAllowCIDR`.
+- **Two JWT knobs were removed because they did nothing.** `jwtExpirationDelta` and `jwtRefreshThreshold` rendered `AIRFLOW__API_AUTH__JWT_EXPIRATION_DELTA` and `AIRFLOW__API_AUTH__JWT_REFRESH_THRESHOLD`, neither of which is an option in Airflow 3.x — tokens were issued with Airflow's own 86400-second lifetime regardless of what those values said. The live knob is `airflow.auth.jwtExpirationTime`; there is no refresh-threshold equivalent.
+
+## Prerequisites
+
+**One secret must exist before you install.** Its values never pass through Helm, so they never land in the release. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the auth secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly three keys — `jwtSecret`, `fernetKey` and `adminPassword`:
+
+    ```bash
+    cpln secret create-dictionary --name my-airflow-auth \
+      --entry jwtSecret="$(openssl rand -base64 48)" \
+      --entry fernetKey="$(openssl rand -base64 32 | tr '+/' '-_')" \
+      --entry adminPassword="$(openssl rand -base64 18)"
+    ```
+
+    Set `airflow.auth.secretName` to the name you used.
+
+    | Key | What it is |
+    |---|---|
+    | `jwtSecret` | Signs Airflow API access tokens — anyone holding it can mint one. |
+    | `fernetKey` | Encrypts the Connections and Variables your DAGs use: database passwords, cloud keys, API tokens. Must be 32 random bytes in URL-safe base64, which is what the command above produces. **It cannot be rotated** — see the warning below. |
+    | `adminPassword` | The web UI and API password for the `airflow.admin.username` login. Record it; it is not displayed anywhere. |
+  </Step>
+  <Step title="Read the secret back later">
+    The `-o yaml` is required — plain `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-airflow-auth -o yaml
+    ```
+  </Step>
+  <Step title="Optional: create a git token secret for a private DAG repository">
+    Only needed when `gitSync.enabled` is `true` and the repository is private. Create an [opaque secret](/guides/create-secret/opaque) with encoding `plain` whose payload is a personal access token, and set `gitSync.auth.secretName` to its name — the sidecar receives the payload as its Git password.
+
+    ```bash
+    printf '%s' "MY_GIT_TOKEN" | cpln secret create-opaque --name my-airflow-git-token --encoding plain -f -
+    ```
+
+    Leave `gitSync.auth.secretName` empty for a public repository or when git-sync is off. Empty turns the credential off entirely, including its policy grant, and setting it while git-sync is disabled is rejected at render.
+  </Step>
+</Steps>
+
+<Warning>
+**Generate the Fernet key once and keep it for the life of the install.** It encrypts every Connection and Variable Airflow stores. A different key does not fail loudly — it simply makes all of them unreadable, and there is no way back short of re-entering each one by hand.
+</Warning>
+
+<Warning>
+**Create the auth secret before installing.** A name pointing at a secret that does not exist installs "successfully" and then wedges: every resource reports created, the workload never becomes ready, and **`cpln logs` returns zero lines** because no container ever starts. The only diagnostic is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-airflow-webserver --gvc GVC_NAME -o yaml
+```
+
+It names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` The command is `get-deployments` — plain `cpln workload get` has no `versions` key at all. Creating the secret recovers the workload on its own, but slowly: **poll for 5.5 to 10.5 minutes rather than time-boxing it** (10 minutes 17 seconds measured here). `cpln workload force-redeployment RELEASE_NAME-airflow-webserver --gvc GVC_NAME` cuts that to roughly 90 seconds.
+</Warning>
 
 ## Installation
 
-This template has no external prerequisites. To install, follow the instructions for your preferred method:
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -62,13 +140,18 @@ This template has no external prerequisites. To install, follow the instructions
 The default `values.yaml` for this template:
 
 ```yaml
-# Global Virtual Cloud (GVC) settings
+# ─── Global Virtual Cloud (GVC) ───────────────────────────────────────────────
+# This template CREATES its GVC (KEDA is a GVC-level setting). Point it at a NEW
+# name — never at a GVC that already holds other workloads, because uninstalling
+# the release deletes the GVC it adopted along with everything in it.
 gvc:
   name: airflow
   locations:
     - name: aws-eu-central-1
 
-# Postgres database configuration
+# ─── Postgres (Airflow metadata database) ─────────────────────────────────────
+# Bundled plumbing: it serves Airflow only, is unreachable from outside the GVC,
+# and nobody ever types this password into a client — so it stays a value.
 postgres:
   image: postgres:18
   resources:
@@ -78,12 +161,12 @@ postgres:
     maxMemory: 1024Mi
   config:
     username: username
-    password: password
+    password: change-me-airflow-db # set at FIRST install; see Upgrading in the README
     database: airflow
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 
-# Redis cache configuration
+# ─── Redis (Celery broker) ────────────────────────────────────────────────────
 redis:
   image: redis:7.4
   resources:
@@ -92,7 +175,7 @@ redis:
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 
-# Apache Airflow configuration
+# ─── Apache Airflow ───────────────────────────────────────────────────────────
 airflow:
   webserver:
     image: apache/airflow:3.0.3
@@ -104,202 +187,222 @@ airflow:
     resources:
       cpu: 256m
       memory: 512Mi
-  webPort: 8080 # Port for accessing the Airflow web interface
+  webPort: 8080 # port serving the Airflow UI and REST API
 
   auth:
-    jwtSecret: CHANGE_ME # REQUIRED: generate with "openssl rand -base64 48"
-    jwtExpirationDelta: 3600 # JWT token expiration time in seconds
-    jwtRefreshThreshold: 300 # Threshold before token expires to allow refresh (seconds)
-    fernetKey: CHANGE_ME # REQUIRED: generate with "python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'"
+    # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. If it does not
+    # exist at install time the deployment WEDGES silently and `cpln logs` returns
+    # nothing at all. A `dictionary` secret holding exactly three keys:
+    #   jwtSecret     — signs API access tokens
+    #   fernetKey     — encrypts the Connections and Variables your DAGs use
+    #                   (database passwords, cloud keys, API tokens). It CANNOT be
+    #                   rotated without making every stored one unreadable.
+    #   adminPassword — the Airflow UI login for `admin.username` below
+    # See Prerequisites in the README for the exact command.
+    secretName: my-airflow-auth
+    jwtExpirationTime: 86400 # API token lifetime in seconds (Airflow's own default)
 
   admin:
-    username: admin
-    password: CHANGE_ME # REQUIRED: change before deploying to production
+    username: admin # its password is `adminPassword` in the secret above
 
   scheduler:
-    dagDirListInterval: 10 # How often to check DAG folder (seconds)
-    minFileProcessInterval: 10 # Minimum interval to process DAG files (seconds)
+    dagDirListInterval: 10 # how often to rescan the DAG folder (seconds)
+    minFileProcessInterval: 10 # minimum interval between processing a DAG file (seconds)
 
   celery:
-    workerConcurrency: 1 # Number of tasks each worker can run concurrently
+    workerConcurrency: 1 # tasks each worker runs concurrently, when KEDA is enabled
 
 volumeset:
   airflow:
-    capacity: 10 # initial capacity in GiB (minimum is 10)
+    capacity: 10 # shared Airflow home (DAGs + logs), GiB (minimum is 10)
 
-# Firewall configuration
+# ─── Access ───────────────────────────────────────────────────────────────────
+# The Airflow UI can trigger arbitrary code and decrypt every stored Connection,
+# so it ships CLOSED to the internet. Reach it with `cpln port-forward`, or add
+# your own CIDRs here (e.g. - 203.0.113.0/24) to expose it. A firewall change
+# takes up to a couple of minutes to propagate.
 firewallConfig:
-  inboundAllowCIDR:
-    - 0.0.0.0/0 # Restrict to specific IPs in production (e.g. - 203.0.113.0/24)
+  inboundAllowCIDR: []
 
-# Git-sync configuration for DAG delivery
+# ─── DAG delivery (git-sync) ──────────────────────────────────────────────────
 gitSync:
   enabled: false
-  repo: "" # Git repository URL (e.g. https://github.com/org/dags)
-  branch: main # Branch to sync
-  period: 60s # How often to sync
-  subPath: "" # Optional subfolder within the repo containing DAGs
+  repo: "" # git repository URL (e.g. https://github.com/YOUR_ORG/dags)
+  branch: main
+  period: 60s # how often to sync
+  subPath: "" # optional subfolder within the repo containing DAGs
   auth:
-    token: "" # Personal access token for private repos (leave empty for public repos)
+    # OPTIONAL PREREQUISITE SECRET, private repos only. An `opaque` secret
+    # (encoding `plain`) whose payload is a personal access token, e.g.
+    # `my-airflow-git-token`. Empty = public repo, no credentials sent.
+    secretName: ""
 
-# KEDA (Kubernetes Event-driven Autoscaling) configuration
-# NOT SUPPORTED in gcp/us-central1
+# ─── KEDA autoscaling (Celery workers) ────────────────────────────────────────
 keda:
-  enabled: true # Enable or disable KEDA autoscaling
-  minScale: 1 # Minimum number of Celery workers
-  maxScale: 3 # Maximum number of Celery workers
-  scaleToZeroDelay: 300 # Time before scaling to zero (seconds)
-  listLength: 3 # Queue length threshold to trigger scaling
-  cooldownPeriod: 1 # Cooldown between scaling events (seconds)
-  initialCooldownPeriod: 1 # Cooldown after startup before scaling (seconds)
-  pollingInterval: 4 # Interval at which KEDA queries metrics (seconds)
+  enabled: true
+  minScale: 1 # minimum number of Celery workers
+  maxScale: 3 # maximum number of Celery workers
+  scaleToZeroDelay: 300 # idle time before scaling to zero (seconds)
+  listLength: 3 # Redis queue length that triggers a scale-up
+  cooldownPeriod: 1 # cooldown between scaling events (seconds)
+  initialCooldownPeriod: 1 # cooldown after startup before scaling begins (seconds)
+  pollingInterval: 4 # how often KEDA queries Redis (seconds)
 ```
 
 ### GVC
 
-- `gvc.name` — The name of the GVC. Must be unique per deployment.
-- `gvc.locations` — List of cloud locations to deploy to (e.g., `aws-eu-central-1`).
+- `gvc.name` — The name of the GVC this template creates. It must not name an existing GVC.
+- `gvc.locations` — The locations the GVC spans.
 
-### PostgreSQL
+### PostgreSQL Metadata Database
 
-- `postgres.image` — PostgreSQL Docker image.
-- `postgres.resources` — CPU and memory bounds for the PostgreSQL workload (`minCpu`, `maxCpu`, `minMemory`, `maxMemory`).
-- `postgres.config.username` / `postgres.config.password` — Database credentials. **Change the default password before deploying to production.**
-- `postgres.config.database` — Name of the Airflow metadata database (default: `airflow`).
-- `postgres.volumeset.capacity` — Persistent storage for PostgreSQL data (GiB, minimum 10).
+- `postgres.image` — The PostgreSQL image.
+- `postgres.resources` — Reservation and limit for the database container (`minCpu` / `maxCpu` / `minMemory` / `maxMemory`).
+- `postgres.config.username` / `postgres.config.password` / `postgres.config.database` — The metadata database credentials. This is bundled plumbing: it serves Airflow only, is unreachable from outside the GVC, and no human ever types it, so it stays a value. **Set the password at first install** — the shipped `change-me-airflow-db` is a published placeholder, and PostgreSQL only reads it when the data directory is initialized.
+- `postgres.volumeset.capacity` — Database volume size in GiB (minimum 10).
 
-### Redis
+### Redis Broker
 
-- `redis.image` — Redis Docker image.
-- `redis.resources` — CPU and memory allocated to Redis.
-- `redis.volumeset.capacity` — Persistent storage for Redis data (GiB, minimum 10).
+- `redis.image` — The Redis image.
+- `redis.resources` — CPU and memory limit for the broker (this block exposes only a limit).
+- `redis.volumeset.capacity` — Broker volume size in GiB (minimum 10).
 
-### Airflow Webserver and Workers
+### Airflow
 
-- `airflow.webserver.image` / `airflow.celeryWorker.image` — Docker images for the webserver and Celery workers.
-- `airflow.webserver.resources` / `airflow.celeryWorker.resources` — CPU and memory per component.
-- `airflow.webPort` — Port the Airflow web UI listens on (default `8080`).
+- `airflow.webserver.image` / `airflow.celeryWorker.image` — Images for the webserver and the Celery workers.
+- `airflow.webserver.resources` / `airflow.celeryWorker.resources` — CPU and memory limits for each tier.
+- `airflow.webPort` — The port serving the UI and the REST API.
+- `airflow.auth.secretName` — Name of the prerequisite dictionary secret holding `jwtSecret`, `fernetKey` and `adminPassword`. It must exist before you install.
+- `airflow.auth.jwtExpirationTime` — API access-token lifetime in seconds, applied as `AIRFLOW__API_AUTH__JWT_EXPIRATION_TIME`. The shipped `86400` is Airflow's own default.
+- `airflow.admin.username` — The admin login paired with the `adminPassword` key of your auth secret.
+- `airflow.scheduler.dagDirListInterval` — How often the DAG folder is rescanned, in seconds.
+- `airflow.scheduler.minFileProcessInterval` — Minimum interval between processing the same DAG file, in seconds.
+- `airflow.celery.workerConcurrency` — Tasks each Celery worker runs concurrently.
 
-### Authentication
-
-Airflow 3.x requires three security credentials, all of which **must be changed before deploying to production**:
-
-- `airflow.auth.jwtSecret` — Secret key used to sign JWT tokens for API authentication. Generate a secure value with:
-  ```bash
-  openssl rand -base64 48
-  ```
-- `airflow.auth.fernetKey` — Key used to encrypt stored connections and variables. Generate with:
-  ```bash
-  python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
-  ```
-- `airflow.auth.jwtExpirationDelta` — Token lifetime in seconds (default `3600`).
-- `airflow.auth.jwtRefreshThreshold` — Seconds before expiry at which a token refresh is allowed (default `300`).
-
-### Admin Account
-
-- `airflow.admin.username` — Username for the initial Airflow admin account (default: `admin`).
-- `airflow.admin.password` — Password for the initial admin account. **Change before deploying to production.**
-
-The admin user is created on first startup using Airflow's `SimpleAuthManager`. Credentials are written to a password file on the shared volume and re-applied on every container restart, so the password always reflects the current value in `values.yaml`.
+The admin account is provisioned by Airflow's `SimpleAuthManager`: the container writes a password file from the secret on every start, so the login always matches the current secret contents.
 
 <Note>
-`SimpleAuthManager` is the default auth manager in Airflow 3.x and is suitable for development and internal deployments. For production deployments requiring SSO or LDAP, consider integrating an external auth provider via OAuth/OIDC.
+`SimpleAuthManager` is Airflow 3.x's default auth manager and has no SSO or LDAP support. Front the UI with an OAuth/OIDC auth manager if you need one.
 </Note>
-
-### Scheduler
-
-- `airflow.scheduler.dagDirListInterval` — How often the scheduler scans the DAG folder for new or modified files (seconds).
-- `airflow.scheduler.minFileProcessInterval` — Minimum interval between processing the same DAG file (seconds).
-
-### Celery
-
-- `airflow.celery.workerConcurrency` — Number of tasks a single Celery worker can execute concurrently.
 
 ### Storage
 
-- `volumeset.airflow.capacity` — Persistent storage for the Airflow home directory shared across workloads (GiB, minimum 10).
+- `volumeset.airflow.capacity` — Size in GiB of the shared Airflow home holding DAGs and logs (minimum 10).
 
-PostgreSQL and Redis storage are configured under their respective sections (`postgres.volumeset.capacity` and `redis.volumeset.capacity`).
+The database and broker volumes are configured separately under `postgres.volumeset.capacity` and `redis.volumeset.capacity`.
 
 <Note>
-The Airflow volume uses a shared (NFS-style) filesystem, allowing both the webserver and Celery workers to read DAGs and write logs to the same volume.
+The Airflow home uses a shared (NFS-style) filesystem so the webserver and every Celery worker read the same DAGs and write to the same log directory.
 </Note>
 
-### Firewall
+### Access
 
-- `firewallConfig.inboundAllowCIDR` — List of CIDR ranges allowed to reach the Airflow webserver. Defaults to `0.0.0.0/0` (public). **Restrict to specific IP ranges in production.**
+- `firewallConfig.inboundAllowCIDR` — CIDR ranges allowed to reach the webserver from the internet. The shipped `[]` means closed: the canonical endpoint returns `403` and the UI is reachable only over a port-forward. Add your own ranges (for example `203.0.113.0/24`) to expose it.
 
-### Git-Sync
+<Warning>
+**The Airflow UI is effectively remote code execution.** It triggers DAGs and can decrypt every stored Connection, and its only authentication is a single `SimpleAuthManager` password. That is why the closed default exists — prefer `cpln port-forward` over `0.0.0.0/0`.
+</Warning>
 
-Git-sync runs as a sidecar container on the webserver and Celery worker workloads, continuously pulling DAGs from a Git repository into the shared Airflow volume. This is the recommended approach for managing DAGs in production.
+<Note>
+A firewall change takes roughly **30 seconds to 5 minutes** to propagate (measured 20–85 seconds here). During the transition the endpoint can return `503` before it settles on `200` or `403`, so re-poll rather than trusting the first response.
+</Note>
+
+### DAG Delivery With git-sync
+
+git-sync runs as a sidecar on the webserver and worker workloads, pulling a Git repository onto the shared Airflow volume and pointing `AIRFLOW__CORE__DAGS_FOLDER` at the synced checkout on both tiers.
 
 | Property | Description |
-|----------|-------------|
-| `gitSync.enabled` | Enable or disable the git-sync sidecar |
-| `gitSync.repo` | Git repository URL (e.g. `https://github.com/org/dags`) |
-| `gitSync.branch` | Branch to sync (default: `main`) |
-| `gitSync.period` | Sync interval (default: `60s`) |
-| `gitSync.subPath` | Optional subfolder within the repo containing DAG files |
-| `gitSync.auth.token` | Personal access token for private repositories (leave empty for public repos) |
+|---|---|
+| `gitSync.enabled` | Enable the git-sync sidecar. Required together with `gitSync.repo` and `gitSync.branch`. |
+| `gitSync.repo` | Git repository URL. Required when git-sync is enabled. |
+| `gitSync.branch` | Branch to sync. Required when git-sync is enabled. |
+| `gitSync.period` | How often to sync. |
+| `gitSync.subPath` | Subfolder within the repository containing the DAGs. It is appended to the DAGs folder on both tiers. |
+| `gitSync.auth.secretName` | Opaque secret holding a personal access token, for a private repository. Empty means no credential is sent; setting it while git-sync is off is rejected at render. |
 
-When git-sync is disabled, DAGs can be placed manually in the `/opt/airflow/dags` directory on the Airflow volume.
+With git-sync off, put DAG files directly in `/opt/airflow/dags` on the shared volume — the dag-processor picks up a new file within seconds at the shipped `dagDirListInterval: 10`.
 
 ### KEDA Autoscaling
 
-KEDA scales Celery workers automatically based on the Redis queue length.
-
-<Note>
-KEDA is not supported in `gcp/us-central1`.
-</Note>
+KEDA scales the Celery workers on the Redis queue length. Scaling from one to three workers under a burst, and back down again, is proven on this template.
 
 | Property | Description |
-|----------|-------------|
-| `keda.enabled` | Enable or disable KEDA autoscaling |
-| `keda.minScale` | Minimum number of Celery workers |
-| `keda.maxScale` | Maximum number of Celery workers |
-| `keda.scaleToZeroDelay` | Seconds of inactivity before scaling to zero |
-| `keda.listLength` | Redis queue length that triggers a scale-up |
-| `keda.cooldownPeriod` | Seconds to wait between scaling events |
-| `keda.initialCooldownPeriod` | Seconds after startup before autoscaling activates |
-| `keda.pollingInterval` | Interval at which KEDA queries Redis for metrics (seconds) |
+|---|---|
+| `keda.enabled` | Enable KEDA autoscaling of the Celery workers. |
+| `keda.minScale` | Minimum number of workers. |
+| `keda.maxScale` | Maximum number of workers. |
+| `keda.scaleToZeroDelay` | Idle time in seconds before scaling to zero. |
+| `keda.listLength` | Redis queue length that triggers a scale-up. |
+| `keda.cooldownPeriod` | Seconds between scaling events. |
+| `keda.initialCooldownPeriod` | Seconds after startup before scaling begins. |
+| `keda.pollingInterval` | How often KEDA queries Redis, in seconds. |
 
-### Connecting to Airflow
+## Wide Fan Outs Can Silently Lose Tasks
 
-Once deployed, the Airflow web UI is available at the workload's canonical endpoint:
+A DAG that dispatches many tasks at the same instant loses roughly a third of them, and **nothing surfaces in the UI as an error** — the tasks are simply marked failed, with no hostname, no start time and an empty log. A measured 24-task burst finished 7 failed and 9 succeeded, with the failures never starting at all.
 
-```text
-https://<gvc-name>-airflow-webserver.<gvc-name>.cpln.app
-```
+The cause is upstream, not anything this template configures: the Celery executor's Redis transport is imported lazily and concurrently by several task-sending threads, and one of them observes a half-initialized module — `module 'redis' has no attribute 'client'` from `kombu/transport/redis.py`. The scheduler then marks those queued tasks failed.
 
-Log in with the `airflow.admin.username` and `airflow.admin.password` set in `values.yaml`.
+Until it is fixed upstream, **stagger task submission** rather than fanning out wide simultaneously, and count completed task instances rather than trusting the UI to flag a problem. A single task, and tasks arriving at a normal rate, are unaffected.
 
-<Note>
-This template creates a GVC with a default name defined in the values file. If you plan to deploy multiple instances, you **must assign a unique GVC name** for each deployment.
-</Note>
+## Connecting to Airflow
+
+| What | Where | Credentials |
+|---|---|---|
+| UI and REST API, no public access | `cpln port-forward RELEASE_NAME-airflow-webserver 8080:8080 --gvc GVC_NAME`, then `http://localhost:8080` | admin login |
+| UI and REST API, public | `status.canonicalEndpoint` of `RELEASE_NAME-airflow-webserver` — `cpln workload get RELEASE_NAME-airflow-webserver --gvc GVC_NAME -o yaml`. Returns `403` until you add a CIDR. | admin login |
+| Metadata database (in-GVC) | `RELEASE_NAME-airflow-postgres.GVC_NAME.cpln.local:5432` | `postgres.config.*` |
+| Redis broker (in-GVC) | `RELEASE_NAME-airflow-redis.GVC_NAME.cpln.local:6379` | none |
+| Admin login | `airflow.admin.username` plus the `adminPassword` key of your auth secret | — |
+
+The port-forward tunnel goes through Control Plane infrastructure and is independent of the firewall, so it works while the canonical endpoint is returning `403`.
+
+### First Run Sequence
+
+<Steps>
+  <Step title="Install with the UI closed">
+    Keep the shipped `firewallConfig.inboundAllowCIDR: []`.
+  </Step>
+  <Step title="Tunnel to the UI and sign in">
+    ```bash
+    cpln port-forward RELEASE_NAME-airflow-webserver 8080:8080 --gvc GVC_NAME
+    ```
+
+    Open `http://localhost:8080` and log in with `airflow.admin.username` and the `adminPassword` from your auth secret.
+  </Step>
+  <Step title="Expose it only if you need to">
+    Run a Helm upgrade with your own CIDR ranges in `firewallConfig.inboundAllowCIDR`, then allow up to a few minutes for the firewall to propagate before testing.
+  </Step>
+</Steps>
 
 ### API Access
 
-Airflow 3.x uses JWT-based authentication for API access. To obtain a token:
+Airflow 3.x issues JWT access tokens signed with your `jwtSecret`. Request one with the same admin credentials:
 
 ```bash
-curl -X POST https://<your-airflow-url>/auth/token \
+curl -X POST http://localhost:8080/auth/token \
   -H "Content-Type: application/json" \
-  -d '{"username": "admin", "password": "your-password"}'
+  -d '{"username": "admin", "password": "ADMIN_PASSWORD"}'
 ```
 
-Use the returned token for subsequent API requests:
+Then pass it on the v2 API:
 
 ```bash
-curl https://<your-airflow-url>/api/v2/dags \
-  -H "Authorization: Bearer <token>"
+curl http://localhost:8080/api/v2/dags \
+  -H "Authorization: Bearer ACCESS_TOKEN"
 ```
 
-## Production Considerations
+## Important Notes
 
-- **Change all `CHANGE_ME` values** before deploying — `jwtSecret`, `fernetKey`, `admin.password`, and `postgres.config.password` are all required.
-- **Restrict `firewallConfig.inboundAllowCIDR`** to trusted IP ranges to limit access to the Airflow UI.
-- **Enable git-sync** for reliable, version-controlled DAG delivery.
-- **Auth**: `SimpleAuthManager` is not recommended for deployments requiring enterprise SSO. Evaluate an OAuth/OIDC integration for those use cases.
+- The auth secret must exist **before** you install. Without it the deployment wedges with no log output at all; see [Prerequisites](#prerequisites) for the one diagnostic that names it, and expect recovery to take up to about ten and a half minutes after you create it.
+- **The Fernet key can never be rotated** — every stored Connection and Variable is encrypted under it. Generate it once, keep it, and back it up somewhere you will still have it later.
+- **A wide simultaneous fan-out silently loses roughly a third of its tasks** — see [Wide Fan Outs Can Silently Lose Tasks](#wide-fan-outs-can-silently-lose-tasks).
+- **This template creates its GVC**, so `gvc.name` must be a new name — uninstalling deletes the GVC it adopted along with everything in it.
+- Set `postgres.config.password` at first install. It is bundled plumbing, but the shipped placeholder is published and the value cannot be changed once the data directory exists.
+- The UI is closed by default and a firewall change takes up to a few minutes to apply, so an endpoint still returning `403` right after an upgrade is not necessarily broken.
+- The first Helm upgrade after an install re-applies resources even with identical values, restarting the webserver and the database — the UI was unavailable for about three minutes in testing. Later upgrades are clean.
+- Changing the admin password means editing the auth secret and restarting the webserver; the password file is rewritten from the secret on every container start.
+- **Uninstalling deletes all three volume sets**, including the DAGs and logs on the shared Airflow home. Export anything you need first.
 
 ## External References
 
@@ -307,17 +410,20 @@ curl https://<your-airflow-url>/api/v2/dags \
     <Card title="Apache Airflow Documentation" icon="book" href="https://airflow.apache.org/docs/">
     Official Apache Airflow documentation
     </Card>
+    <Card title="Fernet Key and Encryption at Rest" icon="lock" href="https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/fernet.html">
+    How Airflow encrypts Connections and Variables
+    </Card>
+    <Card title="Airflow Security Model" icon="shield" href="https://airflow.apache.org/docs/apache-airflow/stable/security/index.html">
+    What the Airflow UI and API can do, and who should reach them
+    </Card>
     <Card title="CeleryExecutor" icon="layer-group" href="https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/celery_executor.html">
-    Learn about the CeleryExecutor and distributed task execution
+    The CeleryExecutor and distributed task execution
     </Card>
     <Card title="KEDA Documentation" icon="chart-line" href="https://keda.sh/docs/">
-    Kubernetes Event-driven Autoscaling documentation
-    </Card>
-    <Card title="Redis Documentation" icon="database" href="https://redis.io/docs/latest/">
-    Official Redis documentation
+    Event-driven autoscaling documentation
     </Card>
     <Card title="git-sync" icon="github" href="https://github.com/kubernetes/git-sync">
-    git-sync sidecar documentation
+    The git-sync sidecar
     </Card>
     <Card title="Airflow Template" icon="github" href="https://github.com/controlplane-com/templates/tree/main/airflow">
     View the source files, default values, and chart definition

--- a/template-catalog/templates/cpln-task-runner.mdx
+++ b/template-catalog/templates/cpln-task-runner.mdx
@@ -1,32 +1,95 @@
 ---
 title: CPLN Task Runner
-description: Deploy CPLN Task Runner on Control Plane using the Template Catalog. Covers configuration, scaling, and HTTP-based task queuing with retry, scheduling, and rate limiting.
-keywords: ['job runner', 'cloud tasks alternative', 'sidekiq alternative', 'celery alternative', 'background worker', 'delayed job', 'work queue', 'job processor', 'cron alternative', 'priority queue']
+description: Deploy CPLN Task Runner on Control Plane using the Template Catalog. HTTP-based task queuing with retry, scheduling, and per-client rate limiting. Covers the prerequisite admin API key secret and why public access is off by default.
+keywords: ['job runner', 'cloud tasks alternative', 'sidekiq alternative', 'celery alternative', 'background worker', 'delayed job', 'work queue', 'job processor', 'cron alternative', 'priority queue', 'prerequisite secret', 'admin api key', 'redis sentinel', 'ssrf']
 ---
 
 ## Overview
 
 Control Plane Task Runner is a self-hosted task queue and scheduler service similar to Google Cloud Tasks. It provides HTTP-based task enqueuing with automatic retry, delayed and scheduled execution, per-client rate limiting, and multi-queue support with priority levels.
 
+The admin API key comes from a secret you create **before** installing, and the API is **not** exposed to the internet by default.
+
+<Warning>
+**`/v1/enqueue` has no authentication of any kind, and this is the reason `api.public.enabled` defaults to `false`.** The endpoint does not merely accept registered clients: an **unknown `client_id` is accepted and auto-registered** rather than rejected — measured against the running image, where posting a never-seen ID returned `status: enqueued` and created that client. So a client ID is not a credential in any sense.
+
+With public access on, anyone who finds the endpoint can make a worker issue arbitrary outbound HTTP requests with a method, headers, and body of their choosing. **No setting closes this** — the application has no client authentication. If you need to accept task submissions from outside the GVC, front the API with an authenticating proxy of your own.
+</Warning>
+
+<Warning>
+**Upgrading an install created with `1.2.x` is a breaking change.** `api.env.adminApiKey` — which disabled admin authentication entirely when left at its shipped empty default — is replaced by `api.admin.apiKeySecretName`, a required prerequisite secret. `api.public.enabled` also flips from `true` to `false`. See [Upgrading From 1.2.x](#upgrading-from-1-2-x).
+</Warning>
+
 ### What Gets Created
 
-- **API Workload** — HTTP endpoint for enqueuing tasks, managing clients, and health checks. Scales between 1 and 3 replicas by default.
-- **Worker Workload** — Background processor that picks tasks off the queue and executes them. Scales between 1 and 5 replicas by default.
+- **API Workload** — HTTP endpoint for enqueuing tasks, managing clients, and health checks. Scales between 1 and 3 replicas by default. Internal-only unless you turn public access on.
+- **Worker Workload** — Background processor that picks tasks off the queue and executes them. Scales between 1 and 5 replicas by default. Always internal-only.
 - **Redis with Sentinel** — A Redis instance with Redis Sentinel for high-availability task persistence and coordination. Sentinel monitors the Redis primary and handles automatic failover.
-- **Secret** — An opaque secret containing Redis and Sentinel passwords and the admin API key (when `createSecret` is `true`).
-- **Identity & Policy** — An identity bound to the workloads with `reveal` access to the task runner secrets.
+- **Secret** *(optional, on by default)* — A dictionary secret holding the bundled Redis and Sentinel passwords. The admin API key is **not** created here — it lives in the secret you create.
+- **Identity & Policy** — An identity bound to the workloads with `reveal` on exactly the secrets they read: the Redis secret and your admin key secret.
 
 ### Architecture
 
-The API workload receives task submissions over HTTP and pushes them into Redis. The Worker workload polls Redis and executes tasks by making outbound HTTP requests to the configured target URLs. Both workloads connect to Redis via Sentinel for failover resilience.
+The API workload receives task submissions over HTTP and pushes them into Redis. The Worker workload polls Redis and executes tasks by making outbound HTTP requests to the configured target URLs. Both workloads connect to Redis via Sentinel for failover resilience. A fresh install reached all four workloads ready in about 58 seconds, and enqueue-to-delivery latency was under 5 seconds.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Prerequisites
+
+**The admin API key secret must exist before you install.** The `/admin/*` endpoints create, edit, and delete clients and rate-limit tiers, and they are guarded by the `X-Admin-Key` header. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the admin key secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain` whose payload *is* the key:
+
+    ```bash
+    printf '%s' "$(openssl rand -hex 32)" | \
+      cpln secret create-opaque --name my-cpln-task-runner-admin-key --encoding plain -f -
+    ```
+
+    Set `api.admin.apiKeySecretName` to the name you used. Use `printf`, not `echo` — `echo` appends a newline, which becomes part of the key and then has to be sent in every admin request.
+  </Step>
+  <Step title="Read it back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its payload:
+
+    ```bash
+    cpln secret reveal my-cpln-task-runner-admin-key -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Note>
+**Admin authentication is enforced, and it is enforced on the internal path too.** Verified on a live deployment: `/admin/clients` returned `401` with no header and `401` with a wrong key, and `200` with the correct one — both over the public endpoint and over in-GVC service DNS.
+</Note>
+
+<Warning>
+**Setting `api.admin.apiKeySecretName` to `""` disables admin authentication completely**, and the chart therefore **refuses to render** while `api.public.enabled` is `true`. An empty name is permitted only for an internal-only deployment, and it is a deliberate act: measured through a port-forward with the name empty, `/admin/clients` returned the full client list with no header at all, and again with a nonsense key.
+</Warning>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, the resources are created, and the API workload then never starts — while the other three come up normally. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-task-runner-api --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-cpln-task-runner-admin-key no longer exists. Workload updates are
+paused until the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery here was measured at **8 minutes 43 seconds**, inside the 5.5–10.5 minute range seen across the catalog, so poll rather than time-boxing it. A forced redeployment shortcuts it to roughly 90 seconds.
+</Warning>
+
+Nothing else is required. The bundled Redis and Sentinel passwords are ordinary values — they are internal plumbing between the workloads and their own datastore, and nobody types them — but they are used exactly as written, so change them from their `change-me-…` defaults before installing.
+
 ## Installation
 
-This template has no external prerequisites. To install, follow the instructions for your preferred method:
+Once the admin key secret exists, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -66,14 +129,18 @@ api:
     max: 3
   port: 8080
   public:
-    enabled: true
+    enabled: false # DEFAULTS TO FALSE — /v1/enqueue has no authentication at all
     pathPrefix: "" # Path prefix for public endpoint (empty for root)
+  admin:
+    # REQUIRED prerequisite secret — an `opaque` secret (encoding: plain) whose
+    # payload is the admin API key. "" disables admin auth and is rejected while
+    # public.enabled is true.
+    apiKeySecretName: my-cpln-task-runner-admin-key
   resources:
     cpu: 500m
     memory: 512Mi
   env:
     logLevel: info # debug, info, warn, error
-    adminApiKey: "" # Admin API key for protected endpoints (leave empty to disable)
     otelEndpoint: "" # OpenTelemetry endpoint (leave empty to disable tracing)
     connectRetries: 30
     retryIntervalSec: 2
@@ -100,18 +167,16 @@ worker:
     retryIntervalSec: 2
     otelEndpoint: ""
 
-# Creates a secret for Redis + Sentinel passwords and admin API key
+# Creates a secret holding the bundled Redis + Sentinel passwords.
+# Set to false to bring your own secret; see redis.*.auth.fromSecret below.
 createSecret: true
 secretName: task-runner-secrets # Must match names below if createSecret is true
 
 # Redis configuration
 redis:
-  redisPassword: mypassword # Change before deploying to production
-  sentinelPassword: mypassword # Change before deploying to production
-  admin:
-    fromSecret:
-      name: task-runner-secrets
-      apiKeyKey: admin-api-key
+  # Used as written when createSecret is true, so change them.
+  redisPassword: change-me-cpln-task-runner-redis
+  sentinelPassword: change-me-cpln-task-runner-sentinel
   redis:
     auth:
       fromSecret:
@@ -135,11 +200,11 @@ redis:
 - `api.enabled` — Enable or disable the API workload.
 - `api.replicas` — Min/max replica count for autoscaling (default: 1–3).
 - `api.port` — Container port (default `8080`).
-- `api.public.enabled` — Expose the API to the public internet.
+- `api.public.enabled` — Expose the API to the public internet. **Defaults to `false`**; read [Public Access and the Open Queue](#public-access-and-the-open-queue) before turning it on.
 - `api.public.pathPrefix` — Optional path prefix for the public endpoint. Leave empty to serve from the root.
+- `api.admin.apiKeySecretName` — Name of your pre-created opaque secret whose payload is the admin API key, sent as the `X-Admin-Key` header. Required; `""` disables admin authentication and is rejected while public access is on. See [Prerequisites](#prerequisites).
 - `api.resources` — CPU and memory allocated to each API replica.
 - `api.env.logLevel` — Log verbosity: `debug`, `info`, `warn`, or `error`.
-- `api.env.adminApiKey` — API key for admin-protected endpoints. Leave empty to disable admin authentication.
 - `api.env.connectRetries` / `api.env.retryIntervalSec` — Redis connection retry behavior on startup.
 
 ### Worker Workload
@@ -150,22 +215,26 @@ redis:
 - `worker.env.concurrency` — Number of tasks a single Worker replica can execute concurrently.
 - `worker.env.taskTimeoutSec` — Maximum duration in seconds before a task execution is considered failed (default `1800`).
 - `worker.env.maxRetry` — Maximum number of retry attempts for a failed task.
-- `worker.env.allowPrivateUrls` — When `true`, allows tasks to target internal/private URLs.
+- `worker.env.allowPrivateUrls` — When `true`, allows tasks to target internal/private URLs. Workers fetch whatever URL a task carries, so leaving this `false` is the only bound on where an enqueued task can reach.
 - `worker.env.cbFailureThreshold` / `worker.env.cbTimeoutSec` — Circuit breaker settings to stop hammering failing endpoints.
 
 ### Secrets and Redis
 
-When `createSecret` is `true`, the template automatically creates a secret named by `secretName` containing the Redis password, Sentinel password, and admin API key. The `redis.*.fromSecret` fields are pre-wired to reference this secret.
+When `createSecret` is `true`, the template creates a dictionary secret named by `secretName` holding the Redis and Sentinel passwords. The `redis.*.fromSecret` fields are pre-wired to reference it. The admin API key is **not** in this secret — it is always your own opaque secret, independent of `createSecret`.
 
-When using an existing secret (`createSecret: false`), update the `redis.*.fromSecret` fields to point to your secret name and the correct keys.
+When bringing your own secret (`createSecret: false`), create a dictionary secret holding the keys named by the `passwordKey` fields and point both `fromSecret.name` values at it. This path was verified end to end alongside the admin secret, including non-default key names.
 
 <Note>
-Change the default `redis.redisPassword` and `redis.sentinelPassword` values before deploying to production.
+**Change `redis.redisPassword` and `redis.sentinelPassword` before the first install** — they are used exactly as written. They stay ordinary values deliberately: they are internal plumbing for a datastore bundled with this one app, which nobody connects to by hand. Once the volumes are initialised, changing them requires uninstalling (which deletes the volume sets) and reinstalling.
 </Note>
 
 ### Enqueuing Tasks
 
-Once deployed, submit tasks to the API workload's public endpoint:
+Submit tasks to the API. With the default `api.public.enabled: false` the endpoint below is the in-GVC address `RELEASE_NAME-task-runner-api.GVC_NAME.cpln.local:8080`; it is a public `*.cpln.app` hostname only if you turned public access on.
+
+<Warning>
+This request carries no credential, and none exists — see [Public Access and the Open Queue](#public-access-and-the-open-queue).
+</Warning>
 
 ```bash
 curl -X POST https://your-api-endpoint/v1/enqueue \
@@ -184,7 +253,7 @@ curl -X POST https://your-api-endpoint/v1/enqueue \
 
 ### Admin Endpoints
 
-When `api.env.adminApiKey` is set, admin endpoints require the `X-Admin-Key` header:
+Every `/admin/*` request requires the `X-Admin-Key` header, whose value is the payload of your `api.admin.apiKeySecretName` secret:
 
 ```bash
 # List clients
@@ -220,6 +289,92 @@ To enable distributed tracing, set `otelEndpoint` in both `api.env` and `worker.
 ```text
 tracing.controlplane:4318
 ```
+
+## Connecting
+
+| What | Address | Credentials |
+|---|---|---|
+| API (internal, default) | `RELEASE_NAME-task-runner-api.GVC_NAME.cpln.local:8080` | none for `/v1/*`; `X-Admin-Key` for `/admin/*` |
+| API (public, opt-in) | the workload's `*.cpln.app` canonical endpoint | same |
+| Redis Sentinel | `RELEASE_NAME-sentinel.GVC_NAME.cpln.local:26379` | the Sentinel password |
+| Admin key | your opaque secret | `cpln secret reveal my-cpln-task-runner-admin-key -o yaml` |
+
+Find the public endpoint under `status.canonicalEndpoint` of `cpln workload get RELEASE_NAME-task-runner-api --gvc GVC_NAME -o yaml`.
+
+## Upgrading From 1.2.x
+
+Two behaviours change, and both will break an existing workflow if you relied on the old defaults.
+
+| | `1.2.x` | `1.3.0` |
+|---|---|---|
+| Admin API key | `api.env.adminApiKey` — a value, shipped empty, which **disabled admin authentication** | `api.admin.apiKeySecretName` — a required opaque secret you create |
+| Public access | `api.public.enabled: true` | `api.public.enabled: false` |
+| Bundled Redis passwords | A working published value | `change-me-…` placeholders |
+| `redis.admin.fromSecret` | Present | Removed — the admin key is its own secret regardless of `createSecret` |
+
+<Warning>
+**Admin authentication is now enforced.** `1.2.x` shipped `api.env.adminApiKey: ""`, which left `/admin/*` unauthenticated **on a public API** — anyone who found the endpoint could create clients and change rate-limit tiers. Create the secret with the *same* key you were using and your admin scripts keep working; create a new one and every caller must be updated.
+</Warning>
+
+<Warning>
+**A `helm upgrade` that still carries either removed key is rejected before anything is applied**, and so is an empty `apiKeySecretName` while public access is on. A real `cpln helm upgrade` carrying the old keys failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+api.admin.apiKeySecretName is empty while api.public.enabled is true. An empty key disables admin
+authentication entirely, which would publish /admin/* — create, edit and delete clients and
+rate-limit tiers — to the internet.
+```
+
+```text
+api.env.adminApiKey was REMOVED in cpln-task-runner 1.3.0. ... set api.admin.apiKeySecretName to
+its name.
+```
+</Warning>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the admin key secret">
+    Follow [Prerequisites](#prerequisites), putting the key you use today into it so existing admin callers keep working.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `api.env.adminApiKey` and `redis.admin.fromSecret`, and set `api.admin.apiKeySecretName` instead.
+  </Step>
+  <Step title="Decide about public access">
+    `api.public.enabled` now defaults to `false`. Leaving it at the new default closes the unauthenticated `/v1/enqueue` endpoint to the internet — read [Public Access and the Open Queue](#public-access-and-the-open-queue) before setting it back to `true`.
+  </Step>
+  <Step title="Upgrade">
+    The first upgrade after an install also re-applies the bundled Redis even with identical values, restarting it; the API returns errors for a minute or two while Redis comes back. Later upgrades are clean.
+  </Step>
+</Steps>
+
+<Note>
+The bundled Redis and Sentinel passwords keep whatever you already set. Only their *defaults* changed, which affects fresh installs.
+</Note>
+
+## Public Access and the Open Queue
+
+`api.public.enabled` is `false` by default. Understand exactly what turning it on exposes:
+
+- **`/v1/enqueue` requires no credential whatsoever.** There is no header, token, or signature to supply.
+- **An unknown `client_id` is auto-registered, not rejected.** Posting a never-before-seen ID returns `status: enqueued` and creates the client with the default tier. A client ID is therefore not a secret and not a control.
+- **The consequence is a request relay.** Anyone reaching the endpoint can make a worker issue outbound HTTP with the method, headers, and body they choose. `worker.env.allowPrivateUrls: false` keeps those requests off internal addresses, which is the only bound.
+- **`/metrics` is served on the same port, unauthenticated, and its labels enumerate every `client_id`.**
+
+No setting fixes this; the application has no client authentication. If you need submissions from outside the GVC, put an authenticating proxy in front of the API and leave `api.public.enabled` at `false`.
+
+<Note>
+**Disabling public access surfaces as `421 Misdirected Request`, not `403`.** After the change the public hostname stops routing entirely — a `421` here means the knob worked, not that something is broken. Access changes take roughly 30 seconds to a few minutes to propagate, so re-test over that window before concluding otherwise.
+</Note>
+
+## Important Notes
+
+- **Create the admin key secret before installing.** A missing prerequisite secret wedges the deployment with no log output at all; [Prerequisites](#prerequisites) gives the one command that diagnoses it.
+- **`/v1/enqueue` is unauthenticated and auto-registers unknown client IDs** — this is why public access is off by default. See [Public Access and the Open Queue](#public-access-and-the-open-queue).
+- **`/metrics` is unauthenticated** and its labels enumerate every `client_id`.
+- **Change the `change-me-…` Redis and Sentinel passwords before the first install.** Changing them later requires uninstalling and reinstalling.
+- **The first Helm upgrade after an install re-applies the bundled Redis** even with identical values, which restarts it; the API returns errors for a minute or two while Redis comes back. Later upgrades are clean.
+- **Access changes take roughly 30 seconds to a few minutes to propagate**, so a freshly toggled `api.public.enabled` looks unchanged at first — and once disabled, the public hostname returns `421`, not `403`.
 
 ## External References
 

--- a/template-catalog/templates/cpln-trivy.mdx
+++ b/template-catalog/templates/cpln-trivy.mdx
@@ -1,12 +1,20 @@
 ---
 title: CPLN Trivy
-description: Automated vulnerability scanning for images stored in a Control Plane image registry. Scans each image using Trivy, stores HTML reports in S3 or Azure File Share, and tags images with a direct link to their report.
-keywords: ['trivy', 'vulnerability scanning', 'container security', 'image scanning', 'cve', 'security', 'devsecops', 'cpln-trivy', 'control plane security']
+description: Automated vulnerability scanning for images stored in a Control Plane image registry. Scans each image using Trivy, stores HTML reports in S3 or Azure File Share, and tags images with a direct link to their report. Covers the two prerequisite secrets, including the bearer token guarding the public report upload endpoint.
+keywords: ['trivy', 'vulnerability scanning', 'container security', 'image scanning', 'cve', 'security', 'devsecops', 'cpln-trivy', 'control plane security', 'prerequisite secret', 'bearer token', 'sbom', 'image tags']
 ---
 
 ## Overview
 
 CPLN Trivy automates vulnerability scanning for every image in your Control Plane image registry. A scheduled daemon queries the registry for unscanned images, runs Trivy against each one, and stores an HTML report in S3 or an Azure File Share. After each scan, the image is tagged with a direct link to its report — visible in the Control Plane console.
+
+<Warning>
+**Upgrading an install created with `1.1.0` or earlier is a breaking change.** `postToken` is no longer a plain value; the bearer token now lives in an opaque secret you create, named by `postToken.secretName`. Put **the same token your install already uses** into that secret — a different one makes report uploads start failing with `401` while every status surface still reads healthy. See [Upgrading From 1.1.0](#upgrading-from-1-1-0).
+</Warning>
+
+<Warning>
+**Running a scan tags and reports on every image in the organization, not only images this install created.** The daemon enumerates the whole registry, writes two tags to each image it scans, and uploads a report per image to your bucket. Before pointing this at a production organization, understand that it mutates images it did not create. Narrow the blast radius by setting `schedule` to a time you choose and `rescanAfter` to `""` for a first run.
+</Warning>
 
 ### Architecture
 
@@ -22,12 +30,18 @@ After each scan, the daemon writes two tags to the image:
 
 Each run scans images that do not yet have a `cpln/trivy-scan` tag. When `rescanAfter` is set (default `7d`), images whose last scan is older than that window are scanned again and their report is refreshed in place at the same URL. Setting `rescanAfter` to `""` disables rescanning — then re-scanning an image requires removing its `cpln/trivy-scan` tag first.
 
+### How the Two Workloads Talk
+
+**The daemon reaches the web-server over the public internet, not over the GVC network.** The two workloads have no in-GVC path to each other, so the daemon posts each report to the web-server's public endpoint — and that endpoint gates writes on the bearer token alone.
+
+That is why the token is a prerequisite secret rather than internal plumbing. Through `1.1.0` it shipped as the value `postToken: changeme`, which meant an internet-facing write endpoint guarded by a string published in a public repository: anyone could upload content into the user's own bucket and have it served back as HTML from their report URLs. Nothing about that credential is unreachable from outside the GVC, which is exactly the condition the bundled-credential exception depends on.
+
 ### What Gets Created
 
 - **Cron Daemon Workload** — Trivy daemon with trivy-api sidecar, runs on a cron schedule.
 - **Serverless Web-Server Workload** — Report storage and serving, autoscales from 1–3 replicas.
-- **Identity & Policy** — Identity bound to each workload with access to the configured storage cloud account, plus `reveal` access to the referenced credentials secret.
-- **Secret** — CPLN secret storing the shared bearer token between the daemon and web-server. The service account key itself lives in an opaque secret you create beforehand (see Prerequisites).
+- **Identity & Policies** — An identity carrying the AWS or Azure cloud-account binding for report storage, plus least-privilege policies: `reveal` on exactly the two prerequisite secrets, `manage` on images so scan tags can be written, and `pull`/`view` for the scanning service account.
+- **No credential secrets** — The template creates no secrets of its own. Both the post token and the registry service account key live in secrets you create.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
@@ -35,7 +49,37 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-### Service Account
+**Two secrets must exist before you install.** Secrets are org-level, so no GVC flag is involved.
+
+### Report Post Token
+
+The bearer token the daemon presents when uploading a report. It guards a publicly reachable write endpoint, so treat it like any other internet-facing credential.
+
+<Steps>
+  <Step title="Create the post token secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain` whose payload is the token:
+
+    ```bash
+    printf '%s' "$(openssl rand -hex 32)" | \
+      cpln secret create-opaque --name my-cpln-trivy-post-token --encoding plain -f -
+    ```
+
+    Set `postToken.secretName` to the name you used. Use `printf`, not `echo` — `echo` appends a newline that becomes part of the token.
+  </Step>
+  <Step title="Read it back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its payload:
+
+    ```bash
+    cpln secret reveal my-cpln-trivy-post-token -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Note>
+**The token is enforced, and only in the `Bearer` form.** Verified against the live public endpoint: a POST with no `Authorization` header, one with a wrong token, and one carrying the correct token *without* the `Bearer ` prefix were all refused with `401`; only `Authorization: Bearer <token>` was accepted. Report **reads** remain deliberately unauthenticated — the URL's SHA-256 hash is the only thing protecting a report.
+</Note>
+
+### Registry Service Account
 
 Trivy authenticates against the Control Plane image registry using a service account key stored in an **opaque** secret.
 
@@ -48,7 +92,8 @@ Trivy authenticates against the Control Plane image registry using a service acc
   </Step>
   <Step title="Store the key in an opaque secret">
     ```bash
-    echo -n "your-service-account-key" | cpln secret create-opaque --name trivy-credentials --encoding plain -f -
+    printf '%s' 'your-service-account-key' | \
+      cpln secret create-opaque --name trivy-credentials --encoding plain -f -
     ```
   </Step>
   <Step title="Reference the secret in values.yaml">
@@ -59,6 +104,23 @@ Trivy authenticates against the Control Plane image registry using a service acc
     ```
   </Step>
 </Steps>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, the resources are created, and the workload then never starts. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments web-server --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-cpln-trivy-post-token no longer exists. Workload updates are
+paused until the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery here was measured at **9 minutes 15 seconds**, inside the 5.5–10.5 minute range seen across the catalog, so poll rather than time-boxing it. A forced redeployment shortcuts it to roughly 90 seconds. The previously deployed revision keeps serving reports throughout.
+</Warning>
 
 ### Storage
 
@@ -115,7 +177,7 @@ Choose a storage backend — either AWS S3 or Azure File Share. Set `storage.typ
   </Tab>
 </Tabs>
 
-To install, follow the instructions for your preferred method:
+Once both secrets exist and your storage backend is ready, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -149,10 +211,10 @@ storage:
   type: s3
 
   s3:
-    cloudAccountName: my-aws-cloud-account
-    bucket: trivy-reports-bucket
-    region: us-east-1
-    policyName: my-trivy-s3-policy  # IAM policy scoped to the bucket (see Prerequisites)
+    cloudAccountName: my-aws-cloud-account # AWS cloud account name registered in Control Plane
+    bucket: trivy-reports-bucket           # S3 bucket name
+    region: us-east-1                      # AWS region
+    policyName: my-trivy-s3-policy         # IAM policy scoped to the bucket (see Prerequisites)
 
   azureFileshare:
     cloudAccountName: my-azure-cloud-account
@@ -160,15 +222,17 @@ storage:
     fileShare: trivy-reports
     scope: "" # /subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/<name>
 
-# Bearer token shared between the daemon and web-server. Change before deploying to production.
-postToken: changeme
+# Bearer token the daemon presents when posting reports to the web-server.
+# Name of a pre-existing CPLN opaque secret whose payload is the token (see Prerequisites).
+postToken:
+  secretName: my-cpln-trivy-post-token
 
 # Authentication for Trivy to pull images from the Control Plane image registry.
 # Name of a pre-existing CPLN opaque secret whose payload is the service account key (see Prerequisites).
 trivyAuth:
   secretName: trivy-credentials
 
-# Control Plane service account that Trivy uses to pull images
+# Control Plane service account that Trivy uses to pull images (see Prerequisites)
 serviceAccountName: trivy-service-account
 
 # Cron schedule for the scanning daemon
@@ -220,7 +284,7 @@ webServer:
 | `storage.azureFileshare.accountName` | — | Azure storage account name |
 | `storage.azureFileshare.fileShare` | — | Azure file share name |
 | `storage.azureFileshare.scope` | — | Full Azure resource scope for role assignment |
-| `postToken` | `changeme` | Shared bearer token between daemon and web-server |
+| `postToken.secretName` | `my-cpln-trivy-post-token` | Name of an existing opaque secret whose payload is the bearer token the daemon uploads with |
 | `trivyAuth.secretName` | `trivy-credentials` | Name of an existing opaque secret whose payload is the service account key |
 | `serviceAccountName` | `trivy-service-account` | Service account Trivy uses to pull images |
 | `schedule` | `*/59 * * * *` | Cron schedule for the scanning daemon |
@@ -232,13 +296,57 @@ webServer:
 | `webServer.autoscaling.minScale` | `1` | Minimum web-server replicas |
 | `webServer.autoscaling.maxScale` | `3` | Maximum web-server replicas |
 
-<Warning>
-Change `postToken` from its default `changeme` value before any production deployment. This token authenticates report submissions from the daemon to the web-server.
-</Warning>
+<Note>
+Report URLs are publicly accessible by default — they contain an unguessable SHA-256 hash, but no authentication on reads. Restrict `webServer.firewall.inboundAllowCIDR` if reports must stay private. Narrowing it also blocks the daemon, which reaches the web-server by that same public path, so add the daemon's egress range when you do.
+</Note>
 
 <Note>
-Report URLs are publicly accessible by default — they contain an unguessable SHA-256 hash, but no authentication. Restrict `webServer.firewall.inboundAllowCIDR` if reports must stay private.
+`webServer.firewall.inboundAllowCIDR` defaults to `0.0.0.0/0` by design — that is how the daemon delivers reports. The token is what keeps that endpoint from accepting anyone's uploads; see [How the Two Workloads Talk](#how-the-two-workloads-talk).
 </Note>
+
+## Upgrading From 1.1.0
+
+Version `1.2.0` moved the report post token out of Helm values. Through `1.1.0` it shipped as `postToken: changeme` — a working, publicly documented token guarding an internet-facing write endpoint.
+
+| | `1.1.0` and earlier | `1.2.0` |
+|---|---|---|
+| Post token | `postToken` — a plain string value | `postToken.secretName` — an opaque secret you create, whose payload is the token |
+| Registry service account key | `trivyAuth.secretName` prerequisite secret | Unchanged |
+| Chart-created secret | Held the post token | None |
+
+<Warning>
+**Reuse the token your install already has.** The daemon and the web-server compare the same string, so a rotation that reaches only one of them fails every upload with `401` while both workloads still report healthy. If you generate a fresh token during the upgrade, both workloads pick it up together on the same rollout — but any token you had recorded elsewhere is then dead.
+</Warning>
+
+<Warning>
+**A `helm upgrade` that still sets `postToken` as a string is rejected before anything is applied.** A real `cpln helm upgrade` carrying the old shape failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+cpln-trivy: postToken is no longer a plain value in 1.2.0. Put the token in an opaque secret
+(encoding: plain) and set postToken.secretName to its name. Reuse the SAME token your install
+already has, or the daemon's uploads start returning 401.
+```
+
+Leaving `postToken.secretName` empty is refused the same way.
+</Warning>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the post token secret">
+    Follow [Prerequisites](#prerequisites), putting your current token into it.
+  </Step>
+  <Step title="Drop the removed key from your values">
+    Remove the `postToken:` string and set `postToken.secretName` instead. Leave `trivyAuth.secretName` and `serviceAccountName` exactly as they are.
+  </Step>
+  <Step title="Upgrade">
+    Both workloads pick the token up on the rollout. Reports already stored keep their URLs.
+  </Step>
+</Steps>
+
+### Rotating the Token Later
+
+Edit the secret, then restart **both** workloads together. They must agree; a rotation reaching only one leaves uploads failing `401` with nothing else looking wrong.
 
 ## Viewing Reports
 
@@ -272,6 +380,17 @@ cpln image query --tag cpln/trivy-scan --max -1 -o json | jq -r '.items[].name' 
 ```
 
 The daemon will pick the images up on its next scheduled run.
+
+## Important Notes
+
+- **Create both prerequisite secrets before installing.** A missing one wedges the deployment with no log output at all; [Prerequisites](#prerequisites) gives the one command that diagnoses it.
+- **A scan touches every image in the organization**, not just images this install created — see the warning in [Overview](#overview).
+- **Rotating the post token requires restarting both workloads together** — see [Rotating the Token Later](#rotating-the-token-later).
+- **Report reads are unauthenticated.** Anyone with the URL can open a report.
+- **Scans take roughly 15–20 seconds per image** — about 30 minutes for 100 images on a first run. Overlapping runs are prevented, so a long run simply delays the next scheduled one.
+- **Rescans overwrite in place** — the report keeps its URL and `cpln/trivy-scan-time` is refreshed, so links saved from the console stay valid.
+- **Rotate the service account key** by adding a new key, updating the opaque secret's payload, then deleting the old key. No reinstall needed.
+- **The workloads are named `daemon` and `web-server` regardless of release name** — install this template only once per GVC.
 
 ## External References
 

--- a/template-catalog/templates/gitea.mdx
+++ b/template-catalog/templates/gitea.mdx
@@ -1,36 +1,114 @@
 ---
 title: Gitea
-description: Deploy Gitea, a lightweight self-hosted Git service, on Control Plane. Covers repositories, pull requests, issues, the package registry, PostgreSQL backing, public HTTPS access, and optional Git-over-SSH.
-keywords: ['gitea', 'self-hosted git', 'git server', 'github alternative', 'gitlab alternative', 'gitea alternative', 'source code management', 'pull requests', 'package registry', 'git over ssh', 'postgresql']
+description: Deploy Gitea, a lightweight self-hosted Git service, on Control Plane. Covers the prerequisite auth secret and its six keys, the signing keys that cannot be rotated, public Git-over-HTTPS, the package registry, PostgreSQL backing, optional Git-over-SSH, and upgrading from template version 1.0.0.
+keywords: ['gitea', 'self-hosted git', 'git server', 'github alternative', 'gitlab alternative', 'gitea alternative', 'source code management', 'pull requests', 'package registry', 'git over ssh', 'git clone', 'jwt secret', 'postgresql']
 ---
 
 ## Overview
 
-Gitea is a lightweight, self-hosted Git service — repositories, pull requests, issues, and a built-in package registry — backed by PostgreSQL. This template deploys a single Gitea server with persistent storage, an automatically wired PostgreSQL database, a public HTTPS web UI with Git-over-HTTPS, and an optional Git-over-SSH endpoint.
+Gitea is a lightweight, self-hosted Git service — repositories, pull requests, issues, and a built-in package registry — backed by PostgreSQL. This template deploys a single Gitea server with persistent storage, an automatically wired PostgreSQL database, a public HTTPS web UI with Git-over-HTTPS, and optional Git-over-SSH.
+
+The site administrator's login and the three long-lived signing keys are not template values. They come from one dictionary secret you create before installing, so they never pass through Helm and never land in the release.
+
+<Warning>
+**Template version 1.1.0 is a breaking change.** `gitea.admin.username`, `gitea.admin.password`, `gitea.admin.email`, `gitea.security.secretKey`, `gitea.security.internalToken` and `gitea.security.jwtSecret` were all removed, and an install or upgrade that still sets any of them now fails at render. If you are running 1.0.0, read [Upgrading From Earlier Versions](#upgrading-from-earlier-versions) before you touch the release — two of those keys cannot be rotated safely.
+</Warning>
 
 ### Architecture
 
 - **Gitea** — Stateful, single-replica workload running the rootless image. Serves the web UI, Git-over-HTTPS, and the package registry on port 3000, plus the built-in SSH server on 2222.
-- **PostgreSQL** — Backing database provisioned from the `postgres` template as a subchart and connected to Gitea on startup.
+- **PostgreSQL** — Backing database provisioned from the [postgres](/template-catalog/templates/postgres) template as a subchart and connected to Gitea on startup.
 
 ### What Gets Created
 
-- **Stateful Gitea Workload** — The Gitea server with configurable CPU and memory, bootstrapped with an admin account on first boot.
+- **Stateful Gitea Workload** — (`RELEASE_NAME-gitea`): the Gitea server, bootstrapped with the site-admin account from your auth secret on first boot.
 - **Stateful PostgreSQL Workload** — Single-replica Postgres, automatically connected to Gitea.
 - **Volume Sets** — A persistent volume set for Gitea (`/var/lib/gitea`: repositories, LFS objects, attachments, and SSH host keys) and one for PostgreSQL data, both with optional autoscaling.
-- **Secrets** — A dictionary secret holding the stable app secrets and admin credentials, an opaque secret holding the admin-bootstrap script, and the PostgreSQL credentials secret.
-- **Identity & Policy** — An identity bound to the Gitea workload with `reveal` access scoped to exactly its two secrets plus the PostgreSQL config secret.
+- **Bootstrap Secret** — (`RELEASE_NAME-gitea-bootstrap`): an opaque secret holding the admin-bootstrap script mounted into the container. The template creates **no credential secret of its own**.
+- **Identity & Policy** — An identity bound to the Gitea workload with `reveal` scoped to exactly three secrets: the bootstrap script, the PostgreSQL config secret, and the auth secret you created.
 - **Direct Load Balancer** *(optional)* — A raw-TCP port for Git-over-SSH, created only when `ssh.enabled` is `true`.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Upgrading From Earlier Versions
+
+Template version 1.0.0 took the admin login and all three security values as plain Helm values and shipped published defaults for every one of them. Those are not merely a web login: `secretKey` encrypts the 2FA secrets, access tokens and mirror credentials stored in the database.
+
+| Removed in 1.0.0 | Key in the 1.1.0 auth secret |
+|---|---|
+| `gitea.admin.username` | `adminUsername` |
+| `gitea.admin.password` | `adminPassword` |
+| `gitea.admin.email` | `adminEmail` |
+| `gitea.security.secretKey` | `secretKey` |
+| `gitea.security.internalToken` | `internalToken` |
+| `gitea.security.jwtSecret` | `jwtSecret` |
+
+Each removed key is rejected at render with a message naming its replacement, so the upgrade fails before anything is applied and the running release is left untouched. There are no compatibility fallbacks.
+
+<Warning>
+**Put your existing values into the secret — do not generate new ones for a live install.** Two of the three cannot be rotated:
+
+- Changing `secretKey` makes every 2FA secret, access token and mirror credential already in the database permanently unreadable.
+- Changing `jwtSecret` invalidates every OAuth2 token already issued.
+
+If your install is still carrying the published 1.0.0 defaults, everything it has encrypted is protected by values printed in a public repository — but rotating them in place is destructive in exactly the way above. The safe path is a fresh 1.1.0 install with new key material and a repository migration onto it. At minimum, change the administrator's password in the Gitea UI immediately.
+</Warning>
+
 ## Prerequisites
 
-None for a default install. Before installing, change the admin password and generate the three security values (see [Important Notes](#important-notes)).
+**One secret must exist before you install.** Its values never pass through Helm, so they never land in the release. Secrets are org-level, so no GVC flag is involved.
 
-Install using your preferred method:
+<Steps>
+  <Step title="Create the auth secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly six keys:
+
+    ```bash
+    cpln secret create-dictionary --name my-gitea-auth \
+      --entry adminUsername=gitea_admin \
+      --entry adminEmail=admin@example.com \
+      --entry adminPassword="$(openssl rand -hex 24)" \
+      --entry secretKey="$(openssl rand -hex 32)" \
+      --entry internalToken="$(openssl rand -hex 32)" \
+      --entry jwtSecret="$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')"
+    ```
+
+    Set `gitea.auth.secretName` to the name you used. Nothing else is required for a default install.
+
+    | Key | What it is |
+    |---|---|
+    | `adminUsername` / `adminPassword` / `adminEmail` | The first site-admin account, created at boot. Its login form is on the public endpoint. |
+    | `secretKey` | Encrypts 2FA secrets, access tokens and mirror credentials. Any random string. **Cannot be rotated.** |
+    | `internalToken` | Shared token for Gitea's internal API. Any random string. |
+    | `jwtSecret` | Signs OAuth2 tokens. **Must be base64url of exactly 32 bytes** — Gitea rejects any other length. **Cannot be rotated.** |
+  </Step>
+  <Step title="Read the secret back later">
+    The `-o yaml` is required — plain `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-gitea-auth -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**`jwtSecret` has a format constraint the other two keys do not.** It must be base64url of exactly 32 bytes — 43 characters, no padding — or Gitea errors on startup. That is what `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` produces, and it is the reason the command pipes through `tr`. Do not substitute a hex string or a passphrase here. (Older guidance to run `gitea generate secret` needs the `gitea` binary, which you do not have outside the container.)
+</Warning>
+
+<Warning>
+**Create the secret before installing.** The template refuses to render when the name is blank, but a name pointing at a secret that does not exist installs "successfully" and then wedges: every resource reports created, the workload never becomes ready, and **`cpln logs` returns zero lines** because no container ever starts. The only diagnostic is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-gitea --gvc GVC_NAME -o yaml
+```
+
+It names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` The command is `get-deployments` — plain `cpln workload get` has no `versions` key at all. Creating the secret recovers the workload on its own: **poll for 5.5 to 10.5 minutes rather than time-boxing it** (8 minutes 35 seconds measured here). `cpln workload force-redeployment RELEASE_NAME-gitea --gvc GVC_NAME` cuts that to roughly 90 seconds.
+</Warning>
+
+## Installation
+
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -56,62 +134,73 @@ Install using your preferred method:
 
 ## Configuration
 
-Key configuration values (see the template's `values.yaml` for the complete set):
+The default `values.yaml` for this template:
 
 ```yaml
+# ─── Image ────────────────────────────────────────────────────────
 image: gitea/gitea:1.27.1-rootless  # rootless variant: runs as UID 1000, built-in SSH server on 2222
 
+# ─── Resources ────────────────────────────────────────────────────
 resources:
   minCpu: 250m
   minMemory: 512Mi
   maxCpu: 1000m
   maxMemory: 1024Mi
 
-# Storage (repos, LFS, attachments, SSH host keys)
+# ─── Storage (repos, LFS, attachments, SSH host keys) ─────────────
 volumeset:
   capacity: 20 # initial capacity in GiB (minimum is 10)
   autoscaling:
-    enabled: false
-    maxCapacity: 200
-    minFreePercentage: 10
-    scalingFactor: 1.2
+    enabled: false # set to true to enable volume autoscaling
+    maxCapacity: 200 # maximum capacity in GiB when autoscaling is enabled
+    minFreePercentage: 10 # minimum free percentage that triggers scaling
+    scalingFactor: 1.2 # how much to grow the volume when scaling is triggered
 
-# Gitea admin + app secrets (template-scoped — CHANGE THESE)
+# ─── Gitea ────────────────────────────────────────────────────────
 gitea:
-  admin:
-    username: gitea_admin
-    password: change-me-admin-pass   # CHANGE before install — the first admin login
-    email: admin@example.com
-  security:
-    # Stable per install. CHANGE THESE. Generate each with:
-    # gitea generate secret SECRET_KEY | INTERNAL_TOKEN | JWT_SECRET
-    # Do NOT rotate after install — changing SECRET_KEY makes existing encrypted data unreadable.
-    secretKey: REPLACE_WITH_gitea_generate_secret_SECRET_KEY
-    internalToken: REPLACE_WITH_gitea_generate_secret_INTERNAL_TOKEN
-    jwtSecret: REPLACE_WITH_gitea_generate_secret_JWT_SECRET
+  auth:
+    # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. If it does
+    # not exist the deployment WEDGES silently and looks like a platform fault.
+    # A `dictionary` secret holding exactly six keys:
+    #   adminUsername   — first site-admin login
+    #   adminPassword   — its password; this login sits on the public endpoint
+    #   adminEmail      — its email address
+    #   secretKey       — encrypts 2FA secrets, tokens and mirror credentials;
+    #                     CANNOT be rotated without making all of them unreadable
+    #   internalToken   — Gitea's internal API shared token
+    #   jwtSecret       — signs OAuth2 tokens; must be base64url of exactly 32 bytes
+    # See README Prerequisites for the exact command.
+    secretName: my-gitea-auth
   disableRegistration: true  # true = admin-invite only; false = allow open self-registration
 
-# Access
+# ─── Access ───────────────────────────────────────────────────────
 publicAccess:
   enabled: true  # HTTPS web UI + Git-over-HTTPS on the auto *.cpln.app endpoint
 
-# Git-over-SSH (optional, OFF by default — see Important Notes)
+# ─── Git-over-SSH (optional, OFF by default) ──────────────────────
+# NOTE: enabling public SSH repoints the single *.cpln.app endpoint to a raw-TCP
+# load balancer on port 22, which takes over the public HTTPS web UI (they cannot
+# share one canonical endpoint). Leave this off to keep the public web UI +
+# Git-over-HTTPS; enable it only if you serve the web UI via a custom domain, or
+# you only need Git-over-SSH. Git-over-HTTPS works fully regardless.
 ssh:
   enabled: false     # false = Git-over-HTTPS only (public web UI stays up); true = public SSH takes the endpoint
   externalPort: 22   # public port clients connect to (also advertised in SSH clone URLs)
   domain: ""         # advertised SSH host in clone URLs; empty = use the web domain
 
-internalAccess:
+internalAccess: # internal firewall scope
   type: same-gvc # options: none, same-gvc, same-org, workload-list
   workloads:  # only used when type is same-gvc or workload-list
     #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
-# Backing database (postgres subchart)
+# ─── Backing database (postgres subchart) ─────────────────────────
+# Bundled plumbing: it serves Gitea only and is unreachable from outside the
+# GVC — but the password is used AS-IS, so change it before installing.
 postgres:
   image: postgres:18
   config:
     username: gitea
-    password: change-me-db-pass
+    password: change-me-gitea-db
     database: gitea
   resources:
     minCpu: 200m
@@ -120,6 +209,11 @@ postgres:
     maxMemory: 512Mi
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
+    autoscaling:
+      enabled: false
+      maxCapacity: 100
+      minFreePercentage: 10
+      scalingFactor: 1.2
   internalAccess:
     type: same-gvc
 ```
@@ -127,7 +221,7 @@ postgres:
 ### Image and Resources
 
 - `image` — The Gitea image. The template uses the **rootless** variant, which runs as UID 1000 and serves SSH on port 2222 inside the container.
-- `resources` — Min/max CPU and memory bounds for the Gitea workload.
+- `resources` — Reservation and limit for the Gitea container (`minCpu` / `maxCpu` / `minMemory` / `maxMemory`).
 
 ### Storage
 
@@ -137,59 +231,78 @@ postgres:
   - `minFreePercentage` — Trigger a scale-up when free space drops below this percentage.
   - `scalingFactor` — Multiply the current capacity by this factor when scaling up.
 
-### Admin and Security
+### Gitea
 
-- `gitea.admin.username` / `gitea.admin.password` / `gitea.admin.email` — The site administrator account, bootstrapped on first boot. **Change the password before installing.**
-- `gitea.security.secretKey` / `internalToken` / `jwtSecret` — Stable per-install app secrets. Generate each with `gitea generate secret SECRET_KEY` (and `INTERNAL_TOKEN`, `JWT_SECRET`). These are values (not auto-generated) so they stay stable across upgrades. **Never rotate `secretKey` after install** — doing so makes all encrypted data (2FA secrets, tokens, mirror credentials) permanently unreadable.
+- `gitea.auth.secretName` — Name of the prerequisite dictionary secret holding the admin login and the three signing keys. It must exist before you install.
 - `gitea.disableRegistration` — `true` (default) restricts new accounts to admin invites; `false` allows open self-registration.
 
 ### Access
 
-- `publicAccess.enabled` — Exposes the HTTPS web UI, Git-over-HTTPS, and the package registry on the auto-assigned `*.cpln.app` canonical endpoint.
-- `ssh.enabled` — Exposes Git-over-SSH via a direct TCP load balancer. **OFF by default** — see [Important Notes](#important-notes) for the trade-off with the public web UI.
-- `ssh.externalPort` — The public SSH port clients connect to; also advertised in SSH clone URLs (default `22`).
+- `publicAccess.enabled` — Serves the HTTPS web UI, Git-over-HTTPS, and the package registry on the auto-assigned `*.cpln.app` canonical endpoint.
+- `ssh.enabled` — Exposes Git-over-SSH via a direct TCP load balancer. **Off by default** — see [The SSH and HTTPS Endpoint Trade-off](#the-ssh-and-https-endpoint-trade-off).
+- `ssh.externalPort` — The public SSH port clients connect to; also advertised in SSH clone URLs.
 - `ssh.domain` — The SSH host advertised in clone URLs. Empty uses the web domain.
 - `internalAccess.type` — Controls which workloads can reach Gitea over the internal network (`none`, `same-gvc`, `same-org`, or `workload-list`).
 
+<Note>
+**Public access is on by default, deliberately.** `git clone` and `git push` from laptops and CI are the point of the service, and both are proven to work against the public endpoint. Self-registration is closed by default, and after 1.1.0 there is no published default credential to protect against — the admin login is one you created.
+
+Set `publicAccess.enabled: false` to keep Gitea inside the GVC and reach the UI with `cpln port-forward RELEASE_NAME-gitea 3000:3000 --gvc GVC_NAME`. A firewall change takes roughly **30 seconds to 5 minutes** to propagate, so re-test rather than trusting the first response.
+</Note>
+
 ### Backing Database
 
-- `postgres.config.username` / `password` / `database` — Credentials for the bundled PostgreSQL, applied on first startup. **Change the password before deploying to production.**
-- `postgres.resources` — Min/max CPU and memory bounds for the PostgreSQL workload.
-- `postgres.volumeset.capacity` — Initial Postgres volume size in GiB (minimum 10).
+Bundled plumbing: the database serves Gitea only and is unreachable from outside the GVC, and nobody ever types this password into a client, so it stays a value.
+
+- `postgres.config.username` / `password` / `database` — Credentials for the bundled PostgreSQL, applied on first startup. **Change the password before installing** — the shipped `change-me-gitea-db` is a published placeholder.
+- `postgres.resources` — Reservation and limit for the PostgreSQL container.
+- `postgres.volumeset.capacity` and `postgres.volumeset.autoscaling` — Initial Postgres volume size in GiB (minimum 10) and its autoscaling settings.
 - `postgres.internalAccess.type` — Controls which workloads can reach PostgreSQL.
 
 <Note>
-PostgreSQL credentials are only applied on first startup when the data directory is empty. Changing them after the initial deployment has no effect on the running database — use PostgreSQL's native commands (e.g. `ALTER USER`) instead.
+PostgreSQL credentials are only applied on first startup, when the data directory is empty. Changing them afterwards has no effect on the running database — use PostgreSQL's own commands (for example `ALTER USER`) instead.
 </Note>
 
 ## Connecting
 
 | Access | Endpoint | Notes |
 |---|---|---|
-| Web UI + Git-over-HTTPS + registry | `https://<canonical>.cpln.app` | Auto-assigned when `publicAccess.enabled`. Find it under `status.canonicalEndpoint` (`cpln workload get <release>-gitea -o yaml`). |
-| Git-over-SSH | direct-LB address on `ssh.externalPort` | Only when `ssh.enabled`. The reachable host is the `loadBalancer.direct` address from the workload status. |
-| Internal (in-GVC) | `<release>-gitea.<gvc>.cpln.local:3000` | Reachable from other workloads per `internalAccess.type`. |
-| Credentials | admin login | `gitea.admin.username` / `gitea.admin.password`. |
+| Web UI, Git-over-HTTPS, registry | `https://<canonical>.cpln.app` | Auto-assigned when `publicAccess.enabled`. Find it under `status.canonicalEndpoint` (`cpln workload get RELEASE_NAME-gitea --gvc GVC_NAME -o yaml`). |
+| Local access (public access off) | `cpln port-forward RELEASE_NAME-gitea 3000:3000 --gvc GVC_NAME`, then `http://localhost:3000` | Tunnels through Control Plane; independent of the firewall. |
+| Git-over-SSH | The `loadBalancer.direct` address from the workload status, on `ssh.externalPort` | Only when `ssh.enabled`. This is not the web URL. |
+| Internal (in-GVC) | `RELEASE_NAME-gitea.GVC_NAME.cpln.local:3000` | Reachable from other workloads per `internalAccess.type`. |
+| Admin login | `adminUsername` / `adminPassword` from your auth secret | `cpln secret reveal my-gitea-auth -o yaml` |
 
-Open the canonical endpoint in a browser and sign in with the admin credentials to create repositories, users, and organizations. Clone and push over HTTPS using the same endpoint.
+Sign in at the canonical endpoint to create repositories, users, and organizations. Clone and push over HTTPS against the same endpoint — full clone, push, and anonymous clone of a public repository all work from outside the GVC:
 
-## The SSH / HTTPS Endpoint Trade-off
+```bash
+git clone https://<canonical>.cpln.app/gitea_admin/my-repo.git
+```
 
-A Control Plane workload has exactly **one** `*.cpln.app` canonical endpoint, and it can serve **either** the HTTPS web UI (web UI + Git-over-HTTPS on port 443) **or** a raw-TCP load balancer for SSH (port 22) — **not both**. Enabling `ssh.enabled` repoints that single endpoint to SSH, which takes the public web UI on 443 offline.
+## The SSH and HTTPS Endpoint Trade-off
 
-Because of this, **`ssh.enabled` is `false` by default**, which keeps the public web UI and Git-over-HTTPS working out of the box — all most users need. Git-over-HTTPS supports full clone, push, and pull, so SSH is not required for normal use.
+A Control Plane workload has exactly **one** `*.cpln.app` canonical endpoint, and it can serve **either** the HTTPS web UI (web UI plus Git-over-HTTPS on port 443) **or** a raw-TCP load balancer for SSH — not both. Enabling `ssh.enabled` repoints that single endpoint to SSH, which takes the public web UI offline.
+
+Because of this, **`ssh.enabled` is `false` by default**, which keeps the public web UI and Git-over-HTTPS working out of the box. Git-over-HTTPS supports full clone, push, and pull, so SSH is not required for normal use.
 
 <Warning>
-Enable `ssh.enabled: true` only if you either (a) serve the web UI through a **custom domain** (so the canonical endpoint is free for SSH), or (b) only need Git-over-SSH. Turning it on repoints the public `*.cpln.app` endpoint to SSH on port 22 and makes the public HTTPS web UI on 443 unreachable.
+Enable `ssh.enabled: true` only if you either (a) serve the web UI through a **custom domain**, so the canonical endpoint is free for SSH, or (b) only need Git-over-SSH. Turning it on repoints the public `*.cpln.app` endpoint to SSH on `ssh.externalPort` and makes the public HTTPS web UI on 443 unreachable.
 </Warning>
+
+<Note>
+With `ssh.enabled: false`, Gitea's REST API still reports a placeholder `ssh://git@localhost:2222/...` clone URL on a repository object. It is cosmetic: the web UI's clone widget offers only the HTTPS URL, so only a script reading `ssh_url` from the API is affected.
+</Note>
 
 ## Important Notes
 
-- **Change `gitea.admin.password` and the three `gitea.security.*` values before installing.** The shipped defaults are illustrative placeholders and are insecure as-is. Generate each security value with `gitea generate secret SECRET_KEY` (and `INTERNAL_TOKEN`, `JWT_SECRET`).
-- **Never rotate `gitea.security.secretKey` after install.** Changing it makes all encrypted data (2FA secrets, tokens, mirror credentials) permanently unreadable. Because it is a value rather than auto-generated, `helm upgrade` keeps it stable.
-- **Public SSH and the public web UI cannot share one endpoint** — SSH is off by default. See [The SSH / HTTPS Endpoint Trade-off](#the-ssh-%2F-https-endpoint-trade-off) above.
-- **Single replica only.** A rolling restart or upgrade incurs brief downtime. Do not raise the workload scale above 1 — replicas would each get separate repo volumes and corrupt state.
-- **Data lives on the volume set** and survives redeploys under the same release name. Change admin credentials after first boot in the Gitea UI, not via values — the data directory keeps the original account. To fully reset, `helm uninstall` (which deletes the volume set) then reinstall.
+- The auth secret must exist **before** you install. Without it the deployment wedges with no log output at all; see [Prerequisites](#prerequisites) for the one diagnostic that names it.
+- **Never rotate `secretKey` or `jwtSecret` after install.** A new `secretKey` makes existing 2FA secrets, tokens and mirror credentials permanently unreadable, and a new `jwtSecret` invalidates issued OAuth2 tokens.
+- **`jwtSecret` must be base64url of exactly 32 bytes** — any other length is rejected at startup. Use the command in [Prerequisites](#prerequisites).
+- **Public SSH and the public web UI cannot share one endpoint** — SSH is off by default. See [The SSH and HTTPS Endpoint Trade-off](#the-ssh-and-https-endpoint-trade-off).
+- **Single replica only.** A rolling restart or upgrade incurs brief downtime. Do not raise the workload scale above 1 — replicas would each get separate repository volumes and corrupt state.
+- **The first Helm upgrade after an install re-applies the bundled PostgreSQL**, so expect Gitea to be briefly unreachable while the database restarts. Later upgrades do not do this.
+- Editing the auth secret after first boot does not change the existing administrator account — the data directory keeps it. Change the password in the Gitea UI instead.
+- **Data lives on the volume set** and survives redeploys under the same release name. To fully reset, `helm uninstall` (which deletes the volume set) then reinstall.
 
 ## External References
 

--- a/template-catalog/templates/glitchtip.mdx
+++ b/template-catalog/templates/glitchtip.mdx
@@ -1,12 +1,18 @@
 ---
 title: GlitchTip
-description: Deploy GlitchTip on Control Plane using the Template Catalog. Open-source, Sentry-compatible error tracking with a stateless web tier, a background worker, Redis/Sentinel task queue, and a highly available PostgreSQL backend. Covers database and queue modes, the optional SMTP prerequisite, closed registration, and backups.
-keywords: ['error tracking', 'error monitoring', 'exception tracking', 'sentry alternative', 'self-hosted sentry', 'sentry-compatible', 'crash reporting', 'application monitoring', 'observability', 'open source', 'mit licensed', 'dsn', 'glitchtip template']
+description: Deploy GlitchTip on Control Plane using the Template Catalog. Open-source, Sentry-compatible error tracking with a stateless web tier, a background worker, a Redis/Sentinel queue and a highly available PostgreSQL backend. Covers the prerequisite auth secret, database and queue modes, closed registration, backups, and upgrading from template version 1.0.x.
+keywords: ['error tracking', 'error monitoring', 'exception tracking', 'sentry alternative', 'self-hosted sentry', 'sentry-compatible', 'crash reporting', 'application monitoring', 'observability', 'mit licensed', 'dsn', 'event ingest', 'django secret key']
 ---
 
 ## Overview
 
-GlitchTip is open-source, Sentry-API-compatible error tracking — applications report crashes and exceptions with standard Sentry SDKs pointed at a GlitchTip DSN, and GlitchTip groups them into issues with alerting. It is fully MIT-licensed with nothing feature-gated; there is no paid tier. This template deploys GlitchTip backed by a highly available PostgreSQL cluster and a Redis/Sentinel queue by default. The web UI and SDK event-ingest endpoint are served on one public HTTPS endpoint, and the admin account is created automatically on first boot — so there is never an unauthenticated setup page and self-signup is closed by default.
+GlitchTip is open-source, Sentry-API-compatible error tracking — applications report crashes and exceptions with standard Sentry SDKs pointed at a GlitchTip DSN, and GlitchTip groups them into issues with alerting. It is fully MIT-licensed with nothing feature-gated; there is no paid tier. This template deploys GlitchTip backed by a highly available PostgreSQL cluster and a Redis/Sentinel queue by default. The web UI and SDK event-ingest endpoint are served on one public HTTPS endpoint, and self-signup is closed by default.
+
+The Django signing key and the initial superuser login are not template values. They come from a dictionary secret you create before installing, so they never pass through Helm and never land in the release.
+
+<Warning>
+**Template version 1.1.0 is a breaking change.** `django.secretKey`, `admin.email` and `admin.password` moved into a prerequisite secret, and `resources.cpu` / `resources.memory` / `worker.resources.cpu` / `worker.resources.memory` were renamed. An install or upgrade that still sets any of them fails at render. If you are running 1.0.x, read [Upgrading From Earlier Versions](#upgrading-from-earlier-versions) first.
+</Warning>
 
 ### Architecture
 
@@ -18,34 +24,88 @@ GlitchTip is open-source, Sentry-API-compatible error tracking — applications 
 
 ### What Gets Created
 
-- **Standard GlitchTip Web Workload** — The stateless web tier serving the UI, API, and SDK event ingest on port `8000` (`replicas` controls its scale).
-- **Standard GlitchTip Worker Workload** — A single-replica worker + scheduler that runs migrations and the admin bootstrap at boot.
+- **Standard GlitchTip Web Workload** — (`RELEASE_NAME-glitchtip`): the stateless web tier serving the UI, API, and SDK event ingest on port `8000` (`replicas` controls its scale).
+- **Standard GlitchTip Worker Workload** — (`RELEASE_NAME-glitchtip-worker`): a single-replica worker plus scheduler that runs migrations and the admin bootstrap at boot.
 - **Database Workloads** — HA mode: a stateful Patroni PostgreSQL workload, a stateful etcd workload, and a standard HAProxy leader-routing workload. Single mode: one stateful PostgreSQL workload.
 - **Redis Workloads** *(default)* — A master-replica Redis deployment with Sentinel for failover. Omitted when `redis.enabled` is `false`.
 - **Volume Sets** — The database subchart's persistent volumes (10 GiB per replica by default), plus Redis persistence when enabled. The GlitchTip web and worker tiers have no volumes of their own.
-- **Secrets** — The Django `SECRET_KEY`, admin bootstrap credentials, two start scripts, and the database and Redis credentials from the subcharts.
-- **Identity & Policy** — A shared identity for the web and worker workloads and a least-privilege policy granting it `reveal` on exactly the secrets it uses (including the optional email secret when configured).
+- **Secrets** — Two start scripts, plus the database and Redis credentials from the subcharts. The template creates **no credential secret of its own**: the signing key and admin login come from the secret you create.
+- **Identity & Policy** — A shared identity for the web and worker workloads and a least-privilege policy granting it `reveal` on exactly the secrets it uses, including your auth secret by name and the optional email secret when configured.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Upgrading From Earlier Versions
+
+Template version 1.0.x carried the Django signing key and the superuser login as plain Helm values, with published defaults for both. Each removed or renamed key is rejected at render with a message naming its replacement, so a failing upgrade leaves the running release untouched. There are no compatibility fallbacks.
+
+| Removed or renamed in 1.0.x | 1.1.0 |
+|---|---|
+| `django.secretKey` | `secretKey` key in the prerequisite auth secret |
+| `admin.email` | `adminEmail` key in the same secret |
+| `admin.password` | `adminPassword` key in the same secret |
+| `resources.cpu` / `resources.memory` | `resources.maxCpu` / `resources.maxMemory` |
+| `worker.resources.cpu` / `worker.resources.memory` | `worker.resources.maxCpu` / `worker.resources.maxMemory` |
+
+<Warning>
+**Put your existing `secretKey` into the secret rather than generating a new one.** It signs live sessions and tokens: a new value logs every user out and invalidates password-reset links already in flight. Nothing is corrupted, but everyone has to sign in again.
+
+If your install is still carrying the published 1.0.x default, its sessions and tokens are signed with a value printed in a public repository. Rotating it is the fix and the cost is exactly that one forced sign-out, so plan the upgrade for a quiet window rather than skipping it. Change the admin password in the UI at the same time.
+</Warning>
+
+The resource keys were renamed because both blocks expose a reservation as well as a limit, and a bare `cpu` sitting next to `minCpu` does not say which one it is. `maxCpu` and `maxMemory` map onto the platform's `cpu` and `memory` fields.
+
 ## Prerequisites
 
-- **None for a default install.**
-- **Optional — outbound email** (member invites, alerts, password resets): create an [opaque secret](/guides/create-secret/opaque) in your org, with encoding `plain`, whose payload is a full email URL, for example `smtp://user:password@smtp.example.com:587`. Set its name in `email.secretName` and create it **before** installing. Leave `email.secretName` empty to run without email.
-- **Optional — database backups**: a bucket and access setup for one of the supported providers — see [Backing Up](#backing-up).
+**One secret must exist before you install.** Its values never pass through Helm, so they never land in the release. Secrets are org-level, so no GVC flag is involved.
 
 <Steps>
-  <Step title="Change the generated credentials">
-    Change `django.secretKey`, `admin.password`, the database password (`postgresHA.postgres.password` or `postgres.config.password`), and the Redis password (`redis.redis.auth.password.value`) from their placeholder defaults before installing.
+  <Step title="Create the auth secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly three keys:
+
+    ```bash
+    cpln secret create-dictionary --name my-glitchtip-auth \
+      --entry secretKey="$(openssl rand -hex 32)" \
+      --entry adminEmail=admin@example.com \
+      --entry adminPassword="$(openssl rand -hex 24)"
+    ```
+
+    Set `auth.secretName` to the name you used. Nothing else is required for a default install.
+
+    | Key | What it is |
+    |---|---|
+    | `secretKey` | Django's `SECRET_KEY` — signs sessions and tokens. Keep it for the life of the install: changing it logs every user out. |
+    | `adminEmail` / `adminPassword` | The initial superuser, seeded on first boot only. Afterwards manage accounts in the UI; editing the secret does not change the existing login. |
   </Step>
-  <Step title="(Optional) Create the email secret">
-    If you want outbound email, create the opaque secret described above and set `email.secretName` to its name before installing.
+  <Step title="Read the secret back later">
+    The `-o yaml` is required — plain `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-glitchtip-auth -o yaml
+    ```
+  </Step>
+  <Step title="Optional: create the email secret">
+    For member invites, alert notifications, and password-reset mail, create an [opaque secret](/guides/create-secret/opaque) with encoding `plain` whose payload is a full email URL — for example `smtp://user:password@smtp.example.com:587`. Set `email.secretName` to its name before installing. Leave it empty to run without outbound email.
+  </Step>
+  <Step title="Optional: set up backup storage">
+    Only if you plan to enable database backups — see [Backing Up](#backing-up).
   </Step>
 </Steps>
 
-Install the template using your preferred method:
+<Warning>
+**Create the auth secret before installing.** A name pointing at a secret that does not exist installs "successfully" and then wedges **both** workloads: every resource reports created, neither becomes ready, and **`cpln logs` returns zero lines** because no container ever starts. The only diagnostic is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-glitchtip --gvc GVC_NAME -o yaml
+```
+
+It names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` The command is `get-deployments` — plain `cpln workload get` has no `versions` key at all. Creating the secret recovers the workloads on their own: **poll for 5.5 to 10.5 minutes rather than time-boxing it.** `cpln workload force-redeployment RELEASE_NAME-glitchtip --gvc GVC_NAME` cuts that to roughly 90 seconds; the worker needs the same treatment.
+</Warning>
+
+## Installation
+
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -77,12 +137,16 @@ Exactly one of the two database modes must be enabled — the chart enforces thi
 |---|---|---|
 | What runs | 3× Patroni PostgreSQL, 3× etcd, HAProxy leader endpoint | One single-replica PostgreSQL workload |
 | Database failover | Automatic (Patroni leader election) | None |
-| First-boot readiness | ~4–6 minutes (worker waits for the HA proxy to open before migrations) | Under a minute |
+| First-boot readiness | About 6 minutes 20 seconds for the full stack | Under a minute |
 | Best for | Production | Development and lightweight installs |
+
+<Note>
+**The HA stack takes about six and a half minutes to converge, and it looks broken while it does.** The worker crash-loops throughout with `django.db.utils.OperationalError: pool error: ... Connection reset by peer` while Patroni elects a leader and the HAProxy endpoint waits for Patroni to answer. This is expected and self-correcting — do not treat it as a failed install, and do not start changing values in the middle of it. If it has not settled after roughly ten minutes, check the worker logs first, not the web logs.
+</Note>
 
 ## Choosing a Queue Mode
 
-By default the [redis](/template-catalog/templates/redis) template is deployed and GlitchTip runs its task queue, cache, and sessions through Redis Sentinel. Set `redis.enabled: false` to run those on PostgreSQL instead — a lighter "lean" shape with no Redis workloads, at lower throughput. Both modes are supported upstream and are proven end to end.
+By default the [redis](/template-catalog/templates/redis) template is deployed and GlitchTip runs its task queue, cache, and sessions through Redis Sentinel. Set `redis.enabled: false` to run those on PostgreSQL instead — a lighter shape with no Redis workloads, at lower throughput. Both modes are supported upstream.
 
 ## Configuration
 
@@ -94,33 +158,44 @@ image: glitchtip/glitchtip:6.2.2
 replicas: 1 # web tier — stateless; set 2+ for high availability (state lives in PostgreSQL/Redis)
 
 resources: # web workload
-  cpu: 1000m
-  memory: 1Gi
   minCpu: 250m
   minMemory: 512Mi
+  maxCpu: 1000m
+  maxMemory: 1Gi
 
-worker: # background worker + scheduler; runs migrations and admin bootstrap at boot (single replica)
+# ─── Background Worker ────────────────────────────────────────────────────────
+# Processes events, alerts, emails, and scheduled jobs; also runs database
+# migrations and admin bootstrap at boot. Single replica (scheduler singleton).
+worker:
   resources:
-    cpu: 1000m
-    memory: 1Gi
     minCpu: 250m
     minMemory: 512Mi
+    maxCpu: 1000m
+    maxMemory: 1Gi
   concurrency: 20 # async tasks processed in parallel (VTASKS_CONCURRENCY)
 
-django:
-  secretKey: change-me-glitchtip-secret-key # session/token signing key — change before installing; rotating later logs out all users
-
-admin: # superuser seeded on first boot only — log in with these, then manage in the UI
-  email: admin@example.com
-  password: change-me-glitchtip-admin # change before installing
+# ─── Authentication ───────────────────────────────────────────────────────────
+auth:
+  # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. If it does not
+  # exist the deployment WEDGES silently and looks like a platform fault.
+  # A `dictionary` secret holding exactly three keys:
+  #   secretKey      — Django session/token signing key; rotating it logs every
+  #                    user out, so keep it for the life of the install
+  #   adminEmail     — the initial superuser login, seeded on first boot; this
+  #                    login form sits on the public endpoint
+  #   adminPassword  — its password
+  # See README Prerequisites for the exact command.
+  secretName: my-glitchtip-auth
 
 registration:
   enabled: false # open self-signup on the endpoint; admin-created users and invites work regardless
 
+# ─── Email (optional) ─────────────────────────────────────────────────────────
 email:
-  secretName: "" # name of a pre-created opaque secret whose payload is an EMAIL_URL (create BEFORE install; empty = outbound email off)
+  secretName: "" # name of a pre-created opaque secret whose payload is an EMAIL_URL, e.g. smtp://user:pass@smtp.example.com:587 (create BEFORE install; empty = outbound email off)
   fromAddress: glitchtip@example.com # DEFAULT_FROM_EMAIL — used only when secretName is set
 
+# ─── Access ───────────────────────────────────────────────────────────────────
 domain: "" # full URL used in DSNs and email links (e.g. https://errors.example.com); empty = canonical *.cpln.app endpoint
 publicAccess:
   enabled: true # UI + SDK event ingest (DSN) on the canonical *.cpln.app HTTPS endpoint
@@ -128,9 +203,15 @@ publicAccess:
 internalAccess: # internal firewall scope (in-GVC SDK callers)
   type: same-gvc # options: none, same-gvc, same-org, workload-list
   workloads: [] # used with workload-list
+  # workloads:
+  #   - //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
-redis: # task queue / cache / sessions (default)
-  enabled: true # false = PostgreSQL carries the queue, cache, and sessions (lighter dev shape)
+# ─── Task Queue / Cache: Redis (default) ──────────────────────────────────────
+# Deploys the redis template (master-replica + Sentinel); GlitchTip connects
+# through Sentinel. Disable to run tasks/cache/sessions on PostgreSQL instead
+# (lighter dev shape, lower throughput).
+redis:
+  enabled: true
   redis:
     replicas: 2
     auth:
@@ -148,17 +229,21 @@ redis: # task queue / cache / sessions (default)
     persistence:
       enabled: true
 
-postgresHA: # default: highly available PostgreSQL
+# ─── Database: Highly Available PostgreSQL (default) ──────────────────────────
+# Deploys the postgres-highly-available template: 3 Patroni replicas, 3 etcd
+# replicas, and an HAProxy leader-routing endpoint GlitchTip connects to.
+postgresHA:
   enabled: true
   postgres:
     username: glitchtip
-    password: change-me-glitchtip-db-password # change before installing
+    password: change-me-glitchtip-db # change before installing
     database: glitchtip
   replicas: 3
   volumeset:
     capacity: 10 # initial capacity in GiB per replica (minimum is 10)
-  backup:
-    enabled: false # optional — see Backing Up
+
+  backup: # optional database backups — see README storage setup
+    enabled: false
     mode: logical # logical or wal-g
     resources:
       cpu: 100m
@@ -170,32 +255,35 @@ postgresHA: # default: highly available PostgreSQL
       intervalSeconds: 21600
     provider: aws # options: aws, gcp, minio
     aws:
-      bucket: glitchtip-pg-backup-bucket
+      bucket: my-glitchtip-backup-bucket
       region: us-east-1
       cloudAccountName: my-s3-cloud-account
-      policyName: glitchtip-pg-backup-policy
+      policyName: my-glitchtip-backup-policy
       prefix: postgres/backups
     gcp:
-      bucket: glitchtip-pg-backup-bucket
+      bucket: my-glitchtip-backup-bucket
       cloudAccountName: my-gcs-cloud-account
       prefix: postgres/backups
     minio:
       endpoint: http://my-minio-workload:9000
-      bucket: glitchtip-pg-backup-bucket
+      bucket: my-glitchtip-backup-bucket
       accessKey: my-minio-username
       secretKey: my-minio-password
       prefix: postgres/backups
 
-postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA first)
+# ─── Database: Single-instance PostgreSQL (dev/lightweight) ───────────────────
+# Enable this and disable postgresHA for a lighter non-HA deployment.
+postgres:
   enabled: false
   config:
     username: glitchtip
-    password: change-me-glitchtip-db-password # change before installing
+    password: change-me-glitchtip-db # change before installing
     database: glitchtip
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
-  backup:
-    enabled: false # optional — see Backing Up
+
+  backup: # optional database backups (Postgres 17+) — see README storage setup
+    enabled: false
     image: ghcr.io/controlplane-com/backup-images/postgres-backup:18.1.0
     schedule: "0 2 * * *"
     resources:
@@ -203,18 +291,18 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
       memory: 128Mi
     provider: aws # options: aws, gcp, minio
     aws:
-      bucket: glitchtip-pg-backup-bucket
+      bucket: my-glitchtip-backup-bucket
       region: us-east-1
       cloudAccountName: my-s3-cloud-account
-      policyName: glitchtip-pg-backup-policy
+      policyName: my-glitchtip-backup-policy
       prefix: postgres/backups
     gcp:
-      bucket: glitchtip-pg-backup-bucket
+      bucket: my-glitchtip-backup-bucket
       cloudAccountName: my-gcs-cloud-account
       prefix: postgres/backups
     minio:
       endpoint: http://my-minio-workload:9000
-      bucket: glitchtip-pg-backup-bucket
+      bucket: my-glitchtip-backup-bucket
       accessKey: my-minio-username
       secretKey: my-minio-password
       prefix: postgres/backups
@@ -222,23 +310,23 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 ### GlitchTip
 
-- `image` — The GlitchTip container image (used by both the web and worker workloads).
-- `replicas` — Web-tier replica count. The web tier is stateless (all state is in PostgreSQL and Redis), so scaling to `2` or more gives high availability. The default `1` renders the proven single-replica shape.
-- `resources` — CPU and memory for the web container.
-- `worker.resources` — CPU and memory for the worker container.
+- `image` — The GlitchTip container image, used by both the web and worker workloads.
+- `replicas` — Web-tier replica count. The web tier is stateless (all state is in PostgreSQL and Redis), so scaling to `2` or more gives high availability. The default `1` is the proven single-replica shape.
+- `resources` — Reservation and limit for the web container (`minCpu` / `maxCpu` / `minMemory` / `maxMemory`).
+- `worker.resources` — The same four keys for the worker container.
 - `worker.concurrency` — Number of async tasks the worker processes in parallel (`VTASKS_CONCURRENCY`).
-- `django.secretKey` — Session and token signing key. **Change it before installing.** Rotating it later logs out all users but corrupts nothing. It is stored as a secret reference, never in plaintext.
-- `admin.email` / `admin.password` — The superuser account, seeded on first boot only. **Change `admin.password` before installing.** Log in with these, then manage users in the UI; changing the values later does not modify the existing account.
-- `registration.enabled` — Open self-signup on the public endpoint. Default `false` (closed) — admin-created users and invites still work either way. See [Onboarding Users](#onboarding-users).
+- `auth.secretName` — Name of the prerequisite dictionary secret holding `secretKey`, `adminEmail` and `adminPassword`. It must exist before you install.
+- `registration.enabled` — Open self-signup on the endpoint. Default `false` (closed) — admin-created users and invites still work either way. See [Onboarding Users](#onboarding-users).
 
 ### Email
 
-- `email.secretName` — Name of your pre-created opaque secret whose payload is an `EMAIL_URL` (see [Prerequisites](#prerequisites)). Empty (default) turns outbound email off. Member invites, alert notifications, and password-reset mail all require this to be set.
-- `email.fromAddress` — The `From` address used on outbound mail; applied only when `email.secretName` is set.
+- `email.secretName` — Name of your pre-created opaque secret whose payload is an `EMAIL_URL` (see [Prerequisites](#prerequisites)). Empty (default) turns outbound email off. Member invites, alert notifications, and password-reset mail all require it.
+- `email.fromAddress` — The `From` address on outbound mail; applied only when `email.secretName` is set.
 
 ### Access
 
-- `publicAccess.enabled` — Serve the UI and SDK event ingest (the DSN endpoint) on the canonical `*.cpln.app` HTTPS endpoint (default). Because Sentry SDKs typically run outside the GVC, public access is on by default. Set to `false` for an internal-only instance (external requests are blocked at the edge; in-GVC callers still reach it per `internalAccess`).
+- `publicAccess.enabled` — Serve the UI and SDK event ingest (the DSN endpoint) on the canonical `*.cpln.app` HTTPS endpoint.
+- `domain` — Full URL (for example `https://errors.example.com`) embedded in DSNs and email links. Empty (default) uses the canonical endpoint, derived automatically at boot.
 - `internalAccess.type` — Internal firewall scope of the web workload:
 
 | Type | Description |
@@ -248,22 +336,29 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 | `same-org` | Allow access from all workloads in the same organization. |
 | `workload-list` | Allow access only from workloads listed in `internalAccess.workloads`. |
 
-- `domain` — Full URL (for example `https://errors.example.com`) embedded in DSNs and email links. Empty (default) uses the canonical `*.cpln.app` endpoint, derived automatically at boot.
+<Note>
+**Public access is on by default, deliberately.** Browser SDKs and applications outside the GVC have to reach the ingest endpoint or they cannot report anything, and both the legacy store API and the modern envelope API are proven to accept events from outside the GVC against this template. Self-signup is closed by default, and after 1.1.0 there is no published default credential to protect against.
 
-### Queue / Cache: Redis
+Set `publicAccess.enabled: false` for in-GVC reporters only, and reach the UI with `cpln port-forward RELEASE_NAME-glitchtip 8000:8000 --gvc GVC_NAME`. A firewall change takes roughly **30 seconds to 5 minutes** to propagate, so re-test rather than trusting the first response.
+</Note>
+
+### Task Queue and Cache
 
 - `redis.enabled` — Deploy the Redis subchart in Sentinel mode for the task queue, cache, and sessions (default). Set to `false` to carry those on PostgreSQL instead — see [Choosing a Queue Mode](#choosing-a-queue-mode).
 - `redis.redis.replicas` — Redis master-replica count.
 - `redis.redis.auth.password.value` — The Redis password. Required when Redis is enabled (the chart enforces it). **Change it before installing** — any characters are fine, the boot script percent-encodes it into the connection URL.
 - `redis.sentinel.replicas` — Number of Sentinel instances. Sentinel authentication must stay disabled — GlitchTip cannot send a Sentinel password; the same-GVC firewall is the boundary there.
 - `redis.redis.persistence.enabled` / `redis.sentinel.persistence.enabled` — Persistent storage for Redis and Sentinel.
+- `redis.redis.firewall.internal_inboundAllowType` / `redis.sentinel.firewall.internal_inboundAllowType` — Internal firewall scope of the Redis and Sentinel workloads.
 
 ### Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). GlitchTip is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). GlitchTip is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+
+Both database passwords are bundled plumbing — the database serves GlitchTip only and is unreachable from outside the GVC — but they are used as-is, so **change `postgresHA.postgres.password` or `postgres.config.password` before installing**. The shipped `change-me-glitchtip-db` is a published placeholder.
 
 <Warning>
-**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
+**Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Version `1.0.1` and later turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
 </Warning>
 
 ## Onboarding Users
@@ -274,13 +369,14 @@ Registration is closed by default (`registration.enabled: false`) — an overrid
 
 | What | Value |
 |---|---|
-| UI (public) | `https://<canonical>.cpln.app` — `status.canonicalEndpoint` of `{release}-glitchtip` |
+| UI (public) | `https://<canonical>.cpln.app` — `status.canonicalEndpoint` of `RELEASE_NAME-glitchtip` |
+| Local access (public access off) | `cpln port-forward RELEASE_NAME-glitchtip 8000:8000 --gvc GVC_NAME`, then `http://localhost:8000` |
 | SDK DSN | Copy from the UI: project → Settings → DSN (it embeds the public endpoint) |
-| Internal (same GVC) | `http://{release}-glitchtip.{gvc}.cpln.local:8000` |
-| Login | `admin.email` / `admin.password` |
+| Internal (same GVC) | `http://RELEASE_NAME-glitchtip.GVC_NAME.cpln.local:8000` |
+| Login | The `adminEmail` / `adminPassword` keys of your auth secret |
 | Django admin (user management) | `https://<canonical>.cpln.app/admin/` |
-| PostgreSQL (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
-| PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
+| PostgreSQL (internal, HA mode) | `RELEASE_NAME-postgres-ha-proxy.GVC_NAME.cpln.local:5432`, credentials in the `RELEASE_NAME-postgres-config` secret |
+| PostgreSQL (internal, single mode) | `RELEASE_NAME-postgres.GVC_NAME.cpln.local:5432`, credentials in the `RELEASE_NAME-pg-config` secret |
 
 ### Reporting Errors
 
@@ -359,14 +455,18 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 
 ## Important Notes
 
-- **Change `django.secretKey`, `admin.password`, the database password, and the Redis password before installing.**
+- The auth secret must exist **before** you install. Without it both workloads wedge with no log output at all; see [Prerequisites](#prerequisites) for the one diagnostic that names it.
+- **The HA database takes about six and a half minutes to converge on a fresh install**, with the worker crash-looping on `Connection reset by peer` throughout. It is self-correcting and indistinguishable from a failed install — wait it out.
+- **Rotating `secretKey` logs every user out** and invalidates password-reset links in flight. Nothing is corrupted, but do it deliberately.
+- **Change the database password and the Redis password before installing** — both are bundled plumbing used as-is.
 - **Do not scale the worker** — it is a fixed singleton (scheduler plus boot-time migrations). Web `replicas` is the scaling knob; a worker outage pauses processing but ingest keeps accepting events and catches up when the worker returns.
-- **First boot: the web tier stays not-ready until the worker finishes migrations** — roughly 4–6 minutes in HA mode while the worker waits for the PostgreSQL HA proxy to open, then self-heals. If it seems stuck, check the worker logs first, not the web logs.
+- **First boot: the web tier stays not-ready until the worker finishes migrations.** If it seems stuck, check the worker logs first, not the web logs.
 - **With registration closed (default), invites only work for accounts that already exist** — create teammate accounts first at `/admin/`, then invite them. Invite and alert emails require `email.secretName`. See [Onboarding Users](#onboarding-users).
+- Editing the auth secret after first boot does not change the existing superuser account — it is seeded once. Change the password in the UI.
+- **The first Helm upgrade after an install re-applies resources** even with identical values, which can briefly bounce the bundled datastores. Later upgrades are clean.
 - **DSNs embed the endpoint URL** — if you add a custom domain later, set `domain`, run a Helm upgrade, and update the DSNs in your apps.
 - **Source-map / artifact uploads are ephemeral** (local disk) — lost on restart and not shared across web replicas. Error ingest itself is unaffected; events go to PostgreSQL.
 - **Uninstall deletes the database volume sets** — all issues, events, and users. Enable backups if the data matters.
-- **This template ships the MIT-licensed open-source image** — GlitchTip is a single edition with nothing feature-gated.
 
 ## External References
 

--- a/template-catalog/templates/keycloak.mdx
+++ b/template-catalog/templates/keycloak.mdx
@@ -1,6 +1,6 @@
 ---
 title: Keycloak
-description: Deploy Keycloak on Control Plane using the Template Catalog. Covers clustering, PostgreSQL backing stores, access configuration, and optional database backups.
+description: Deploy Keycloak on Control Plane using the Template Catalog. Covers the prerequisite admin credentials secret, clustering, PostgreSQL backing stores, access configuration, and optional database backups.
 keywords: ['auth server', 'oauth2', 'oidc', 'saml', 'sso', 'iam', 'idp', 'auth0 alternative', 'okta alternative', 'single sign-on', 'user federation', 'infinispan', 'realm']
 ---
 
@@ -15,7 +15,7 @@ Keycloak is an open-source identity and access management platform that provides
 - **Single-Instance PostgreSQL Workload** (optional) — The [PostgreSQL template](/template-catalog/templates/postgres) instead, for lighter dev/test deployments.
 - **Volume Sets** — Persistent storage for the PostgreSQL (and etcd) data.
 - **Backup Cron Workload** (optional) — Created by the backing store subchart when its backup pass-through is enabled.
-- **Secrets** — A dictionary secret with the bootstrap admin credentials, an opaque startup script secret, and the database credentials secret created by the PostgreSQL subchart.
+- **Secrets** — An opaque startup script secret, plus the database credentials secret created by the PostgreSQL subchart. The bootstrap admin credentials are **not** created by this template: you create that dictionary secret yourself before installing and reference it by name (see [Prerequisites](#prerequisites)).
 - **Identity & Policy** — An identity bound to the Keycloak workload with a least-privilege policy granting `reveal` access to exactly the secrets it mounts.
 
 All durable state — realms, users, and active sessions — lives in PostgreSQL; the Keycloak tier is stateless on disk.
@@ -26,7 +26,50 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-None for a default install.
+**One dictionary secret must exist before you install.** The bootstrap admin guards a login form on the public endpoint, so its credentials are a prerequisite secret rather than template values — a value would sit in plaintext in the Helm release for the life of the install. The template creates no admin secret of its own.
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `username` and `password`. Secrets are org-level, so no GVC flag is involved:
+
+    ```bash
+    cpln secret create-dictionary --name my-keycloak-admin \
+      --entry username=admin \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `admin.secretName` to the name you used.
+  </Step>
+  <Step title="Read the password back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-keycloak-admin -o yaml
+    ```
+  </Step>
+</Steps>
+
+| Key | What it is |
+|---|---|
+| `username` | The temporary bootstrap admin's login name. |
+| `password` | Its password. The login form it guards is on the public endpoint. |
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** The install still exits 0 and reports success, every resource is created, and the workload then never starts. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-keycloak --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-keycloak-admin no longer exists. Workload updates are paused until
+the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery has measured between 5.5 and 10.5 minutes across the catalog, so poll rather than giving up. `cpln workload force-redeployment RELEASE_NAME-keycloak --gvc GVC_NAME` shortcuts it to roughly 90 seconds.
+</Warning>
 
 If you enable the optional database backups, you need a cloud account and a bucket for the backing store's backup job. The backup configuration is a pass-through to the backing PostgreSQL template — follow the [PostgreSQL Highly Available backup prerequisites](/template-catalog/templates/postgres-highly-available#backup-prerequisites) (default store) or the [PostgreSQL backup prerequisites](/template-catalog/templates/postgres#backup-prerequisites) (dev/test store).
 
@@ -56,6 +99,46 @@ To install, follow the instructions for your preferred method:
     </Card>
 </CardGroup>
 
+## Upgrading From 1.0.x
+
+Version `1.1.0` moved the bootstrap admin login out of Helm values. Earlier versions shipped a username and a working password as values, used exactly as written — a published default guarding a login form on the public endpoint, sitting in the Helm release for the life of the install.
+
+| | `1.0.x` | `1.1.0` |
+|---|---|---|
+| Bootstrap admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `username` and `password` |
+| Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
+| Database password | A value (`postgresHA.postgres.password` / `postgres.config.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+
+<Warning>
+**An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+keycloak: admin.password was REMOVED in 1.1.0. Put it in a `dictionary` secret (key: `password`)
+together with `username`, and set admin.secretName to that secret's name. Create the secret BEFORE
+installing; see Prerequisites in the README.
+```
+
+Leaving `admin.secretName` empty is refused the same way.
+</Warning>
+
+<Note>
+**An existing install's admin password does not change on upgrade.** Keycloak consults `KC_BOOTSTRAP_ADMIN_*` only when no admin account exists yet, so the account already in the database is untouched by whatever the secret holds. Create the secret so the release renders, then change the password in the Keycloak admin console. If the install is still carrying the published `1.0.x` default (`change-me-keycloak-admin`), treat that password as compromised and change it in the console now.
+</Note>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    Follow [Prerequisites](#prerequisites). Putting your current credentials in it keeps your values file honest, but it does not re-seed the account.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `admin.username` and `admin.password`, and set `admin.secretName` instead.
+  </Step>
+  <Step title="Upgrade">
+    Realms, users, and sessions are in PostgreSQL and are untouched. The Keycloak replicas restart — see [Replicas and Clustering](#replicas-and-clustering).
+  </Step>
+</Steps>
+
 ## Configuration
 
 The default `values.yaml` for this template:
@@ -74,11 +157,14 @@ resources: # per replica
   minMemory: 1Gi
 
 # ─── Admin Bootstrap ──────────────────────────────────────────────────────────
-# Creates a temporary admin on first boot. Log in and create a permanent admin,
-# then remove the temporary one (Keycloak warns until you do).
+# REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. A `dictionary`
+# secret holding exactly two keys, `username` and `password`; it is the
+# temporary admin Keycloak creates on first boot, and its login form sits on the
+# public endpoint. If the secret does not exist at install time the deployment
+# WEDGES silently — `cpln logs` returns nothing at all. See Prerequisites in the
+# README for the exact `cpln secret create-dictionary` command.
 admin:
-  username: admin
-  password: change-me-keycloak-admin # change before installing
+  secretName: my-keycloak-admin
 
 # ─── Backing Store: Highly Available PostgreSQL (default) ────────────────────
 # Deploys the postgres-highly-available template: 3 Patroni replicas, 3 etcd
@@ -175,13 +261,19 @@ internalAccess:
 - Clustered replicas must be able to reach each other on ports 7800/57800, so `replicas > 1` requires `internalAccess.type` other than `none` — the chart enforces this at render.
 - Scaling is operator-driven: change `replicas` via a template upgrade. There is deliberately no autoscaling, so cluster membership only changes intentionally.
 
+<Note>
+**A rolling upgrade is not constrained to one replica at a time.** Control Plane silently discards `maxUnavailableReplicas` on stateful workloads, so version `1.1.0` stopped declaring it and now renders only what the platform actually applies — nothing limits how many replicas restart together. Realms, users, and sessions live in PostgreSQL and survive regardless, but plan for a brief gap in availability during an upgrade rather than assuming a strictly serialized rollout.
+</Note>
+
 ### Keycloak Resources
 
 - `resources` — CPU and memory per replica. The JVM heap is sized to 70% of the memory limit; do not set `memory` below `1.5Gi`.
 
 ### Admin Bootstrap
 
-- `admin.username` / `admin.password` — Credentials for a temporary bootstrap admin created on first boot. **Change the password before installing.** After the first login, create a permanent admin account and remove the temporary one — Keycloak warns until you do.
+- `admin.secretName` — Name of the dictionary secret you created in [Prerequisites](#prerequisites), holding the `username` and `password` of a temporary bootstrap admin. The credentials never pass through values, and the template creates no secret of its own — it references yours and grants the workload `reveal` on exactly that one secret.
+- The account is created on **first boot only**. Keycloak reads those credentials when no admin exists yet, so editing the secret on a running install changes nothing — change the password in the admin console instead.
+- After the first login, create a permanent admin account and remove the temporary one — Keycloak warns until you do.
 
 ### Backing Store
 
@@ -198,7 +290,7 @@ Exactly one of the two stores must be enabled — the chart enforces this at ren
 
 ### Access
 
-- `publicAccess.enabled` — Exposes Keycloak over HTTPS at the automatically assigned canonical `*.cpln.app` endpoint. Keep it enabled for browser-based SSO — end-user browsers must reach Keycloak's login endpoints. Disable it only for pure service-to-service deployments; internal access keeps working.
+- `publicAccess.enabled` — Exposes Keycloak over HTTPS at the automatically assigned canonical `*.cpln.app` endpoint. It is **deliberately on by default**: Keycloak is the identity provider your applications and their users authenticate against, so browsers must reach its login and OIDC endpoints for SSO to work at all, and the admin login is now a credential you created rather than a published default. Disable it only for pure service-to-service deployments; internal access keeps working. A firewall change takes roughly 30 seconds to a few minutes to propagate, so re-test rather than trusting the first response.
 - `internalAccess.type` — Controls which workloads can reach Keycloak inside Control Plane (`none`, `same-gvc`, `same-org`, or `workload-list`). With `workload-list`, list the allowed workloads in `internalAccess.workloads`.
 
 ### Backup
@@ -218,15 +310,17 @@ For provider setup, backup modes, and restore procedures, see the backing store'
 | Admin console | `https://{canonical-endpoint}/admin` |
 | OIDC discovery | `https://{canonical-endpoint}/realms/{realm}/.well-known/openid-configuration` |
 | In-GVC (internal) | `http://{release}-keycloak.{gvc}.cpln.local:8080` |
-| Admin credentials | `admin.username` / `admin.password` values |
+| Admin credentials | The `username` / `password` in your `admin.secretName` secret — `cpln secret reveal my-keycloak-admin -o yaml` |
 
 <Note>
-On a first install of the default HA stack, the Keycloak container waits for the PostgreSQL cluster to come up (logging `Waiting for PostgreSQL...`) before starting. Expect the Keycloak workload to become ready roughly 4–5 minutes after install; the dev-mode store (`postgres` with `replicas: 1`) is ready in about 2 minutes.
+On a first install of the default HA stack, the Keycloak container waits for the PostgreSQL cluster to come up (logging `Waiting for PostgreSQL...`) before starting. A default install measured **303 seconds** from install to a ready workload, most of that spent waiting on the Patroni and etcd replicas; the dev-mode store (`postgres` with `replicas: 1`) is ready in about 2 minutes.
 </Note>
 
 ## Important Notes
 
-- **Change both default passwords before installing** — the admin bootstrap password and the database password. The bootstrap admin is temporary by design: log in, create a permanent admin, then remove it.
+- **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
+- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **The bootstrap admin is temporary by design** — log in, create a permanent admin, then remove it. Its credentials are seeded on first boot only; change the password in the admin console, not by editing the secret.
 - **Keep `publicAccess` enabled for browser SSO** — end-user browsers must reach Keycloak's login endpoints; disable it only for pure service-to-service deployments.
 - **Do not disable the HA proxy** (`postgresHA.proxy.enabled`) — Keycloak connects through the HAProxy leader endpoint for writes; the chart enforces this at render.
 - **Scaling is operator-driven** — change `replicas` via a template upgrade; there is deliberately no autoscaling, so cluster membership only changes intentionally.

--- a/template-catalog/templates/listmonk.mdx
+++ b/template-catalog/templates/listmonk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Listmonk
-description: Deploy listmonk on Control Plane using the Template Catalog. Self-hosted newsletter and mailing list manager — a Mailchimp alternative — with automatic schema install and admin bootstrap on first boot, persistent media uploads, public subscription pages, and a single-instance or highly available PostgreSQL backing store.
+description: Deploy listmonk on Control Plane using the Template Catalog. Self-hosted newsletter and mailing list manager — a Mailchimp alternative — with a prerequisite Super Admin secret, automatic schema install and admin bootstrap on first boot, persistent media uploads, public subscription pages, and a single-instance or highly available PostgreSQL backing store.
 keywords: ['listmonk', 'newsletter', 'mailing list manager', 'email marketing', 'mailchimp alternative', 'sendy alternative', 'mautic alternative', 'campaign management', 'subscriber lists', 'opt-in signup form', 'transactional email', 'smtp relay', 'self-hosted email']
 ---
 
@@ -19,8 +19,8 @@ Listmonk is a high-performance, self-hosted newsletter and mailing list manager 
 - **Stateful Listmonk Workload** — The listmonk server on port `9000`, one replica, with configurable CPU and memory.
 - **Database Workloads** — Single mode: one stateful PostgreSQL workload. HA mode: a stateful Patroni PostgreSQL workload, a stateful etcd workload, and a standard HAProxy leader-routing workload.
 - **Volume Sets** — A persistent uploads volume set mounted at `/listmonk/uploads` for media uploaded through the admin UI, plus the database subchart's data volumes (10 GiB by default; per replica in HA mode).
-- **Secret** — A dictionary secret holding the admin bootstrap username and password. The database credentials secret is created by the backing store subchart.
-- **Identity & Policy** — An identity bound to the listmonk workload, with a policy granting `reveal` on exactly two secrets: the admin bootstrap secret and the active backing store's credentials secret.
+- **Secrets** — The database credentials secret created by the backing store subchart. The Super Admin credentials are **not** created by this template: you create that dictionary secret yourself before installing and reference it by name (see [Prerequisites](#prerequisites)).
+- **Identity & Policy** — An identity bound to the listmonk workload, with a policy granting `reveal` on exactly two secrets: your admin credentials secret and the active backing store's credentials secret.
 - **Cron Backup Workload** *(optional)* — Created in the backing PostgreSQL store when database backups are enabled.
 
 <Note>
@@ -29,12 +29,66 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-None for a default install — it deploys with a working PostgreSQL backend, an installed schema, a bootstrapped admin account, and an auto-assigned HTTPS endpoint. Two things are configured after install rather than at install time:
+**One dictionary secret must exist before you install.** The Super Admin guards a login form on the public endpoint, so its credentials are a prerequisite secret rather than template values — a value would sit in plaintext in the Helm release for the life of the install. The template creates no admin secret of its own.
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `username` and `password`. Secrets are org-level, so no GVC flag is involved:
+
+    ```bash
+    cpln secret create-dictionary --name my-listmonk-admin \
+      --entry username=admin \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `admin.secretName` to the name you used.
+  </Step>
+  <Step title="Read the password back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-listmonk-admin -o yaml
+    ```
+  </Step>
+</Steps>
+
+| Key | What it is |
+|---|---|
+| `username` | The Super Admin's login name. **Minimum 3 characters** — an upstream requirement. |
+| `password` | Its password. **Minimum 8 characters.** The login form it guards is on the public endpoint. |
+
+<Warning>
+**A username or password below the minimum length is caught at startup, by design.** listmonk's own `--install` step fails on every attempt when either value is too short, and that step runs inside the container's database-wait loop — so before this check existed the only symptom was `waiting for database...` repeating forever, which sends you to debug a database that is perfectly healthy. The container now checks both lengths first and exits immediately with a message that names the secret to fix — measured firing **33 seconds** after install, with zero `waiting for database` lines:
+
+```text
+listmonk: the my-listmonk-admin secret must hold a username of at least 3 characters and a password
+of at least 8 (upstream install requirement)
+```
+</Warning>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** The install still exits 0 and reports success, every resource is created, and the workload then never starts. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-listmonk --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-listmonk-admin no longer exists. Workload updates are paused until
+the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery measured **9 minutes 31 seconds** here, within the 5.5 to 10.5 minute range seen across the catalog, so poll rather than giving up. `cpln workload force-redeployment RELEASE_NAME-listmonk --gvc GVC_NAME` shortcuts it to roughly 90 seconds.
+</Warning>
+
+Two more things are configured after install rather than at install time:
 
 - **SMTP** — required before any mail is delivered. Configured in listmonk's own admin UI (see [Post-Install Setup](#post-install-setup)).
 - **Database backups** *(optional)* — need a bucket and provider access set up beforehand (see [Backing Up](#backing-up)).
 
-Install the template using your preferred method:
+Once the admin secret exists, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -87,9 +141,13 @@ resources: # single Go binary — light footprint
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
 
+# REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. A `dictionary`
+# secret holding exactly two keys, `username` (min 3 chars) and `password`
+# (min 8 chars); the login form it guards sits on the public endpoint. The
+# Super Admin is created on FIRST install only — editing the secret later does
+# NOT update the account.
 admin:
-  username: admin                    # min 3 chars
-  password: change-me-listmonk-admin # min 8 chars — change before installing
+  secretName: my-listmonk-admin # name of your pre-created dictionary secret
 
 timezone: Etc/UTC # container TZ — governs campaign scheduling times
 
@@ -152,19 +210,19 @@ postgresHA: # durable HA: 3-replica Patroni store with an HAProxy leader endpoin
 
 ```yaml
 admin:
-  username: admin                    # min 3 chars
-  password: change-me-listmonk-admin # min 8 chars — change before installing
+  secretName: my-listmonk-admin # your pre-created dictionary secret (see Prerequisites)
 ```
 
-These become the Super Admin account created during the first boot's schema install, and are stored in the template-managed `{release}-listmonk-admin` dictionary secret. The chart rejects a username shorter than 3 characters or a password shorter than 8 at render time, before anything is deployed.
+- `admin.secretName` — Name of the dictionary secret you created in [Prerequisites](#prerequisites), holding the `username` and `password` of the Super Admin. The credentials never pass through values, and the template creates no secret of its own — it references yours and grants the workload `reveal` on exactly that one secret.
+- The account is created during the first boot's schema install, from the secret's contents. Because the values are no longer visible when the chart renders, the container enforces upstream's minimum lengths at startup instead — see the length warning in [Prerequisites](#prerequisites).
 
 <Warning>
-The Super Admin is created on the **first install only**. Afterwards the account lives in the database, and changing `admin.username` / `admin.password` in values does not update it. Set a strong password before you install; manage users afterwards in **Admin → Settings → Users**.
+The Super Admin is created on the **first install only**. Afterwards the account lives in the database, and editing the secret does not update it. Manage users afterwards in **Admin → Settings → Users**.
 </Warning>
 
 ### Access
 
-- `publicAccess.enabled` — Serve listmonk on the auto-assigned `*.cpln.app` HTTPS canonical endpoint (default). This is what makes the subscriber-facing pages — subscription forms, unsubscribe links, and tracking pixels — reachable from the internet. The admin UI and admin API on the same endpoint remain authentication-gated. Set to `false` for an internal-only instance: external requests are then refused at the edge, and in-GVC callers still reach it per `internalAccess`.
+- `publicAccess.enabled` — Serve listmonk on the auto-assigned `*.cpln.app` HTTPS canonical endpoint. It is **deliberately on by default** and load-bearing: the subscriber-facing pages — subscription forms, unsubscribe links, and tracking pixels — are served to your subscribers on the open internet, so a private instance cannot do the job. The admin UI and admin API on the same endpoint remain authentication-gated, behind a credential you created rather than a published default. Set to `false` for an internal-only instance: external requests are then refused at the edge, and in-GVC callers still reach it per `internalAccess`.
 - `internalAccess.type` — Controls which workloads can reach listmonk over the internal network:
 
 | Type | Description |
@@ -175,7 +233,7 @@ The Super Admin is created on the **first install only**. Afterwards the account
 | `workload-list` | Allow access only from workloads listed in `internalAccess.workloads`. |
 
 <Note>
-Firewall changes take up to a couple of minutes to propagate after a `helm upgrade` reports success.
+Firewall changes take roughly 30 seconds to a few minutes to propagate after an upgrade reports success — re-test rather than trusting the first response.
 </Note>
 
 ### Backing Store
@@ -188,6 +246,47 @@ The database holds everything except uploaded media: lists, subscribers, campaig
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, which is off by default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
 </Warning>
 
+## Upgrading From 1.0.x
+
+Version `1.1.0` moved the Super Admin login out of Helm values. Earlier versions shipped a username and a working password as values, used exactly as written — a published default guarding a login form on the public endpoint, sitting in the Helm release for the life of the install.
+
+| | `1.0.x` | `1.1.0` |
+|---|---|---|
+| Super Admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `username` and `password` |
+| Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
+| Minimum-length check | At render, from the values | At container startup, from the secret — with a message naming the secret |
+| Database password | A value (`postgres.config.password` / `postgresHA.postgres.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+
+<Warning>
+**An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+listmonk: admin.password was REMOVED in 1.1.0. Put it in a `dictionary` secret (key: `password`)
+together with `username`, and set admin.secretName to that secret's name. Create the secret BEFORE
+installing; see Prerequisites in the README.
+```
+
+Leaving `admin.secretName` empty is refused the same way.
+</Warning>
+
+<Note>
+**An existing install's Super Admin password does not change on upgrade.** The account was written to the database on the first install and `LISTMONK_ADMIN_*` is never read again, so the secret's contents only matter to a fresh install. Change the password in **Admin → Settings → Users**. If the install is still carrying the published `1.0.x` default (`change-me-listmonk-admin`), treat that password as compromised and change it now.
+</Note>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    Follow [Prerequisites](#prerequisites). Putting your current credentials in it keeps your values file honest, but it does not re-seed the account.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `admin.username` and `admin.password`, and set `admin.secretName` instead.
+  </Step>
+  <Step title="Upgrade">
+    The single replica stops before the new one starts, so expect a brief gap. Lists, subscribers, campaigns, and uploaded media are on the database and the uploads volume set, and are untouched.
+  </Step>
+</Steps>
+
 ## Connecting
 
 | What | Value |
@@ -198,11 +297,11 @@ The database holds everything except uploaded media: lists, subscribers, campaig
 | Health check | `https://<canonical>.cpln.app/health` — public and unauthenticated (`/api/health` requires a session) |
 | HTTP API | `https://<canonical>.cpln.app/api/...` — authenticated; lists, subscribers, campaigns, transactional mail |
 | Internal (same GVC) | `http://{release}-listmonk.{gvc}.cpln.local:9000` |
-| Admin credentials | The `admin.username` / `admin.password` values, stored in the `{release}-listmonk-admin` secret |
+| Admin credentials | The `username` / `password` in your `admin.secretName` secret — `cpln secret reveal my-listmonk-admin -o yaml` |
 | Database (single mode) | `{release}-postgres.{gvc}.cpln.local:5432` |
 | Database (HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432` (HAProxy leader endpoint) |
 
-Once the workload reports ready, open `https://<canonical>.cpln.app/admin` and sign in with the bootstrap credentials — the schema is already installed and the Super Admin already exists, so there is no setup wizard and no manual install step.
+A default install reaches ready in about a minute (**62 seconds** measured). Once the workload reports ready, open `https://<canonical>.cpln.app/admin` and sign in with the credentials from your admin secret — the schema is already installed and the Super Admin already exists, so there is no setup wizard and no manual install step.
 
 ## Post-Install Setup
 
@@ -275,7 +374,9 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 ## Important Notes
 
 - **Single instance by design — there is no `replicas` knob.** Listmonk runs its campaign workers in-process, so two instances against one database would send every campaign twice. The workload is pinned to one replica and rolls out without surge: the old replica stops before the new one starts, which means an upgrade or restart causes a brief gap in availability instead of overlapping senders. Durability comes from PostgreSQL and the uploads volume set.
-- **Change `admin.password` and the database password before installing.** Both are applied on the first boot only; editing them afterwards does not change the existing account or database.
+- **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
+- **Mind the minimum credential lengths** — a username under 3 characters or a password under 8 makes upstream's install step fail; the container catches this at startup and names the secret instead of looping on a misleading database message.
+- **Change the database password before installing** (`postgres.config.password` / `postgresHA.postgres.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design. Both the admin account and the database are seeded on first boot only.
 - **No mail is delivered until SMTP is configured** in **Admin → Settings → SMTP**. Before that, starting a campaign is not an error — it runs and finishes with zero messages sent.
 - **Keep `publicAccess` enabled for subscriber-facing pages to work.** Subscription forms, unsubscribe links, and tracking pixels must be reachable from the internet; the admin UI and API stay authentication-gated either way.
 - **Use `/health` for external health checks**, not `/api/health` — the latter requires an authenticated session.

--- a/template-catalog/templates/metabase.mdx
+++ b/template-catalog/templates/metabase.mdx
@@ -1,6 +1,6 @@
 ---
 title: Metabase
-description: Deploy Metabase on Control Plane using the Template Catalog. Open-source BI with dashboards, a SQL editor, and scheduled reports, backed by a highly available PostgreSQL app database. Covers the encryption-key prerequisite, database modes, first-boot admin setup, and backups.
+description: Deploy Metabase on Control Plane using the Template Catalog. Open-source BI with dashboards, a SQL editor, and scheduled reports, backed by a highly available PostgreSQL app database. Covers the prerequisite admin and encryption-key secrets, database modes, first-boot admin setup, and backups.
 keywords: ['business intelligence', 'data visualization', 'looker alternative', 'tableau alternative', 'power bi alternative', 'superset alternative', 'redash alternative', 'self-hosted', 'reporting', 'charts', 'sql questions', 'metabase template']
 ---
 
@@ -19,7 +19,7 @@ Metabase is an open-source business intelligence platform — dashboards, a SQL 
 - **Standard Metabase Workload** — A single stateless replica serving the UI and API on port `3000`.
 - **Database Workloads** — HA mode: a stateful Patroni PostgreSQL workload, a stateful etcd workload, and a standard HAProxy leader-routing workload. Single mode: one stateful PostgreSQL workload.
 - **Volume Sets** — The database subchart's persistent volumes (10 GiB per replica by default). Metabase itself has none.
-- **Secrets** — Admin bootstrap credentials, the start script that creates the admin account on first boot, and the database credentials from the subchart.
+- **Secrets** — The start script that creates the admin account on first boot, plus the database credentials from the subchart. The admin login and the encryption key are **not** created by this template: you create both secrets yourself before installing and reference them by name (see [Prerequisites](#prerequisites)).
 - **Identity & Policy** — A least-privilege policy granting the Metabase identity `reveal` on exactly the secrets it uses, including your pre-created encryption-key secret.
 - **Cron Backup Workload** *(optional)* — When database backups are enabled.
 
@@ -29,31 +29,78 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-Metabase encrypts the connection details of every data source you save with a key it reads from an [opaque secret](/guides/create-secret/opaque) that you create **before** installing. The key is never passed through values.
+**Two secrets must exist before you install.** Both hold credentials or long-lived key material, so neither passes through Helm values — a value would sit in plaintext in the release for the life of the install, and the admin login is on a public endpoint. The template creates neither of them.
 
 <Steps>
-  <Step title="Generate an encryption key">
-    Generate a random string of at least 16 characters, for example:
+  <Step title="Create the admin login secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `email` and `password`. Secrets are org-level, so no GVC flag is involved:
 
     ```bash
-    openssl rand -hex 24
+    cpln secret create-dictionary --name my-metabase-admin \
+      --entry email=admin@example.com \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `admin.secretName` to the name you used.
+  </Step>
+  <Step title="Create the encryption-key secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain` whose entire payload is a random string of at least 16 characters:
+
+    ```bash
+    printf '%s' "$(openssl rand -hex 24)" | cpln secret create-opaque --name my-metabase-encryption-key --encoding plain -f -
+    ```
+
+    Set `encryptionKey.secretName` to the name you used, and store a copy of the key somewhere safe outside Control Plane.
+  </Step>
+  <Step title="Read either secret back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-metabase-admin -o yaml
     ```
   </Step>
-  <Step title="Create an opaque secret">
-    Create an [opaque secret](/guides/create-secret/opaque) in your org with encoding `plain` whose payload is the generated key. Set its name in `encryptionKey.secretName`.
-  </Step>
-  <Step title="Back up the key">
-    Store a copy of the key somewhere safe, outside Control Plane.
-  </Step>
 </Steps>
+
+| Key in the admin secret | What it is |
+|---|---|
+| `email` | The admin account's login email. |
+| `password` | Its password. It must pass Metabase's own check — letters **and** digits, 8+ characters (the `openssl rand -hex` value above satisfies this). |
+
+<Warning>
+**Neither the email nor the password may contain a double quote (`"`) or a backslash (`\`).** Both values are embedded in the JSON body of the first-boot setup call, and either character breaks it. The container checks this at startup and refuses to run setup instead of sending a malformed request — measured firing **32 seconds** after install, with a log line that names the offending secret:
+
+```text
+cpln-bootstrap: ERROR: the email and password in the my-metabase-admin secret must not contain a
+double quote or a backslash — they are embedded in the first-boot setup API JSON body
+```
+
+The workload then stays unready and its public endpoint answers `503`, so a bad credential never results in a reachable, half-configured instance. Fix the secret's contents and redeploy.
+</Warning>
 
 <Warning>
 Losing or changing the encryption key means re-entering every saved database connection — Metabase can no longer decrypt them. Rotation is only possible offline, using Metabase's `rotate-encryption-key` command. Back the key up before installing.
 </Warning>
 
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** The install still exits 0 and reports success, every resource is created, and the workload then never starts. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-metabase --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-metabase-admin no longer exists. Workload updates are paused until
+the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery has measured between 5.5 and 10.5 minutes across the catalog, so poll rather than giving up. `cpln workload force-redeployment RELEASE_NAME-metabase --gvc GVC_NAME` shortcuts it to roughly 90 seconds.
+</Warning>
+
 For optional database backups, you also need a bucket and access setup for one of the supported providers — see [Backing Up](#backing-up).
 
-Once your encryption-key secret exists, install the template using your preferred method:
+Once both secrets exist, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -88,7 +135,11 @@ Exactly one of the two database modes must be enabled — the chart enforces thi
 | Footprint | 8 replicas across 3 workloads (3× Patroni, 3× etcd, 2× HAProxy) | 1 workload |
 | Best for | Production | Development and lightweight installs |
 
-A fresh HA-mode install takes roughly 10–15 minutes to fully converge; single mode is ready in about 2 minutes.
+A fresh HA-mode install takes roughly 10–15 minutes to fully converge; single mode is ready in about 2 minutes. Metabase itself reached ready **261 seconds** after a default HA install.
+
+<Note>
+For the first few minutes of an HA-mode install, the Metabase container may log Java stack traces (`An attempt by a client to checkout a Connection has timed out`) and restart while the Patroni cluster elects a leader. It resolves itself once the database is routable — the traces are not a failed install.
+</Note>
 
 ## Configuration
 
@@ -104,13 +155,18 @@ resources:
   minMemory: 1Gi
 
 encryptionKey:
-  secretName: my-metabase-encryption-key # name of your pre-created opaque secret (see Prerequisites)
+  secretName: my-metabase-encryption-key # name of your pre-created opaque secret
 
-admin: # admin account, created automatically on first boot
-  email: admin@example.com # admin login email
+# Admin account, created automatically on first boot (no public /setup window).
+# REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. A `dictionary`
+# secret holding exactly two keys, `email` and `password`; the login form it
+# guards sits on the public endpoint. The password must satisfy Metabase's own
+# check (letters + digits, 8+ chars), and neither value may contain a double
+# quote or a backslash — both are embedded in the first-boot setup API call.
+admin:
+  secretName: my-metabase-admin # name of your pre-created dictionary secret
   firstName: Metabase
   lastName: Admin
-  password: change-me-metabase-1 # change before installing; letters + digits, 8+ chars
 
 siteName: Metabase # instance name shown in the UI and emails
 
@@ -198,12 +254,14 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 - `image` — The Metabase open-source container image.
 - `resources` — CPU and memory for the Metabase container. The template caps the JVM at 75% of the container memory limit (`JAVA_OPTS: -XX:MaxRAMPercentage=75.0`), so raising `resources.memory` also raises the Java heap. The 2 GiB default is sized for the JVM — lowering it is not recommended.
 - `encryptionKey.secretName` — Name of your pre-created opaque secret holding the key that encrypts saved data-source credentials. See [Prerequisites](#prerequisites).
-- `admin.*` — The admin account, created automatically on first boot against the local setup API. There is no unauthenticated setup page at any point: the workload only becomes ready — and only starts receiving traffic — once setup is complete, and if setup fails it never becomes ready at all (fail-closed). **Change `admin.password` before installing** — it must pass Metabase's complexity check (letters + digits, 8+ characters), and none of the `admin.*` values may contain double quotes or backslashes (enforced at render). The account is created exactly once, on first boot — changing these values later does not modify the existing account.
+- `admin.secretName` — Name of the dictionary secret you created in [Prerequisites](#prerequisites), holding the `email` and `password` of the admin account. The credentials never pass through values; the template references your secret and grants the workload `reveal` on exactly it.
+- `admin.firstName` / `admin.lastName` — The admin's display name. These are ordinary values (not credentials) and, like the secret's contents, may not contain double quotes or backslashes — these two are checked at render.
+- The account is created automatically on first boot against the local setup API, so there is no unauthenticated setup page at any point: the workload only becomes ready — and only starts receiving traffic — once setup is complete, and if setup fails it never becomes ready at all (fail-closed). Setup runs exactly once; editing the secret afterwards does not modify the existing account, so change the password in the Metabase UI instead.
 - `siteName` — The instance name shown in the UI and in emails Metabase sends.
 
 ### Access
 
-- `publicAccess.enabled` — Serve the UI and API on the canonical `*.cpln.app` HTTPS endpoint (default). Everything behind the endpoint is gated by Metabase's own login. Set to `false` for an internal-only instance (external requests are blocked at the edge; in-GVC callers still reach it per `internalAccess`).
+- `publicAccess.enabled` — Serve the UI and API on the canonical `*.cpln.app` HTTPS endpoint. It is **deliberately on by default**: Metabase is a browser tool people open directly, everything behind the endpoint is gated by its own login, and that login is now a credential you created rather than a published default. Set to `false` for an internal-only instance (external requests are blocked at the edge; in-GVC callers still reach it per `internalAccess`). A firewall change takes roughly 30 seconds to a few minutes to propagate, so re-test rather than trusting the first response.
 - `internalAccess.type` — Internal firewall scope of the Metabase workload:
 
 | Type | Description |
@@ -221,13 +279,55 @@ Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/ligh
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
 </Warning>
 
+## Upgrading From 1.0.x
+
+Version `1.1.0` moved the admin login out of Helm values. Earlier versions shipped an email and a working password as values, used exactly as written — a published default guarding a login form on the public endpoint, sitting in the Helm release for the life of the install.
+
+| | `1.0.x` | `1.1.0` |
+|---|---|---|
+| Admin login | `admin.email` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `email` and `password` |
+| Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
+| `admin.firstName` / `admin.lastName` / `siteName` | Values | Unchanged |
+| `encryptionKey.secretName` | Prerequisite opaque secret | Unchanged |
+| Database password | A value (`postgresHA.postgres.password` / `postgres.config.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+
+<Warning>
+**An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+metabase: admin.password was REMOVED in 1.1.0. Put it in a `dictionary` secret (key: `password`)
+together with `email`, and set admin.secretName to that secret's name. Create the secret BEFORE
+installing; see Prerequisites in the README.
+```
+
+Leaving `admin.secretName` empty is refused the same way.
+</Warning>
+
+<Note>
+**An existing install's admin password does not change on upgrade.** The account already lives in the app database and first-boot setup never runs again, so the secret's contents only matter to a fresh install. Change the password in the Metabase UI (account settings). If the install is still carrying the published `1.0.x` default (`change-me-metabase-1`), treat that password as compromised and change it now.
+</Note>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the admin login secret">
+    Follow [Prerequisites](#prerequisites). Your existing encryption-key secret stays exactly as it is.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `admin.email` and `admin.password`, and set `admin.secretName` instead. Leave `admin.firstName`, `admin.lastName`, and `siteName` alone.
+  </Step>
+  <Step title="Upgrade">
+    The single Metabase replica restarts; questions, dashboards, and users are in the app database and are untouched.
+  </Step>
+</Steps>
+
 ## Connecting
 
 | What | Value |
 |---|---|
 | UI / API (public) | `https://<canonical>.cpln.app` — `status.canonicalEndpoint` of `{release}-metabase` |
 | Internal (same GVC) | `http://{release}-metabase.{gvc}.cpln.local:3000` |
-| Login | `admin.email` / `admin.password` |
+| Login | The `email` / `password` in your `admin.secretName` secret — `cpln secret reveal my-metabase-admin -o yaml` |
 | App database (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
 | App database (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
 
@@ -304,7 +404,9 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 ## Important Notes
 
 - **Back up the encryption-key secret** — losing or changing it means re-entering every saved database connection; rotation is only possible offline via Metabase's `rotate-encryption-key` command.
-- **Change `admin.password` and the database password** (`postgresHA.postgres.password` / `postgres.config.password`) before installing. An admin password that fails Metabase's complexity check (letters + digits, 8+ characters) keeps the workload unready by design.
+- **Create both prerequisite secrets before installing** — a missing one leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
+- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **A weak or malformed admin password keeps the workload unready by design** — Metabase's own check requires letters and digits, 8+ characters, and the container refuses to run setup if the email or password contains a double quote or a backslash. A failed bootstrap is fail-closed rather than exposing an open setup page.
 - **Metabase is single-replica in this template** — the default HA PostgreSQL backend removes the database as a failure point.
 - **Upgrades restart the single replica** — expect a few minutes of UI downtime per Helm upgrade; the HA app database keeps running and no data is lost.
 - **Uninstall deletes the app-database volume sets** — all questions, dashboards, and users. Enable backups if the data matters.

--- a/template-catalog/templates/n8n.mdx
+++ b/template-catalog/templates/n8n.mdx
@@ -1,26 +1,33 @@
 ---
 title: n8n
-description: Deploy n8n on Control Plane using the Template Catalog. Workflow automation backed by a highly available PostgreSQL cluster. Covers the encryption-key prerequisite, database modes, webhooks on the canonical endpoint, and database backups.
-keywords: ['zapier alternative', 'make alternative', 'ipaas', 'no-code', 'low-code', 'self-hosted', 'fair-code', 'integration platform', 'api orchestration', 'scheduled triggers', 'webhook automation', 'n8n template']
+description: Deploy n8n on Control Plane using the Template Catalog. Workflow automation backed by a highly available PostgreSQL cluster. Covers the two prerequisite secrets — the owner login as a bcrypt hash and the credential-encryption key — plus database modes, webhooks on the canonical endpoint, and database backups.
+keywords: ['zapier alternative', 'make alternative', 'ipaas', 'no-code', 'low-code', 'self-hosted', 'fair-code', 'integration platform', 'api orchestration', 'scheduled triggers', 'webhook automation', 'n8n template', 'prerequisite secret', 'bcrypt hash', 'htpasswd']
 ---
 
 ## Overview
 
 n8n is a workflow automation platform (fair-code, distributed under the [Sustainable Use License](https://docs.n8n.io/sustainable-use-license/)). This template deploys an n8n instance backed by a highly available PostgreSQL cluster by default. The editor, REST API, and webhook endpoints are served on one public HTTPS endpoint, and the instance owner account is pre-provisioned at install — there is never an unauthenticated setup page.
 
+Both the owner login and the credential-encryption key come from secrets you create **before** installing. Neither passes through Helm values, which matters here because the n8n login form sits on a public endpoint by default.
+
+<Warning>
+**Upgrading an install created with `1.0.0` or `1.0.1` is a breaking change, and it can change the password you log in with.** `owner.email` and `owner.password` no longer exist; the owner now comes from a dictionary secret holding `email` and a **bcrypt hash** of the password. Because n8n re-applies the owner from that secret on **every start**, hashing a *new* password during the upgrade silently replaces your current login. Hash the password you are already using. See [Upgrading From 1.0.x](#upgrading-from-1-0-x).
+</Warning>
+
 ### Architecture
 
 - **n8n** — A single-replica stateful workload serving the editor, REST API, and webhooks on port `5678`. Public URLs are derived from the canonical endpoint at start, so webhook URLs work out of the box.
 - **PostgreSQL (HA, default)** — The [postgres-highly-available](/template-catalog/templates/postgres-highly-available) template as a subchart: 3× Patroni PostgreSQL, 3× etcd, and a HAProxy leader-routing endpoint n8n connects through.
 - **PostgreSQL (dev/lightweight, optional)** — The single-instance [postgres](/template-catalog/templates/postgres) template instead, for lighter non-HA deployments.
+- **Owner managed from a secret** — The owner account is applied from your prerequisite secret at every start, so n8n never opens an unauthenticated setup page and the account cannot be edited from inside the app.
 
 ### What Gets Created
 
 - **Stateful n8n Workload** — Single replica serving the editor, API, and webhooks on port `5678`.
 - **Database Workloads** — HA mode: a stateful Patroni PostgreSQL workload, a stateful etcd workload, and a standard HAProxy leader-routing workload. Single mode: one stateful PostgreSQL workload.
 - **Volume Sets** — 10 GiB persistent storage for n8n instance config and binary execution data (`/home/node/.n8n`), plus the database subchart's own volume sets.
-- **Secrets** — Owner bootstrap credentials (bcrypt-hashed), a start script that derives public URLs at runtime, and the database credentials from the subchart.
-- **Identity & Policy** — A least-privilege policy granting the n8n identity `reveal` on exactly the secrets it uses, including your pre-created encryption-key secret.
+- **Secrets** — A start-script secret that derives public URLs at runtime, plus the database credentials created by the subchart. The owner login and the encryption key are **not** created here — they live in the two secrets you create.
+- **Identity & Policy** — A least-privilege policy granting the n8n identity `reveal` on exactly the secrets it uses, including your two pre-created secrets.
 - **Cron Backup Workload** *(optional)* — When database backups are enabled.
 
 <Note>
@@ -29,31 +36,84 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-n8n encrypts every credential it stores with a key it reads from an [opaque secret](/guides/create-secret/opaque) that you create **before** installing. The key is never passed through values.
+**Two secrets must exist before you install.** Secrets are org-level, so no GVC flag is involved.
 
 <Steps>
-  <Step title="Generate an encryption key">
-    Generate a long random string, for example:
+  <Step title="Create the encryption key secret">
+    An [opaque secret](/guides/create-secret/opaque) with encoding `plain` whose payload is a long random key. n8n encrypts every credential it stores with it:
 
     ```bash
-    openssl rand -hex 24
+    printf '%s' "$(openssl rand -hex 24)" | \
+      cpln secret create-opaque --name my-n8n-encryption-key --encoding plain -f -
+    ```
+
+    Set `encryptionKey.secretName` to the name you used, and store a copy of the key somewhere safe outside Control Plane.
+  </Step>
+  <Step title="Hash the owner password">
+    n8n accepts only a **bcrypt hash** for the owner password, never plaintext, so hash it first. `htpasswd -B` emits the `$2y$` form, which n8n accepts:
+
+    ```bash
+    OWNER_HASH=$(htpasswd -bnBC 10 "" 'your-owner-password' | tr -d ':\n')
     ```
   </Step>
-  <Step title="Create an opaque secret">
-    Create an [opaque secret](/guides/create-secret/opaque) in your org with encoding `plain` whose payload is the generated key. Set its name in `encryptionKey.secretName`.
+  <Step title="Create the owner secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `email` and `passwordHash`:
+
+    ```bash
+    cpln secret create-dictionary --name my-n8n-owner \
+      --entry email=admin@example.com \
+      --entry passwordHash="$OWNER_HASH"
+    ```
+
+    Set `owner.secretName` to the name you used.
+
+    | Key | What it is |
+    |---|---|
+    | `email` | The instance owner's login email. |
+    | `passwordHash` | A bcrypt hash of the owner password. Its `$` characters survive the round trip into the container intact — verified byte for byte on a live deployment. |
   </Step>
-  <Step title="Back up the key">
-    Store a copy of the key somewhere safe, outside Control Plane.
+  <Step title="Read a secret back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-n8n-owner -o yaml
+    ```
   </Step>
 </Steps>
+
+<Warning>
+**The owner is re-applied from the secret on every start** (`N8N_INSTANCE_OWNER_MANAGED_BY_ENV`). Two consequences, both measured on a live instance:
+
+- **Editing the secret and restarting the workload is how you rotate the password.** After a rotation, the old password returned `401` and the new one `200`.
+- **The account cannot be changed from inside n8n.** A password change through the API is refused with `403 This account is managed via environment variables and cannot be modified through the API`.
+
+So whatever is in the secret *is* the login, at every restart. Put the password you actually want there.
+</Warning>
 
 <Warning>
 Losing the encryption key makes every credential n8n has stored permanently undecryptable, and the key must never change after first boot — n8n fails to start on a key mismatch. Back it up before installing.
 </Warning>
 
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, the resources are created, and the workload then never starts. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-n8n --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-n8n-owner no longer exists. Workload updates are
+paused until the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery across the catalog has been measured between **5.5 and 10.5 minutes**, so poll rather than time-boxing it. A forced redeployment shortcuts it to roughly 90 seconds.
+</Warning>
+
 For optional database backups, you also need a bucket and access setup for one of the supported providers — see [Backing Up](#backing-up).
 
-Once your encryption-key secret exists, install the template using your preferred method:
+Once both secrets exist, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -77,6 +137,47 @@ Once your encryption-key secret exists, install the template using your preferre
     </Card>
 </CardGroup>
 
+## Upgrading From 1.0.x
+
+Version `1.1.0` moved the instance owner out of Helm values. `1.0.0` and `1.0.1` shipped the owner's email and password as values, used exactly as written, guarding a login form that is public by default.
+
+| | `1.0.0` / `1.0.1` | `1.1.0` |
+|---|---|---|
+| Owner login | `owner.email` and `owner.password` values | `owner.secretName` — a dictionary secret you create with `email` and `passwordHash` |
+| Password format | Plaintext | **Bcrypt hash** — n8n rejects plaintext |
+| Encryption key | `encryptionKey.secretName` prerequisite secret | Unchanged |
+| `owner.firstName` / `owner.lastName` | Values | Unchanged; still values |
+
+<Warning>
+**This is the one upgrade in this batch that can change your password.** Everywhere else, an existing credential keeps working untouched. Here it does not: n8n re-applies the owner from the secret at every start, so the hash you put in the secret becomes the login the moment the workload restarts. **Hash the password you are using today**, not a new one — unless changing it is what you intend.
+</Warning>
+
+<Warning>
+**A `helm upgrade` that still carries either removed key is rejected before anything is applied.** A real `cpln helm upgrade` carrying the old keys failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+n8n: owner.password was removed in 1.1.0. Put a BCRYPT HASH of it in the prerequisite dictionary
+secret named by owner.secretName (key: passwordHash) — hash the password you are using today to
+keep the same login.
+```
+
+Leaving `owner.secretName` empty is refused the same way.
+</Warning>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the owner secret">
+    Follow [Prerequisites](#prerequisites), hashing **the password you log in with today** so the login does not change.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `owner.email` and `owner.password`, and set `owner.secretName` instead. Leave `encryptionKey.secretName`, `owner.firstName`, and `owner.lastName` exactly as they are.
+  </Step>
+  <Step title="Upgrade">
+    The single replica restarts and the editor and webhooks are briefly unavailable — see [Important Notes](#important-notes). Workflows, credentials, and execution data on the volume set are untouched.
+  </Step>
+</Steps>
+
 ## Choosing a Database Mode
 
 Exactly one of the two database modes must be enabled — the chart enforces this at render and fails the install with a clear message otherwise.
@@ -96,19 +197,18 @@ The default `values.yaml` for this template:
 image: n8nio/n8n:2.29.8
 
 resources:
-  cpu: 1000m
-  memory: 1Gi
   minCpu: 250m
   minMemory: 512Mi
+  maxCpu: 1000m
+  maxMemory: 1Gi
 
 encryptionKey:
   secretName: my-n8n-encryption-key # name of your pre-created opaque secret (see Prerequisites)
 
-owner: # instance owner, created automatically on first boot
-  email: admin@example.com # owner login email
+owner: # instance owner, re-applied from the secret on every start
+  secretName: my-n8n-owner # name of your pre-created dictionary secret (see Prerequisites)
   firstName: Instance
   lastName: Owner
-  password: change-me-n8n-owner # change before installing
 
 timezone: UTC # IANA timezone for Schedule triggers and $now
 
@@ -197,9 +297,10 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 ### n8n Instance
 
 - `image` — The n8n container image.
-- `resources` — CPU and memory for the n8n container.
+- `resources` — CPU and memory for the n8n container. `minCpu` / `minMemory` are the reservation; `maxCpu` / `maxMemory` are the limit.
 - `encryptionKey.secretName` — Name of your pre-created opaque secret holding the credential-encryption key. See [Prerequisites](#prerequisites).
-- `owner.*` — The instance owner account, created automatically on first boot. Because the owner is managed through the environment, there is no unauthenticated setup page at any point. **Change `owner.password` before installing.** To rotate it later, change the value and run a Helm upgrade — the new password takes effect on the restart.
+- `owner.secretName` — Name of your pre-created dictionary secret holding `email` and `passwordHash`. The owner is re-applied from it on every start, so editing the secret and restarting the workload is how you rotate the login — and the account cannot be edited from inside n8n. See [Prerequisites](#prerequisites).
+- `owner.firstName` / `owner.lastName` — Display name for the owner account. These remain ordinary values; only the email and password moved into the secret.
 - `timezone` — IANA timezone applied to Schedule triggers and `$now` expressions (e.g. `America/Chicago`).
 - `volumeset.capacity` — Volume size in GiB (minimum 10) for instance config and binary execution data.
 
@@ -231,7 +332,7 @@ Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/ligh
 | Production webhooks | `https://<canonical>.cpln.app/webhook/<path>` |
 | Test webhooks | `https://<canonical>.cpln.app/webhook-test/<path>` |
 | Internal (same GVC) | `http://{release}-n8n.{gvc}.cpln.local:5678` |
-| Login | `owner.email` / `owner.password` |
+| Login | The `email` and the password behind `passwordHash` in your `owner.secretName` secret |
 | PostgreSQL (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
 | PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
 
@@ -312,9 +413,12 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 ## Important Notes
 
 - **Back up the encryption-key secret** — losing it permanently bricks every credential n8n has stored; never change it after first boot (n8n fails to start on a key mismatch).
-- **Change `owner.password` and the database password** (`postgresHA.postgres.password` / `postgres.config.password`) before installing.
+- **Create both prerequisite secrets before installing.** A missing one wedges the deployment with no log output at all; [Prerequisites](#prerequisites) gives the one command that diagnoses it.
+- **The owner secret is authoritative at every restart** — it is not a one-time bootstrap. Changing it changes the login; see [Upgrading From 1.0.x](#upgrading-from-1-0-x).
+- **Change the bundled database password** (`postgresHA.postgres.password` / `postgres.config.password`) before installing — it is used exactly as written. It stays a value deliberately: it is internal plumbing between n8n and its own database that nobody types.
 - **The n8n main instance is single-replica by upstream design** — the default HA PostgreSQL backend removes the database as a failure point.
-- **Upgrades restart the single replica** — expect roughly a minute of editor/webhook downtime per Helm upgrade.
+- **Upgrades restart the single replica** — expect roughly a minute of editor/webhook downtime per Helm upgrade. The first upgrade after an install also re-applies the bundled database, which can add a couple of minutes.
+- **Access changes take time to propagate** — after toggling `publicAccess` or `internalAccess`, re-test over roughly 30 seconds to 5 minutes before concluding the knob is broken.
 - **Synchronous webhook responses must finish within 30 seconds** — see [Webhooks](#webhooks).
 - **Uninstall deletes the database and n8n volume sets** — all workflows, credentials, and execution data. Enable backups if the data matters.
 - **n8n is fair-code under the Sustainable Use License** — free to self-host, but not OSI open source.

--- a/template-catalog/templates/redpanda.mdx
+++ b/template-catalog/templates/redpanda.mdx
@@ -1,28 +1,95 @@
 ---
 title: Redpanda
-description: Deploy a Kafka-compatible Redpanda streaming cluster on Control Plane. Covers SASL authentication, Schema Registry, Redpanda Console, external TLS access with per-replica SNI routing, and broker tuning.
-keywords: ['redpanda', 'kafka', 'kafka-compatible', 'event streaming', 'schema registry', 'sasl', 'scram', 'pandaproxy', 'redpanda console', 'message queue', 'streaming platform']
+description: Deploy a Kafka-compatible Redpanda streaming cluster on Control Plane. Covers the prerequisite SASL credential secrets, the console that has no login and is closed by default, the unauthenticated broker Admin API, Schema Registry, topic-data snapshots, external TLS access, and upgrading from template version 1.0.x.
+keywords: ['redpanda', 'kafka', 'kafka-compatible', 'event streaming', 'schema registry', 'sasl', 'scram', 'pandaproxy', 'redpanda console', 'rpk', 'message queue', 'streaming platform', 'port forward']
 ---
 
 ## Overview
 
 Redpanda is a Kafka-compatible streaming platform written in C++. It implements the Kafka wire protocol natively, so any Kafka client, SDK, or tool works without modification. This template deploys a stateful Redpanda broker cluster with SASL authentication, Schema Registry, an optional HTTP REST proxy, and an optional web console.
 
+SASL credentials are not template values. Each user comes from a dictionary secret you create before installing, so the credentials never pass through Helm and never land in the release. The console ships **closed to the internet**, because the build shipped here has no login of its own.
+
+<Warning>
+**Template version 1.1.0 is a breaking change.** `redpanda.auth.users[].username` and `redpanda.auth.users[].password` were removed in favour of `credentialsSecretName`, and the console's public firewall rule is no longer set. An install that still sets the old keys fails at render. See [Upgrading From Earlier Versions](#upgrading-from-earlier-versions).
+</Warning>
+
 ### What Gets Created
 
-- **Stateful Redpanda Workload** — A multi-replica broker cluster using the Seastar async runtime. Each broker gets its own persistent volume.
-- **Standard Redpanda Console Workload** *(optional, enabled by default)* — Web UI for browsing topics, inspecting messages, managing consumer groups, and viewing Schema Registry schemas.
-- **Volume Set** — One persistent volume per broker replica for data storage.
-- **Identity & Policy** — An identity bound to the workloads with `reveal` access to credential secrets.
-- **Secrets** — A dictionary secret holding SASL user credentials injected at startup.
+- **Stateful Redpanda Workload** — (`RELEASE_NAME-cluster`): 1, 3, or 5 brokers forming a Raft quorum, each with its own persistent volume. The container assembles `/etc/redpanda/redpanda.yaml` from the injected credentials at boot.
+- **Standard Redpanda Console Workload** *(optional, enabled by default)* — (`RELEASE_NAME-console`): the web UI for browsing topics, inspecting messages, managing consumer groups, and viewing Schema Registry schemas.
+- **Volume Set** — (`RELEASE_NAME-data`): one block volume per broker holding the topic data directory, with platform-managed snapshots.
+- **Startup-Script Secrets** — One opaque secret per workload holding the script that assembles the broker and console configuration files at boot. The template creates **no credential secret of its own**.
+- **Identity & Policy** — An identity bound to the workloads and a policy granting it `reveal` on exactly the script secrets plus each SASL credentials secret you named.
+- **Domain** *(optional)* — Created only when external Kafka access or a console domain is configured.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Upgrading From Earlier Versions
+
+Template version 1.0.x took each SASL user's username and password as plain Helm values and shipped a working default for the superuser, and it published the console to `0.0.0.0/0`. Both changed in 1.1.0.
+
+| 1.0.x | 1.1.0 |
+|---|---|
+| `redpanda.auth.users[].username` | `username` key of the dictionary secret named by `credentialsSecretName` |
+| `redpanda.auth.users[].password` | `password` key of the same secret |
+| `redpanda_console.firewall.external_inboundAllowCIDR: "0.0.0.0/0"` | not set — the console is closed to the internet |
+
+Each removed key is rejected at render with a message naming its replacement, so a failing upgrade leaves the running release untouched.
+
+- **Create the secret with the username and password the cluster already uses.** SASL users live in the cluster's own metadata on disk, so changing this value does **not** change the password of an existing cluster — it only changes what the internal clients present, and a mismatch means they can no longer authenticate. Rotate a real user with `rpk security user update` and update the secret to match.
+- **The console's public URL now returns `403`.** Reach it with `cpln port-forward` (see [Redpanda Console](#redpanda-console)), or set `redpanda_console.firewall.external_inboundAllowCIDR` back explicitly — knowing the UI has no login at all.
+
 ## Prerequisites
 
-This template has no external prerequisites. To install, follow the instructions for your preferred method:
+**One secret per SASL user must exist before you install.** Every entry in `redpanda.auth.users` names a dictionary secret holding `username` and `password`. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the superuser credentials secret">
+    The **first** entry in `redpanda.auth.users` is the cluster superuser: the console, the Schema Registry client and (when enabled) the HTTP Proxy all authenticate to the brokers as it.
+
+    ```bash
+    cpln secret create-dictionary \
+      --name my-redpanda-admin-credentials \
+      --entry username=admin \
+      --entry password='CHOOSE-A-STRONG-PASSWORD'
+    ```
+
+    Set `redpanda.auth.users[0].credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Add one secret per additional user">
+    Create another dictionary secret in the same shape for each extra SASL user, and add one `credentialsSecretName` entry per secret. Each additional user starts with no ACLs, so it can authenticate but cannot read or write anything until you grant it access.
+  </Step>
+  <Step title="Read a secret back later">
+    The `-o yaml` is required — plain `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-redpanda-admin-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**Use `printf`, not `echo`, if you pipe a generated password in from elsewhere.** `echo` appends a newline, which Redpanda cannot carry in a config value. The startup script detects that and fails with a message naming the secret and key, rather than starting a cluster that rejects every login. Passwords containing quotes, colons and braces are handled correctly.
+</Warning>
+
+<Warning>
+**Create the secrets before installing.** A name pointing at a secret that does not exist installs "successfully" and then wedges: every resource reports created, the workload never becomes ready, and **`cpln logs` returns zero lines** because no container ever starts. The only diagnostic is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-cluster --gvc GVC_NAME -o yaml
+```
+
+It names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.` The command is `get-deployments` — plain `cpln workload get` has no `versions` key at all. Creating the secret recovers the workload on its own: **poll for 5.5 to 10.5 minutes rather than time-boxing it.** `cpln workload force-redeployment RELEASE_NAME-cluster --gvc GVC_NAME` cuts that to roughly 90 seconds.
+</Warning>
+
+Nothing else is required for a default install. Exposing the brokers over the internet additionally needs a domain you control and a dedicated load balancer — see [External Access](#external-access).
+
+## Installation
+
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -62,23 +129,34 @@ redpanda:
   memory: 4Gi
   minCpu: 500m
   minMemory: 2Gi
-  smp: 1           # Seastar reactor threads — must match the floor of your cpu limit
-  reserveMemory: 1G # memory reserved for the OS; Redpanda uses (memory - reserveMemory)
+  # smp: number of Seastar reactor threads — must match the container's vCPU count (floor of cpu limit).
+  # Without this, Seastar uses all node CPUs and divides memory across them, starving each shard.
+  smp: 1
+  # reserveMemory: memory set aside for the OS; Redpanda uses (memory - reserveMemory).
+  reserveMemory: 1G
 
   volume:
-    initialCapacity: 10 # In GiB
-    performanceClass: general-purpose-ssd # or high-throughput-ssd (min 200 GiB)
+    initialCapacity: 10 # In GB
+    performanceClass: general-purpose-ssd # For production workloads, switch to high-throughput-ssd (min 200GB) for higher IOPS
     fileSystemType: xfs # xfs / ext4
+    # Platform-managed snapshots of the topic data. Topic data is the only durable
+    # state this template holds, and nothing else backs it up.
+    snapshots:
+      createFinalSnapshot: true # take a snapshot when the volume set is deleted
+      retentionDuration: 7d # how long each snapshot is kept
+      schedule: 0 0 * * * # cron in UTC; "" disables scheduled snapshots
     # customEncryption:
     #   enabled: true
     #   region: aws-us-east-2
     #   keyId: arn:aws:kms:us-east-2:1234567890:key/your-key-id
 
+  # To disable all traffic, comment out the corresponding rule. Docs: https://docs.controlplane.com/concepts/security#firewall
   firewall:
     internal_inboundAllowType: "same-gvc" # Options: same-org / same-gvc
     # external_inboundAllowCIDR: 0.0.0.0/0
     # inboundAllowWorkload:
     #   - //gvc/my-gvc/workload/my-app
+    # external_outboundAllowCIDR: "0.0.0.0/0"
 
   listeners:
     kafka:
@@ -88,6 +166,7 @@ redpanda:
       #   directReplicaRouting:
       #     containerPort: 9094
       #     publicAddress: redpanda.example.com
+      # Uncomment to enable external Kafka access over TLS via a public domain.
 
     adminApi:
       port: 9644
@@ -99,25 +178,35 @@ redpanda:
       enabled: false
       port: 8082
 
+  # ─── SASL authentication ───────────────────────────────────────────────────
   auth:
     saslMechanism: SCRAM-SHA-256 # SCRAM-SHA-256 / SCRAM-SHA-512
+    # Each entry names a `dictionary` secret holding the keys `username` and `password`.
+    #
+    # EVERY SECRET LISTED HERE MUST EXIST BEFORE YOU INSTALL — a missing secret wedges
+    # the deployment silently and `cpln logs` returns nothing at all. See Prerequisites
+    # in the README for the exact commands and for how to diagnose a wedged deployment.
+    #
+    # The FIRST entry is the cluster superuser: the console, the Schema Registry client
+    # and (when enabled) the HTTP Proxy all authenticate to the brokers as it.
     users:
-      - username: admin
-        password: "your-admin-password"
-      # - username: your-app-user
-      #   password: "your-app-password"
+      - credentialsSecretName: my-redpanda-admin-credentials
+      # - credentialsSecretName: my-redpanda-app-credentials
+    # Extra usernames to grant superuser rights, for users created outside this chart.
     superusers: []
 
   acl:
     allowEveryoneIfNoAclFound: false
 
   secrets:
-    cluster_id: ""  # leave empty to auto-generate; set explicitly to preserve identity across reinstalls
+    # Leave empty to auto-generate on first boot. Set explicitly to preserve identity across reinstalls.
+    cluster_id: ""
 
   extra_configurations: {}
     # auto_create_topics_enabled: false
     # log_retention_ms: 604800000
     # log_segment_size: 134217728
+    # log_retention_bytes: -1
 
 redpanda_console:
   enabled: true
@@ -128,27 +217,42 @@ redpanda_console:
   minCpu: 50m
   minMemory: 64Mi
   replicas: 1
-  # domain: console.your-domain.com
+  timeoutSeconds: 30
+  # domain: console.example.com
+  # The console has NO LOGIN of its own — authentication and RBAC are Redpanda
+  # Enterprise features, so in this build every visitor shares the console's own
+  # SASL superuser session. External inbound is therefore CLOSED by default; reach
+  # the UI with `cpln port-forward <console-workload> 8080:8080 --gvc <gvc>`.
+  # Uncommenting external_inboundAllowCIDR publishes an unauthenticated Kafka admin
+  # UI to the whole internet. Docs: https://docs.controlplane.com/concepts/security#firewall
   firewall:
-    external_inboundAllowCIDR: "0.0.0.0/0"
+    # internal_inboundAllowType: "same-gvc"
+    # external_inboundAllowCIDR: "0.0.0.0/0"
+    external_outboundAllowCIDR: "0.0.0.0/0"
 ```
 
 ### Cluster Size and Resources
 
-- `redpanda.replicas` — Number of broker replicas. A minimum of 3 is recommended for production to ensure Raft quorum.
-- `redpanda.cpu` / `redpanda.memory` — Maximum CPU and memory per broker.
-- `redpanda.minCpu` / `redpanda.minMemory` — Minimum guaranteed CPU and memory per broker.
-- `redpanda.smp` — Number of Seastar reactor threads. Must match the floor of `cpu` (e.g., `cpu: 1500m` → `smp: 1`, `cpu: 3` → `smp: 3`). Without this, Seastar uses all node CPUs and incorrectly divides memory across them.
-- `redpanda.reserveMemory` — Memory set aside for the OS. Redpanda uses `(memory - reserveMemory)` for its own heap. Default `1G` works for most configurations.
+- `redpanda.name` — Suffix of the broker workload name, which is `RELEASE_NAME-{name}`.
+- `redpanda.replicas` — Number of brokers. Must be `1`, `3`, or `5`: an even count cannot form a Raft quorum and is rejected at install. Changing it changes cluster membership, so treat it as a deliberate operation.
+- `redpanda.cpu` / `redpanda.memory` — Limit per broker. `redpanda.minCpu` / `redpanda.minMemory` — reservation per broker. The shipped ratio is 3:1; if you raise `cpu`, raise `minCpu` with it, because a stateful workload rejects a CPU-to-reservation ratio above 4:1.
+- `redpanda.smp` — Number of Seastar reactor threads. It must match the floor of the CPU limit (`cpu: 1500m` → `smp: 1`). Without it, Seastar uses all node CPUs and divides memory across them, starving each shard.
+- `redpanda.reserveMemory` — Memory set aside for the OS. Redpanda uses `(memory - reserveMemory)`.
 - `redpanda.multiZone` — Spread brokers across availability zones within the location.
+- `redpanda.env` — Extra environment variables for the broker container.
 
 ### Storage
 
-Each broker replica gets its own persistent volume. For production workloads with high throughput, use `high-throughput-ssd` (minimum 200 GiB).
+Each broker gets its own persistent volume. For high-throughput production workloads switch to `high-throughput-ssd` (minimum 200 GiB).
 
-- `redpanda.volume.initialCapacity` — Initial volume size in GiB.
+- `redpanda.volume.initialCapacity` — Initial volume size in GB.
 - `redpanda.volume.performanceClass` — `general-purpose-ssd` or `high-throughput-ssd`.
-- `redpanda.volume.fileSystemType` — `xfs` (default, recommended for Redpanda) or `ext4`.
+- `redpanda.volume.fileSystemType` — `xfs` (default) or `ext4`.
+- `redpanda.volume.snapshots.createFinalSnapshot` — Take a snapshot when the volume set is deleted.
+- `redpanda.volume.snapshots.retentionDuration` — How long each snapshot is kept.
+- `redpanda.volume.snapshots.schedule` — Cron expression in UTC for scheduled snapshots; an empty string disables them.
+
+Topic data is the only durable state this template holds, and nothing else backs it up, so the snapshot schedule is the backup story for a cluster that is not mirroring elsewhere.
 
 **Volume encryption** via AWS KMS is supported:
 
@@ -162,31 +266,33 @@ redpanda:
 ```
 
 <Note>
-After deploying with custom encryption enabled, navigate to each created volume in the Control Plane console, click `spec`, and follow the **AWS Custom Encryption Instructions** to complete the setup.
+After deploying with custom encryption enabled, open each created volume in the Control Plane console, click `spec`, and follow the **AWS Custom Encryption Instructions** to complete the setup.
 </Note>
 
 ### Authentication
 
-SASL is always enabled. All users are defined under `redpanda.auth.users`. The first user in the list is automatically granted superuser privileges. Additional superusers can be added under `redpanda.auth.superusers`.
+SASL is always enabled, and every user's credentials are a prerequisite secret (see [Prerequisites](#prerequisites)). The first entry in the list becomes the cluster superuser.
 
 - `redpanda.auth.saslMechanism` — `SCRAM-SHA-256` (default) or `SCRAM-SHA-512`.
-- `redpanda.auth.users` — List of `username` / `password` pairs created at startup.
-- `redpanda.auth.superusers` — Additional usernames to grant superuser privileges.
+- `redpanda.auth.users[].credentialsSecretName` — Name of the dictionary secret holding that user's `username` and `password`. At least one entry is required.
+- `redpanda.auth.superusers` — Extra usernames to grant superuser rights, for users created outside this chart.
+
+SASL users are created by broker 0 on first boot and then live in the cluster's own metadata. Editing a credentials secret afterwards does not rotate the user — update it with `rpk security user update` and change the secret to match.
 
 ### ACLs
 
-- `redpanda.acl.allowEveryoneIfNoAclFound` — When `false` (default), clients without an explicit ACL are denied. Set to `true` to allow unauthenticated access when no ACL exists for a resource.
+- `redpanda.acl.allowEveryoneIfNoAclFound` — When `false` (default), a client with no matching ACL is denied. A non-superuser with no ACLs can authenticate but sees no topics and cannot create one.
 
 ### Listeners
 
-| Listener | Port | Description |
-|----------|------|-------------|
-| Kafka | `9092` | Kafka-compatible wire protocol (internal) |
-| Admin API | `9644` | Redpanda Admin API for cluster management |
-| Schema Registry | `8081` | Confluent-compatible Schema Registry |
-| PandaProxy | `8082` | HTTP REST proxy *(disabled by default)* |
+| Listener | Port | Authentication |
+|----------|------|----------------|
+| Kafka | `9092` | SASL |
+| Admin API | `9644` | **None** — see [The Admin API Is Unauthenticated](#the-admin-api-is-unauthenticated) |
+| Schema Registry | `8081` | HTTP basic, using the same SASL credentials |
+| HTTP Proxy | `8082` | HTTP basic, same credentials *(disabled by default)* |
 
-Enable PandaProxy to produce and consume messages over HTTP without a Kafka client:
+Enable the HTTP Proxy to produce and consume over REST without a Kafka client:
 
 ```yaml
 redpanda:
@@ -198,7 +304,7 @@ redpanda:
 
 ### Extra Broker Configuration
 
-Pass any Redpanda broker property directly via `extra_configurations`. These are injected into `redpanda.yaml` at startup:
+Pass any Redpanda broker property through `extra_configurations`; they are written into `redpanda.yaml` at startup. `redpanda.secrets.cluster_id` is generated on first boot when left empty — set it explicitly to preserve cluster identity across reinstalls.
 
 ```yaml
 redpanda:
@@ -211,80 +317,91 @@ redpanda:
 
 ### Firewall
 
-- `redpanda.firewall.internal_inboundAllowType` — Controls which workloads can reach the brokers:
-  - `same-gvc` — All workloads in the same GVC (default).
-  - `same-org` — All workloads in the org.
-- `redpanda.firewall.inboundAllowWorkload` — Allow specific workloads by path.
+- `redpanda.firewall.internal_inboundAllowType` — Which workloads can reach the brokers: `same-gvc` (default) or `same-org`.
+- `redpanda.firewall.inboundAllowWorkload` — Narrow internal access to specific workloads by path. This is the control that limits who can reach the unauthenticated Admin API.
+- `redpanda.firewall.external_inboundAllowCIDR` / `external_outboundAllowCIDR` — Commented out by default. Comment a rule back in to allow that traffic.
+
+### Console
+
+- `redpanda_console.enabled` — Deploy the Redpanda Console workload (default `true`).
+- `redpanda_console.image`, `cpu`, `memory`, `minCpu`, `minMemory`, `replicas`, `timeoutSeconds` — Image, resources and request timeout for the console workload.
+- `redpanda_console.domain` — A custom domain for the console. It also requires external inbound to be open.
+- `redpanda_console.firewall.external_inboundAllowCIDR` — Commented out, so the console is closed to the internet. See [Redpanda Console](#redpanda-console) before uncommenting it.
 
 ## Connecting
 
-Redpanda is accessible internally from any workload in the same GVC:
+Redpanda is reachable from any workload in the same GVC:
 
-| Listener | Hostname | Port |
-|----------|----------|------|
-| Kafka | `{clusterName}.{gvc}.cpln.local` | `9092` |
-| Admin API | `{clusterName}.{gvc}.cpln.local` | `9644` |
-| Schema Registry | `{clusterName}.{gvc}.cpln.local` | `8081` |
-| PandaProxy *(if enabled)* | `{clusterName}.{gvc}.cpln.local` | `8082` |
+| What | Address | Credentials |
+|---|---|---|
+| Kafka API | `RELEASE_NAME-cluster.GVC_NAME.cpln.local:9092` | SASL, from your credentials secret |
+| Admin API | `RELEASE_NAME-cluster.GVC_NAME.cpln.local:9644` | **none** — unauthenticated for reads *and* writes |
+| Schema Registry | `RELEASE_NAME-cluster.GVC_NAME.cpln.local:8081` | HTTP basic, same SASL credentials |
+| HTTP Proxy (if enabled) | `RELEASE_NAME-cluster.GVC_NAME.cpln.local:8082` | HTTP basic, same SASL credentials |
+| Console (if enabled) | `cpln port-forward` — see [Redpanda Console](#redpanda-console) | none — the console has no login |
 
-To connect to a specific broker replica directly:
+A specific broker replica is addressable directly:
 
+```text
+RELEASE_NAME-cluster-0.RELEASE_NAME-cluster.GVC_NAME.cpln.local:9092
+RELEASE_NAME-cluster-1.RELEASE_NAME-cluster.GVC_NAME.cpln.local:9092
 ```
-{clusterName}-0.{clusterName}.{gvc}.cpln.local:9092
-{clusterName}-1.{clusterName}.{gvc}.cpln.local:9092
-```
 
-Connect using `rpk`:
+Connect with `rpk` from a workload in the same GVC:
 
 ```bash
 rpk topic list \
-  -X brokers={clusterName}.{gvc}.cpln.local:9092 \
+  -X brokers=RELEASE_NAME-cluster.GVC_NAME.cpln.local:9092 \
   -X sasl.mechanism=SCRAM-SHA-256 \
   -X user=admin \
-  -X pass=your-admin-password
+  -X pass=YOUR_PASSWORD
 ```
 
-For Kafka clients, use the following connection properties:
+For Kafka clients:
 
 ```properties
-bootstrap.servers={clusterName}.{gvc}.cpln.local:9092
+bootstrap.servers=RELEASE_NAME-cluster.GVC_NAME.cpln.local:9092
 security.protocol=SASL_PLAINTEXT
 sasl.mechanism=SCRAM-SHA-256
 sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
   username="admin" \
-  password="your-admin-password";
+  password="YOUR_PASSWORD";
 ```
 
 ## Redpanda Console
 
-The Redpanda Console is enabled by default and accessible via the Control Plane external endpoint for the `{release-name}-console` workload. It provides a web UI for browsing topics, inspecting messages, managing consumer groups, and viewing Schema Registry schemas.
+**The console has no login in this build, and that is a licensing fact rather than a configuration gap.** Console authentication (OIDC and basic login) and role-based authorization are Redpanda **Enterprise** features. Unlicensed, the console runs in static service account mode: there is no login screen, every visitor shares the same access level, and that shared session carries the **cluster superuser's** SASL credentials. Anyone who can reach the console can browse and publish messages, create and delete topics, and manage consumer groups and ACLs.
 
-To expose the console on a custom domain, set `redpanda_console.domain`:
+Adding authentication was therefore not an option, so external inbound is closed by default. Reach the UI through a tunnel instead — the tunnel goes through Control Plane infrastructure and is independent of the firewall:
 
-```yaml
-redpanda_console:
-  domain: console.your-domain.com
+```bash
+cpln port-forward RELEASE_NAME-console 8080:8080 --gvc GVC_NAME
+# then open http://localhost:8080
 ```
 
-This creates a Control Plane domain resource that routes HTTPS traffic to the console workload. The same DNS prerequisites apply as for any Control Plane domain (ownership TXT record and CNAME to the GVC alias).
+<Warning>
+Uncommenting `redpanda_console.firewall.external_inboundAllowCIDR` publishes an unauthenticated Kafka admin UI. Do it only behind your own authenticating proxy, or narrowed to a CIDR range you control — never `0.0.0.0/0`. Setting `redpanda_console.domain` also requires external inbound to be open. A firewall change takes roughly 30 seconds to a few minutes to propagate.
+</Warning>
 
-To restrict console access to specific IPs, update `redpanda_console.firewall.external_inboundAllowCIDR`:
+<Note>
+**The console crash-loops for about 34 seconds on a cold install**, logging a red `Invalid credentials` error. It has started before broker 0's `postStart` hook has created the SASL users, so its first run fails, and the platform restarts it into a working state. It self-heals with no action needed — do not go looking for a credential mistake in the first minute of a fresh install.
+</Note>
 
-```yaml
-redpanda_console:
-  firewall:
-    external_inboundAllowCIDR: "203.0.113.0/24"
-```
+## The Admin API Is Unauthenticated
+
+The broker Admin API on port `9644` requires no credentials — **for writes as well as reads** — and under the default `same-gvc` firewall it is reachable by every workload in the GVC. This was verified directly: a neighbouring workload holding no credentials at all created a SASL user through it and then deleted it again. Reads leak the cluster topology and the SASL usernames.
+
+It is not publicly reachable: external inbound on the broker workload is closed, so the exposure is bounded by the GVC. But **treat GVC membership as equivalent to cluster admin** until you narrow it, which you do with `redpanda.firewall.inboundAllowWorkload` — listing exactly the workloads that need broker access. The readiness probe, the `postStart` hook and the console all depend on this listener, so it cannot simply be closed.
 
 ## External Access
 
-Redpanda brokers can be exposed over the internet via TLS using a public domain. Each broker advertises its own per-replica subdomain and Control Plane routes clients to the correct broker using SNI.
+Redpanda brokers can be exposed over the internet with TLS via a public domain. Each broker advertises its own per-replica subdomain and Control Plane routes clients to the correct broker using SNI.
 
-### Prerequisites
+### Requirements
 
-1. **A domain you control** with DNS managed by your registrar (e.g. Cloudflare).
-2. **Dedicated Load Balancer** enabled on your GVC — required for external TCP routing. Enable under GVC settings in the Control Plane console. See [Configure Domain documentation](https://docs.controlplane.com/guides/configure-domain#dedicated-load-balancing).
-3. **DNS records added before deploying.** Disable proxying (e.g. Cloudflare's orange cloud) — TCP traffic must pass through directly:
+1. **A domain you control** with DNS managed by your registrar.
+2. **Dedicated Load Balancer** enabled on your GVC — required for external TCP routing. See [Configure Domain](https://docs.controlplane.com/guides/configure-domain#dedicated-load-balancing).
+3. **DNS records added before deploying.** Disable proxying (for example Cloudflare's orange cloud) — TCP traffic must pass through directly:
 
 | Type | Name | Value |
 |------|------|-------|
@@ -292,12 +409,11 @@ Redpanda brokers can be exposed over the internet via TLS using a public domain.
 | CNAME | `@` | `{gvcAlias}.cpln.app` |
 | CNAME | `_acme-challenge` | `_acme-challenge.cpln.app` |
 | CNAME | `{clusterName}-0-{location}` | `{gvcAlias}.cpln.app` |
-| CNAME | `{clusterName}-1-{location}` | `{gvcAlias}.cpln.app` |
 | CNAME | `{clusterName}-N-{location}` | `{gvcAlias}.cpln.app` |
 
-Add one CNAME per broker replica. The `_acme-challenge` record is required for Control Plane to issue the TLS certificate via DNS-01. Your GVC alias is visible under GVC settings in the Control Plane console.
+Add one CNAME per broker replica, pointing at the GVC gateway rather than at a direct replica address. The `_acme-challenge` record lets Control Plane issue the certificate via DNS-01. Your GVC alias is under GVC settings in the Control Plane console.
 
-### Configuration
+### External Access Configuration
 
 ```yaml
 redpanda:
@@ -311,27 +427,30 @@ redpanda:
 
 ### Connecting Externally
 
-Each broker advertises its own subdomain in the format `{clusterName}-{ordinal}-{location}.{domain}`. Use all broker addresses as the bootstrap list:
+Each broker advertises `{clusterName}-{ordinal}-{location}.{domain}`. Use them all as the bootstrap list:
 
 ```bash
 rpk topic list \
-  -X brokers=cluster-0-aws-us-east-1.your-domain.com:9094,cluster-1-aws-us-east-1.your-domain.com:9094,cluster-2-aws-us-east-1.your-domain.com:9094 \
+  -X brokers=cluster-0-aws-us-east-1.your-domain.com:9094,cluster-1-aws-us-east-1.your-domain.com:9094 \
   -X tls.enabled=true \
   -X sasl.mechanism=SCRAM-SHA-256 \
   -X user=admin \
-  -X pass=your-admin-password
+  -X pass=YOUR_PASSWORD
 ```
 
-For Kafka clients:
+For Kafka clients, use `security.protocol=SASL_SSL`, `sasl.mechanism=SCRAM-SHA-256`, and the same bootstrap list.
 
-```properties
-security.protocol=SASL_SSL
-sasl.mechanism=SCRAM-SHA-256
-bootstrap.servers=cluster-0-aws-us-east-1.your-domain.com:9094,cluster-1-aws-us-east-1.your-domain.com:9094,cluster-2-aws-us-east-1.your-domain.com:9094
-sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
-  username="admin" \
-  password="your-admin-password";
-```
+## Important Notes
+
+- Every credentials secret named in `redpanda.auth.users` must exist **before** you install. Without one the deployment wedges with no log output at all; see [Prerequisites](#prerequisites) for the one diagnostic that names it.
+- **Anyone who can reach the console acts as the cluster superuser** — there is no login. Keep external inbound closed unless the console sits behind your own authenticating proxy.
+- **The broker Admin API on `9644` is unauthenticated for reads and writes** and open to the whole GVC by default — see [The Admin API Is Unauthenticated](#the-admin-api-is-unauthenticated).
+- **The console crash-loops for roughly 34 seconds on a cold install** with an `Invalid credentials` error, before the SASL users exist. It self-heals.
+- SASL users live in the cluster's metadata after first boot. Editing a credentials secret does not rotate the user; use `rpk security user update` and change the secret to match.
+- `redpanda.replicas` must be `1`, `3`, or `5`. An even count cannot form a Raft quorum and is rejected at install.
+- **A rolling upgrade is not serialized for a stateful workload**, so brokers may restart together. Configure producers and consumers to retry.
+- **The first Helm upgrade after an install re-applies resources** even with identical values, bouncing both workloads. Later upgrades are clean.
+- Topic data survives reschedules and reinstalls of the same release, and the volume set carries scheduled snapshots — but the snapshots are the only backup, so use tiered storage or a mirroring job if you need point-in-time recovery elsewhere.
 
 ## External References
 
@@ -347,5 +466,8 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
   </Card>
   <Card title="Schema Registry API" href="https://docs.redpanda.com/current/develop/http-proxy/" icon="code">
     Confluent-compatible Schema Registry and HTTP Proxy API reference
+  </Card>
+  <Card title="Redpanda Template" href="https://github.com/controlplane-com/templates/tree/main/redpanda" icon="github">
+    View the source files, default values, and chart definition
   </Card>
 </CardGroup>

--- a/template-catalog/templates/sftpgo.mdx
+++ b/template-catalog/templates/sftpgo.mdx
@@ -1,31 +1,91 @@
 ---
 title: SFTPGo
-description: Deploy SFTPGo on Control Plane using the Template Catalog. An SFTP server backed by S3, GCS, or S3-compatible object storage, with a scale-to-zero mode that suspends the server when idle.
-keywords: ['sftp server', 'sftp gateway', 'sftp to s3', 'secure file transfer', 'ftp alternative', 'managed file transfer', 's3 sftp', 'gcs sftp', 'minio sftp', 'scale to zero', 'object storage sftp', 'sftpgo template']
+description: Deploy SFTPGo on Control Plane using the Template Catalog. An SFTP server backed by S3, GCS, or S3-compatible object storage, with a scale-to-zero mode that suspends the server when idle. Covers the prerequisite admin credentials secret and the web admin reached over a port-forward.
+keywords: ['sftp server', 'sftp gateway', 'sftp to s3', 'secure file transfer', 'ftp alternative', 'managed file transfer', 's3 sftp', 'gcs sftp', 'minio sftp', 'scale to zero', 'object storage sftp', 'sftpgo template', 'prerequisite secret', 'port forward', 'ssh public key auth']
 ---
 
 ## Overview
 
 SFTPGo is an SFTP server backed by object storage. Clients speak standard SFTP; files land in your bucket, with per-user folder isolation and declarative user management. This template offers a choice between an always-on server and a **scale-to-zero mode** that suspends the server when idle behind a tiny always-on proxy.
 
+The SFTPGo administrator login — which guards the REST API and the web admin — comes from a secret you create **before** installing, so it never passes through Helm values.
+
+<Warning>
+**Upgrading an install created with `1.0.0` is a breaking change.** `admin.username` and `admin.password` no longer exist, and an upgrade that still sets either one stops with an error naming its replacement. Your existing admin login is unaffected — the secret only seeds a fresh install. See [Upgrading From 1.0.0](#upgrading-from-1-0-0).
+</Warning>
+
 ### Architecture
 
 - **SFTPGo** — A single-replica stateful workload serving SFTP on port `2022`. An embedded bolt database and the SSH host keys persist on a volume set so host keys stay stable across restarts and wakes.
 - **Scale-to-zero proxy** *(scale_to_zero mode only)* — An always-on activator workload that accepts client connections while SFTPGo sleeps, wakes it via the platform API, splices traffic through, and suspends it again after an idle window.
+- **Admin login from a secret** — The administrator username and password come from a dictionary secret you create. SFTPGo consumes them only when the embedded database has no admin yet, i.e. on first boot.
 
 ### What Gets Created
 
 - **Stateful SFTPGo Workload** — Serves SFTP on port `2022`; holds the embedded database and SSH host keys.
 - **Standard Scale-to-Zero Proxy Workload** *(scale_to_zero mode only)* — Always-on TCP activator that fronts SFTPGo and manages suspend/wake.
 - **Volume Set** — 10 GiB persistent storage for the embedded database and SSH host keys.
-- **Secrets** — A dictionary secret with the admin bootstrap credentials and an opaque secret with the declared-users file.
-- **Identity & Policy** — An identity bound to the workloads with `reveal` access to the secrets, keyless cloud storage access for AWS and GCP backends, and a least-privilege policy letting the proxy's identity suspend and wake exactly the SFTPGo workload — nothing else.
+- **Secret** — An opaque secret holding the declared-users file. The admin credentials are **not** created here — they live in the secret you create.
+- **Identity & Policy** — An identity bound to the workloads with `reveal` access to the secrets it mounts, including your admin credentials secret; keyless cloud storage access for AWS and GCP backends; and a least-privilege policy letting the proxy's identity suspend and wake exactly the SFTPGo workload — nothing else.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
 ## Prerequisites
+
+### Admin Credentials
+
+**This secret must exist before you install.** It is the SFTPGo administrator login for the REST API and web admin. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `username` and `password`:
+
+    ```bash
+    cpln secret create-dictionary --name my-sftpgo-admin \
+      --entry username=admin \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `admin.secretName` to the name you used.
+
+    | Key | What it is |
+    |---|---|
+    | `username` | The administrator login. |
+    | `password` | Its password. Used only when the embedded database has no admin yet, i.e. on first boot. |
+  </Step>
+  <Step title="Read it back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-sftpgo-admin -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Note>
+**The admin secret seeds the first boot only.** SFTPGo applies it when the embedded database has no administrator yet, so on an existing install editing the secret does not change the admin password — rotate that through the REST API or web admin instead. This is also why an upgrade from `1.0.0` leaves your current login working.
+</Note>
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports success, the resources are created, and the workload then never starts. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-sftpgo --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-sftpgo-admin no longer exists. Workload updates are
+paused until the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery across the catalog has been measured between **5.5 and 10.5 minutes**, so poll rather than time-boxing it. A forced redeployment shortcuts it to roughly 90 seconds.
+</Warning>
+
+### Object Storage
 
 SFTPGo requires an existing bucket in one of the supported backends and the access setup for it. Complete the steps for your chosen backend before installing.
 
@@ -92,13 +152,13 @@ SFTPGo requires an existing bucket in one of the supported backends and the acce
         Set `storage.minio.endpoint` to the S3 API address including port. For the `minio` marketplace template deployed in the same GVC, this is `http://WORKLOAD_NAME:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `storage.minio.accessKey` and `storage.minio.accessSecret` to credentials with access to the bucket. For the MinIO template, these are its `admin.username` and `admin.password`.
+        Set `storage.minio.accessKey` and `storage.minio.accessSecret` to credentials with access to the bucket. For the [minio](/template-catalog/templates/minio) template, these are the `username` and `password` in the dictionary secret named by its `admin.credentialsSecretName`.
       </Step>
     </Steps>
   </Tab>
 </Tabs>
 
-Once your backend is ready, install the template using your preferred method:
+Once the admin secret exists and your backend is ready, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -121,6 +181,54 @@ Once your backend is ready, install the template using your preferred method:
     Declare templates in your Pulumi programs
     </Card>
 </CardGroup>
+
+## Upgrading From 1.0.0
+
+Version `1.1.0` moved the SFTPGo administrator login out of Helm values. `1.0.0` shipped a working username and password as values, used exactly as written, guarding the REST API and web admin.
+
+| | `1.0.0` | `1.1.0` |
+|---|---|---|
+| Admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create with `username` and `password` |
+| Chart-created secret | Held the admin credentials | Only the declared-users file |
+| SFTP user credentials | `users[]` values | Unchanged — see [What Stays a Value](#what-stays-a-value) |
+
+<Warning>
+**A `helm upgrade` that still carries either removed key is rejected before anything is applied.** A real `cpln helm upgrade` carrying the old keys failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+sftpgo: admin.password was removed in 1.1.0. Put it in the prerequisite dictionary secret named by
+admin.secretName (key: password) — the secret only seeds a fresh data provider.
+```
+
+Leaving `admin.secretName` empty is refused the same way.
+</Warning>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    Follow [Prerequisites](#prerequisites), putting the username and password you already use into it. Your existing login keeps working either way — the secret only seeds an install whose database has no admin yet.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `admin.username` and `admin.password`, and set `admin.secretName` instead. Leave `users[]` and the storage block exactly as they are.
+  </Step>
+  <Step title="Upgrade">
+    In `scale_to_zero` mode an upgrade while suspended wakes the server; it re-suspends after the next connection comes and goes.
+  </Step>
+</Steps>
+
+## What Stays a Value
+
+Two things are deliberately **not** prerequisite secrets, and this is a limitation rather than a preference:
+
+- `users[].password` — the passwords of the declared SFTP users
+- `storage.minio.accessKey` / `storage.minio.accessSecret` — static keys for an S3-compatible backend
+
+SFTPGo reads both from its LOADDATA file, a literal JSON document it does no variable substitution in, so a `cpln://secret/...` reference placed there would be stored verbatim as the credential rather than resolved. The usual workaround — a startup script that substitutes the value — is unavailable too: the shipped image is `distroless-slim` and has **no shell at all** (`/bin/sh`, `sh`, `/bin/bash`, `/bin/busybox`, and even `/bin/ls` are all absent, verified in the running container). Whatever string sits in those fields is the credential.
+
+<Tip>
+**Prefer public-key users.** Setting `users[].publicKeys` and omitting `password` needs no secret at all, is better practice for SFTP regardless, and sidesteps the limitation entirely. The AWS and GCP storage backends are keyless already — only the `minio` backend takes static keys.
+</Tip>
 
 ## Choosing a Mode
 
@@ -147,20 +255,19 @@ scaleToZero: # only used when mode is scale_to_zero
   proxy:
     image: ghcr.io/controlplane-com/scale-to-zero-proxy:0.1.0
     resources: # all SFTP traffic flows through the proxy
-      cpu: 500m
-      memory: 256Mi
       minCpu: 100m
       minMemory: 128Mi
+      maxCpu: 500m
+      maxMemory: 256Mi
 
 resources: # SFTPGo container; CPU governs transfer throughput and wake speed
-  cpu: 1000m
-  memory: 512Mi
   minCpu: 250m
   minMemory: 256Mi
+  maxCpu: 1000m
+  maxMemory: 512Mi
 
-admin: # SFTPGo administrator (REST API / optional web admin), created on first boot
-  username: admin
-  password: change-me-sftpgo-admin # change before installing
+admin: # SFTPGo administrator (REST API / web admin), seeded on first boot only
+  secretName: my-sftpgo-admin # name of your pre-created dictionary secret (see Prerequisites)
 
 storage:
   type: aws # options: aws, gcp, minio
@@ -214,10 +321,10 @@ webAdmin:
 ### SFTPGo
 
 - `image` — The SFTPGo container image.
-- `resources` — CPU and memory for the SFTPGo container. CPU governs transfer throughput and wake speed.
-- `admin.username` / `admin.password` — The SFTPGo administrator, created on first boot for the REST API and optional web admin. **Change the password before installing.**
+- `resources` — CPU and memory for the SFTPGo container. CPU governs transfer throughput and wake speed; `minCpu` / `minMemory` are the reservation and `maxCpu` / `maxMemory` the limit.
+- `admin.secretName` — Name of your pre-created dictionary secret holding `username` and `password`. It seeds the administrator on first boot only. See [Prerequisites](#prerequisites).
 - `volumeset.capacity` — Volume size in GiB (minimum 10) for the embedded database and SSH host keys.
-- `webAdmin.enabled` — Declare SFTPGo's web admin / REST API on port `8080`. Reachable via the canonical endpoint in `always_warm` mode when `publicAccess` is enabled.
+- `webAdmin.enabled` — Declare SFTPGo's web admin / REST API on port `8080`. Reach it with a port-forward — **not** the canonical endpoint; see [Reaching the Web Admin](#reaching-the-web-admin).
 
 ### Storage Backend
 
@@ -235,10 +342,10 @@ Set `storage.type` to `aws`, `gcp`, or `minio`, and configure that block. AWS an
 
 ### Users
 
-Declared users are re-applied on every start; each is isolated to the bucket folder `{keyPrefix}{username}/` unless overridden per user. Provide a `password`, one or more `publicKeys`, or both.
+Declared users are re-applied on every start; each is isolated to the bucket folder `{keyPrefix}{username}/` unless overridden per user. Provide a `password`, one or more `publicKeys`, or both — **prefer `publicKeys`**, which needs no credential in your values at all (see [What Stays a Value](#what-stays-a-value)).
 
 - `users[].username` — Login name.
-- `users[].password` — Password. Omit when `publicKeys` is set.
+- `users[].password` — Password. Used exactly as written and cannot be moved into a secret ([why](#what-stays-a-value)) — omit it when `publicKeys` is set.
 - `users[].publicKeys` — SSH public keys, e.g. `["ssh-ed25519 AAAA... user@laptop"]`.
 - `users[].keyPrefix` — Optional per-user bucket folder override.
 
@@ -261,8 +368,18 @@ Declared users are re-applied on every start; each is isolated to the bucket fol
 | Public SFTP endpoint | `tcp://...cpln.app:2022` — `status.endpoint` of `{release}-sftpgo-proxy` (scale_to_zero) or `{release}-sftpgo` (always_warm) |
 | Connect | `sftp -P 2022 {username}@{endpoint-host}` |
 | In-GVC (internal) | `{release}-sftpgo-proxy:2022` (scale_to_zero) or `{release}-sftpgo:2022` (always_warm) |
-| Web admin (if enabled) | Canonical `*.cpln.app` endpoint of `{release}-sftpgo` (always_warm + publicAccess) |
-| Credentials | `users[]` entries; admin per `admin.*` |
+| Web admin (if enabled) | A port-forward to `{release}-sftpgo` on port `8080` — **not** the canonical endpoint. See [Reaching the Web Admin](#reaching-the-web-admin). |
+| Credentials | SFTP logins from `users[]`; the administrator from your `admin.secretName` secret |
+
+### Reaching the Web Admin
+
+**The web admin is not served on the canonical endpoint.** Public access uses `loadBalancer.direct` on port `2022`, which makes the workload's canonical endpoint a raw TCP address of the form `tcp://....cpln.app:2022`; an HTTPS request to that host reaches nothing at all. Reach the web admin and REST API through a port-forward instead, which tunnels through Control Plane infrastructure and needs no public exposure:
+
+```bash
+cpln port-forward RELEASE_NAME-sftpgo 8080:8080 --gvc GVC_NAME
+```
+
+Then open `http://localhost:8080` and sign in with the credentials from your `admin.secretName` secret. This requires `webAdmin.enabled: true`, which declares port `8080` on the container.
 
 ## Cold Starts and Client Configuration
 
@@ -278,7 +395,11 @@ For third-party clients you cannot configure, use `always_warm`.
 
 ## Important Notes
 
-- **Change the default admin and user passwords before installing.** The admin bootstrap only applies on first boot; changing `admin.*` later requires the REST API.
+- **Create the admin credentials secret before installing.** A missing prerequisite secret wedges the deployment with no log output at all; [Prerequisites](#prerequisites) gives the one command that diagnoses it.
+- **Change the default `users[]` passwords before installing** — they are used exactly as written, and cannot be moved into a secret. Prefer `publicKeys`; see [What Stays a Value](#what-stays-a-value).
+- **The admin secret seeds first boot only.** Rotate an existing administrator's password through the REST API or web admin, not by editing the secret.
+- **The web admin is reached by port-forward, not the canonical endpoint** — see [Reaching the Web Admin](#reaching-the-web-admin).
+- **Access changes take time to propagate** — after toggling `publicAccess` or `internalAccess`, re-test over roughly 30 seconds to 5 minutes before concluding the knob is broken.
 - **Declared users are authoritative** — edits made to them via the admin API/UI are overwritten on the next restart or wake. Users *created* via the API are untouched.
 - **Upgrading while suspended wakes the server**; it re-suspends after the next connection comes and goes.
 - **First install: the public endpoint's DNS takes a few minutes** to propagate after the load balancer is created.

--- a/template-catalog/templates/unleash.mdx
+++ b/template-catalog/templates/unleash.mdx
@@ -1,6 +1,6 @@
 ---
 title: Unleash
-description: Deploy Unleash on Control Plane using the Template Catalog. Open-source feature-flag server with an admin UI and SDK APIs, backed by a highly available PostgreSQL cluster. Covers replicas, first-boot API token seeding, database modes, and backups.
+description: Deploy Unleash on Control Plane using the Template Catalog. Open-source feature-flag server with an admin UI and SDK APIs, backed by a highly available PostgreSQL cluster. Covers the prerequisite admin secret, replicas, first-boot API token seeding, database modes, and backups.
 keywords: ['launchdarkly alternative', 'flagsmith alternative', 'split alternative', 'feature toggles', 'gradual rollout', 'kill switch', 'a/b testing', 'canary release', 'self-hosted', 'getunleash', 'client sdk', 'unleash template']
 ---
 
@@ -19,7 +19,7 @@ Unleash is an open-source feature-flag server — toggle features on and off, ro
 - **Standard Unleash Workload** — One or more stateless replicas serving the admin UI and the Admin, Client, and Frontend APIs on port `4242`.
 - **Database Workloads** — HA mode: a stateful Patroni PostgreSQL workload, a stateful etcd workload, and a standard HAProxy leader-routing workload. Single mode: one stateful PostgreSQL workload.
 - **Volume Sets** — The database subchart's persistent volumes (10 GiB per replica by default). Unleash itself has none.
-- **Secrets** — Admin bootstrap credentials, the start script that derives the public URL at runtime, and the database credentials from the subchart.
+- **Secrets** — The start script that derives the public URL and waits for the database at startup, plus the database credentials from the subchart. The admin login is **not** created by this template: you create that dictionary secret yourself before installing and reference it by name (see [Prerequisites](#prerequisites)).
 - **Identity & Policy** — A least-privilege policy granting the Unleash identity `reveal` on exactly the secrets it uses, including your pre-created API-token secret when one is configured.
 - **Cron Backup Workload** *(optional)* — When database backups are enabled.
 
@@ -29,9 +29,52 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 
 ## Prerequisites
 
-None for a default install — install, log in with `admin.username` / `admin.password`, and create SDK API tokens in the admin UI.
+**One dictionary secret must exist before you install.** The initial admin guards a login form on the public endpoint, so its credentials are a prerequisite secret rather than template values — a value would sit in plaintext in the Helm release for the life of the install. The template creates no admin secret of its own.
 
-Optionally, the template can seed a backend and a frontend SDK API token on first boot from a [dictionary secret](/guides/create-secret/dictionary) that you create **before** installing. The token strings are never passed through values.
+<Steps>
+  <Step title="Create the admin credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `username` and `password`. Secrets are org-level, so no GVC flag is involved:
+
+    ```bash
+    cpln secret create-dictionary --name my-unleash-admin \
+      --entry username=admin \
+      --entry password="$(openssl rand -hex 24)"
+    ```
+
+    Set `admin.secretName` to the name you used.
+  </Step>
+  <Step title="Read the password back later">
+    `-o yaml` is required; without it the command prints the secret's metadata table rather than its contents:
+
+    ```bash
+    cpln secret reveal my-unleash-admin -o yaml
+    ```
+  </Step>
+</Steps>
+
+| Key | What it is |
+|---|---|
+| `username` | The initial admin's login name. |
+| `password` | Its password. The login form it guards is on the public endpoint. |
+
+<Warning>
+**A missing prerequisite secret wedges the install rather than failing it.** The install still exits 0 and reports success, every resource is created, and the workload then never starts. Because the container never ran, `cpln logs` returns **zero lines**, which reads as a broken platform rather than a missing prerequisite.
+
+The only diagnostic is `status.versions[].message`, which names the missing secret:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-unleash --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-unleash-admin no longer exists. Workload updates are paused until
+the secret is added or the reference to the secret removed.
+```
+
+It is **`get-deployments`** — plain `cpln workload get` has no `versions` key at all. Creating the missing secret clears the wedge on its own, but slowly: recovery has measured between 5.5 and 10.5 minutes across the catalog, so poll rather than giving up. `cpln workload force-redeployment RELEASE_NAME-unleash --gvc GVC_NAME` shortcuts it to roughly 90 seconds.
+</Warning>
+
+Optionally, the template can also seed a backend and a frontend SDK API token on first boot from a second [dictionary secret](/guides/create-secret/dictionary) that you create **before** installing. This one is unchanged from earlier versions, and the token strings are never passed through values.
 
 <Steps>
   <Step title="Generate token strings">
@@ -44,7 +87,13 @@ Optionally, the template can seed a backend and a frontend SDK API token on firs
     Generate one token string for backend SDKs and one for frontend SDKs.
   </Step>
   <Step title="Create a dictionary secret">
-    Create a [dictionary secret](/guides/create-secret/dictionary) in your org with exactly two keys, `backend` and `frontend`, each holding a full token string.
+    Create a [dictionary secret](/guides/create-secret/dictionary) with exactly two keys, `backend` and `frontend`, each holding a full token string:
+
+    ```bash
+    cpln secret create-dictionary --name my-unleash-api-tokens \
+      --entry backend="default:production.$(openssl rand -hex 24)" \
+      --entry frontend="default:production.$(openssl rand -hex 24)"
+    ```
   </Step>
   <Step title="Reference it in values">
     Set `apiTokens.secretName` to the secret's name. Leave it empty to skip seeding and create tokens in the admin UI instead.
@@ -53,7 +102,7 @@ Optionally, the template can seed a backend and a frontend SDK API token on firs
 
 For optional database backups, you also need a bucket and access setup for one of the supported providers — see [Backing Up](#backing-up).
 
-Install the template using your preferred method:
+Once the admin secret exists, install the template using your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -88,7 +137,11 @@ Exactly one of the two database modes must be enabled — the chart enforces thi
 | Footprint | 8 replicas across 3 workloads (3× Patroni, 3× etcd, 2× HAProxy) | 1 workload |
 | Best for | Production | Development and lightweight installs |
 
-A fresh HA-mode install takes roughly 5–7 minutes to fully converge; transient `Failed to migrate db` log errors while the database cluster starts are expected and self-heal, at any replica count. Single mode is ready in about a minute.
+A fresh HA-mode install takes several minutes to fully converge while the Patroni and etcd replicas come up; single mode is ready in about a minute.
+
+<Note>
+**Unleash waits for its database before starting.** Version `1.1.0` added that wait to the start script. Earlier versions ran their schema migrations immediately at boot and did not retry, so on the default HA database they raced Patroni's leader election and crash-looped for roughly six minutes with `Failed to migrate db Error: read ECONNRESET` — long enough that the install looked broken and, in one measured run, missed a five-minute readiness expectation. The database itself was healthy throughout; only the startup ordering was wrong.
+</Note>
 
 ## Configuration
 
@@ -105,9 +158,13 @@ resources:
 
 replicas: 1 # stateless server — set 2+ for high availability (all state lives in PostgreSQL)
 
-admin: # initial admin login, seeded on first boot only
-  username: admin
-  password: change-me-unleash-admin # change before installing
+# Initial admin login, seeded on first boot only.
+# REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL. A `dictionary`
+# secret holding exactly two keys, `username` and `password`; the login form it
+# guards sits on the public endpoint. The account then lives in the database —
+# change it later in the UI, not here.
+admin:
+  secretName: my-unleash-admin # name of your pre-created dictionary secret
 
 apiTokens:
   secretName: "" # your pre-created dictionary secret (see Prerequisites); empty = create tokens in the UI
@@ -196,12 +253,12 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 - `image` — The Unleash open-source server image.
 - `resources` — CPU and memory for the Unleash container.
 - `replicas` — Number of Unleash replicas behind the platform load balancer. The server is stateless, so scaling is a single value change; `2+` is recommended for production. At 2 replicas, rolling redeploys and a killed replica were both verified to serve every request with zero failures.
-- `admin.*` — The initial admin login, seeded into the database on first boot only. **Change `admin.password` before installing** — the upstream default password is rejected once your own is set. Changing these values later does not modify the existing account; change the password in the admin UI instead.
+- `admin.secretName` — Name of the dictionary secret you created in [Prerequisites](#prerequisites), holding the `username` and `password` of the initial admin. The credentials never pass through values, and the template creates no secret of its own — it references yours and grants the workload `reveal` on exactly that one secret. The account is seeded into the database on first boot only, so editing the secret later does not modify it; change the password in the admin UI instead.
 - `apiTokens.secretName` — Name of your pre-created dictionary secret with keys `backend` and `frontend` (see [Prerequisites](#prerequisites)). When set, both tokens are seeded on first boot; when empty (default), create tokens in the admin UI after install. Like the admin account, tokens are seeded on first boot only.
 
 ### Access
 
-- `publicAccess.enabled` — Serve the admin UI and SDK APIs on the canonical `*.cpln.app` HTTPS endpoint (default). Every surface is authenticated — the UI and Admin API by login, the Client and Frontend APIs by tokens. Set to `false` for an internal-only instance (external requests are blocked at the edge; in-GVC callers still reach it per `internalAccess`). The public URL Unleash embeds in password-reset and invite links (`UNLEASH_URL`) is derived at startup — from the canonical endpoint when public, or the internal `cpln.local` address when not — and re-derived on every restart.
+- `publicAccess.enabled` — Serve the admin UI and SDK APIs on the canonical `*.cpln.app` HTTPS endpoint. It is **deliberately on by default** and load-bearing: SDKs running in browsers and in applications outside the GVC call `/api/frontend` and `/api/client` directly, so a private instance cannot serve them. Every surface is authenticated — the UI and Admin API by login, the Client and Frontend APIs by tokens — and the login is now a credential you created rather than a published default. A firewall change takes roughly 30 seconds to a few minutes to propagate, so re-test rather than trusting the first response. Set to `false` for an internal-only instance (external requests are blocked at the edge; in-GVC callers still reach it per `internalAccess`). The public URL Unleash embeds in password-reset and invite links (`UNLEASH_URL`) is derived at startup — from the canonical endpoint when public, or the internal `cpln.local` address when not — and re-derived on every restart.
 - `internalAccess.type` — Internal firewall scope of the Unleash workload:
 
 | Type | Description |
@@ -219,6 +276,48 @@ Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/ligh
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
 </Warning>
 
+## Upgrading From 1.0.x
+
+Version `1.1.0` moved the initial admin login out of Helm values. Earlier versions shipped a username and a working password as values, used exactly as written — a published default guarding a login form on the public endpoint, sitting in the Helm release for the life of the install.
+
+| | `1.0.x` | `1.1.0` |
+|---|---|---|
+| Initial admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `username` and `password` |
+| Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
+| `apiTokens.secretName` | Prerequisite dictionary secret | Unchanged |
+| Database startup | Migrations ran immediately at boot | The start script waits for the database first |
+| Database password | A value (`postgresHA.postgres.password` / `postgres.config.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+
+<Warning>
+**An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
+
+```text
+unleash: admin.password was REMOVED in 1.1.0. Put it in a `dictionary` secret (key: `password`)
+together with `username`, and set admin.secretName to that secret's name. Create the secret BEFORE
+installing; see Prerequisites in the README.
+```
+
+Leaving `admin.secretName` empty is refused the same way.
+</Warning>
+
+<Note>
+**An existing install's admin password does not change on upgrade.** `UNLEASH_DEFAULT_ADMIN_*` is read on first boot only; the account then lives in the database, so the secret's contents only matter to a fresh install. Change the password in the admin UI. If the install is still carrying the published `1.0.x` default (`change-me-unleash-admin`), treat that password as compromised and change it now.
+</Note>
+
+To upgrade an existing install:
+
+<Steps>
+  <Step title="Create the admin credentials secret">
+    Follow [Prerequisites](#prerequisites). An existing `apiTokens.secretName` secret stays exactly as it is.
+  </Step>
+  <Step title="Drop the removed keys from your values">
+    Remove `admin.username` and `admin.password`, and set `admin.secretName` instead.
+  </Step>
+  <Step title="Upgrade">
+    The Unleash replicas restart; flags, users, and tokens are in PostgreSQL and are untouched.
+  </Step>
+</Steps>
+
 ## Connecting
 
 | What | Value |
@@ -227,7 +326,7 @@ Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/ligh
 | Client API (backend SDKs) | `https://<canonical>.cpln.app/api/client` — `Authorization: <backend token>` |
 | Frontend API (browser/mobile SDKs) | `https://<canonical>.cpln.app/api/frontend` — `Authorization: <frontend token>` |
 | Internal (same GVC) | `http://{release}-unleash.{gvc}.cpln.local:4242` |
-| Login | `admin.username` / `admin.password` |
+| Login | The `username` / `password` in your `admin.secretName` secret — `cpln secret reveal my-unleash-admin -o yaml` |
 | PostgreSQL (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
 | PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
 
@@ -313,11 +412,12 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 
 ## Important Notes
 
-- **Change `admin.password` and the database password** (`postgresHA.postgres.password` / `postgres.config.password`) before installing.
-- **Admin credentials and API tokens are seeded on first boot only** — they live in the database afterwards; change the password or manage tokens in the admin UI, not by upgrading values.
+- **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
+- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **Admin credentials and API tokens are seeded on first boot only** — they live in the database afterwards; change the password or manage tokens in the admin UI, not by editing the secrets.
 - **Backend tokens must stay secret** (server-side SDKs, `/api/client`); frontend tokens are safe to embed in browsers (`/api/frontend`). A `401` usually means the wrong token type or environment.
 - **The free edition ships exactly two environments** (`development`, `production`) — SSO, role-based access control, multiple projects, change requests, and audit logs require an Unleash Enterprise license and are not available in this template.
-- **HA-mode first boot takes ~5–7 minutes** — transient `Failed to migrate db` log errors while the database cluster starts are expected and self-heal, at any replica count.
+- **HA-mode first boot takes several minutes** while the database cluster converges. Since `1.1.0` the start script waits for the database before running migrations, which is what earlier versions crash-looped on.
 - **Uninstall deletes the database volume sets** — all flags, users, and tokens. Enable backups if the data matters.
 
 ## External References


### PR DESCRIPTION
Docs for the twelve templates that close the catalog secrets audit — merged in templates PRs **#440–#444**. Changelog entries in templates **#445**; three stale README/briefing statements corrected in **#446**.

Twelve existing pages updated. **No `overview.mdx`, `docs.json` or icon changes.**

| Page | Version | What the release changed |
|---|---|---|
| `airflow` | 1.5.0 | fernet key, JWT secret, admin password → one secret; UI private by default |
| `gitea` | 1.1.0 | admin login + three signing keys → one secret |
| `glitchtip` | 1.1.0 | signing key + admin login → one secret |
| `redpanda` | 1.1.0 | SASL superuser → secrets; console closed; volumeset snapshots added |
| `cpln-task-runner` | 1.3.0 | admin key → secret; public access off by default |
| `keycloak` `metabase` `listmonk` `unleash` | 1.1.0 | admin login → prerequisite secret |
| `n8n` | 1.1.0 | owner login → secret holding a bcrypt hash |
| `sftpgo` | 1.1.0 | admin login → secret |
| `cpln-trivy` | 1.2.0 | report-upload token → secret |

## The pages that matter are not the credential moves

Each release removed a working credential published in this repository — but the more useful content is what testing exposed underneath, and several pages had to *correct* claims rather than extend them.

**airflow** documents that a wide task fan-out **silently loses about a third of its tasks** (measured: a 24-task burst finished 7 failed / 9 success, the failures never starting). It is an upstream race in the Celery executor's Redis transport, **nothing surfaces in the UI**, and a user would only notice by counting. Its fernet key is also stated as a *migration*, not an upgrade: anyone carrying the published default forward has every stored Connection credential encrypted under a known key, and rotating it makes them unreadable.

**redpanda** explains why its console had to be **closed rather than secured** — console authentication and RBAC are Enterprise-licensed, so the shipped build runs one shared session carrying the cluster superuser. It also documents that the broker Admin API is unauthenticated for **reads and writes** GVC-wide, verified by a neighbouring workload creating and deleting a SASL user with no credentials.

**cpln-task-runner** states plainly that `/v1/enqueue` authenticates nothing and **auto-registers unknown client IDs**, so no setting closes it — which is why public access now defaults off, and why public submission needs a user-supplied proxy.

**cpln-trivy** carries the argument the audit initially got wrong: the two workloads have no in-GVC path, so the daemon posts to the **public** endpoint, which gates writes on the token alone. A published default meant an internet-facing write endpoint guarded by a repo string.

**n8n** is the one page where "your existing password is unaffected" is **false** — it re-applies the owner on every start, so users must hash the password they already use. Stated three times where it cannot be missed.

**sftpgo** replaces an access instruction that never worked (the web admin is not on the canonical endpoint — `loadBalancer.direct` on 2022 makes that a `tcp://` address) and adds an honest **What Stays a Value** section for the credentials that genuinely cannot move yet.

**unleash** removes a stale claim that presented a bug as normal — the old page said a transient `Failed to migrate db` was expected; 1.1.0 waits for its database instead.

## Verification

- **Anchors: 48 across twelve pages, 0 dead**, with no linked heading containing punctuation (Mintlify preserves colons and commas).
- **No retired credential appears inside a code block** on any page — checked fence-aware. They appear only in upgrade prose, which is where a compromised value belongs.
- **YAML blocks diffed against shipped `values.yaml`** by every writer; w3 reports 65/35/25/42 key-value pairs with zero mismatches and zero invented keys.
- **All documented `cpln` commands were executed**, not transcribed, with probe secrets deleted afterwards.
- **Renders verified by content marker, not status code.** This mattered: on w3 the shared `~/.mintlify/mint` cache **actually served a sibling's pre-edit copy while returning 200 on all four pages**. It was caught by the marker check and re-run under an isolated `HOME`, deliberately without clearing the cache other writers were using.

## Known-good, do not flag

`mk8s/add-ons/dashboard.mdx → headlamp` is a pre-existing repo-wide broken link. `dev.mysql.com` and `streamlinehq.com` return 403/429 to curl (bot-blocking and rate-limiting respectively), not dead links.

## One follow-up

The self-heal figure disagrees across shipped READMEs — airflow says 5.5–8.5 min in one bullet and ~10 in another; gitea and glitchtip say 6–8. The measured band across five templates is **5.5–10.5 min**, which is what these pages state. Worth a small in-place sweep of the templates repo once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
