### PR TITLE
docs: postgres 3.4.x and all twenty adopters

### DIFF
--- a/template-catalog/templates/chatwoot.mdx
+++ b/template-catalog/templates/chatwoot.mdx
@@ -52,7 +52,7 @@ Chatwoot signs its sessions and encrypts sensitive columns with four keys that y
     Store a copy somewhere safe, outside Control Plane. All four keys are write-once for the life of the installation.
   </Step>
   <Step title="Change the bundled credentials">
-    Change the database password (`postgresHA.postgres.password` or `postgres.config.password`) and the Redis password (`redis.auth.password`) from their placeholder defaults before installing. Both seed their component on first boot and are not updated by later value edits.
+    Change the database password (`postgresHA.postgres.password` or `postgres.credentials.password`) and the Redis password (`redis.auth.password`) from their placeholder defaults before installing. Both seed their component on first boot and are not updated by later value edits.
   </Step>
 </Steps>
 
@@ -216,10 +216,12 @@ postgresHA: # default: highly available PostgreSQL 17.5, pgvector native
 postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA first)
   enabled: false
   image: pgvector/pgvector:pg18 # MUST carry pgvector — stock postgres:18 does not
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: chatwoot
     password: change-me-chatwoot-pg # change before installing
     database: chatwoot
+  config:
+    credentialsSecretName: my-chatwoot-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 250m
     maxCpu: 1000m
@@ -245,8 +247,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: my-chatwoot-pg-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-chatwoot-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 
 redis: # bundled single node — queues, live updates, cache (required)
@@ -444,7 +445,9 @@ Enable exactly one of `postgresHA` (default) or `postgres` — the chart refuses
 - **`postgresHA` (default)** — 3× Patroni PostgreSQL 17.5 with etcd and a HAProxy leader endpoint. Its image ships pgvector natively, which is why it is the default. A first install on this path takes roughly eight minutes.
 - **`postgres`** — One PostgreSQL instance for lighter, non-production deployments. It reaches ready in a few minutes but has no failover.
 
-In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it seeds the database on first boot and is not updated by later value edits.
+In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it seeds the database on first boot and is not updated by later value edits.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Warning>
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
@@ -567,7 +570,7 @@ Enable backups with `postgresHA.backup.enabled` or `postgres.backup.enabled` (ma
         Set `backup.minio.endpoint` to the S3 API address including scheme and port. For the [MinIO](/template-catalog/templates/minio) template deployed in the same GVC, this is `http://WORKLOAD_NAME.GVC_NAME.cpln.local:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket.
+        The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/docmost.mdx
+++ b/template-catalog/templates/docmost.mdx
@@ -153,10 +153,12 @@ internalAccess:
 
 postgres: # documents, users, spaces
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: docmost
     password: change-me-docmost-pg # change before installing
     database: docmost
+  config:
+    credentialsSecretName: my-docmost-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 250m
     maxCpu: 1000m
@@ -342,7 +344,8 @@ With SMTP disabled there is no way to deliver a member invitation. The image sen
 
 ### Databases
 
-- `postgres.config.username` / `password` / `database` — Credentials for the bundled PostgreSQL from the [postgres](/template-catalog/templates/postgres) subchart. **Change the password before installing** — it seeds the database on first boot and is not updated by later value edits.
+- `postgres.credentials.username` / `password` / `database` — Credentials for the bundled PostgreSQL from the [postgres](/template-catalog/templates/postgres) subchart. **Change the password before installing** — it seeds the database on first boot and is not updated by later value edits.
+- `postgres.config.credentialsSecretName` — Name of the dictionary secret the chart creates from those three values and hands to the bundled PostgreSQL. Secret names are organization-wide, so give each release its own name; a second release left on the default is **refused at install** and creates nothing, leaving the first release untouched.
 - `postgres.resources` / `postgres.volumeset.capacity` — CPU and memory bounds and the initial data volume size in GiB (minimum 10).
 - `redis.auth.password` — Password for the bundled Redis, wired into Docmost's `REDIS_URL`. **Change it before installing.** Redis requires authentication: an unauthenticated client is refused.
 - `redis.resources` / `redis.volumeset.capacity` — CPU and memory bounds and the volume size for the Redis AOF file at `/data`.
@@ -372,7 +375,7 @@ Redis is not optional. Docmost's health check reports the Redis connection along
 - **`docmost.replicas` above `1` requires `storage.type: s3`** — local attachments are per-replica and would `404` across replicas.
 - **AWS S3 is keyless only** — use a cloud account plus a bucket-scoped IAM policy. Static keys are accepted only when `storage.s3.endpoint` points at an S3-compatible server.
 - **Uploads larger than `storage.fileUploadSizeLimit` are truncated, not rejected** — raise the limit before importing large attachments.
-- **Change `postgres.config.password` and `redis.auth.password` before installing** — both seed their component on first boot and are not updated by later value edits.
+- **Change `postgres.credentials.password` and `redis.auth.password` before installing** — both seed their component on first boot and are not updated by later value edits.
 - **Pages survive restarts and upgrades** — documents live in the PostgreSQL volume set and local attachments in the storage volume set. Uninstalling deletes those volume sets and everything in them; your `APP_SECRET` secret is yours and survives an uninstall.
 - **Docmost is licensed under the AGPL** — this template deploys the open-source edition.
 

--- a/template-catalog/templates/fusionauth.mdx
+++ b/template-catalog/templates/fusionauth.mdx
@@ -114,10 +114,12 @@ firewall:
 # Database configuration
 postgres:
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: username
     password: password
     database: test
+  config:
+    credentialsSecretName: my-fusionauth-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 200m
     minMemory: 128Mi
@@ -173,8 +175,9 @@ postgres:
 
 ### PostgreSQL
 
-- `postgres.config.username` / `postgres.config.password` — Database credentials. **Change before deploying to production.**
-- `postgres.config.database` — Name of the database created on startup.
+- `postgres.credentials.username` / `postgres.credentials.password` — Database credentials. They ship as the literal strings `username` and `password`, which work exactly as written rather than failing loudly, so **set your own before the first install**.
+- `postgres.credentials.database` — Name of the database created on startup. Ships as `test`.
+- `postgres.config.credentialsSecretName` — Name of the dictionary secret the chart creates from those three values and hands to the bundled PostgreSQL. Secret names are organization-wide, so give each release its own name; a second release left on the default is **refused at install** and creates nothing, leaving the first release untouched.
 
 <Note>
 These values are only applied on first startup when the data directory is empty. Updating them after the initial deployment will have no effect on the running database. To change credentials or the database name on an existing instance, use PostgreSQL's native commands (e.g. `ALTER USER`, `ALTER DATABASE`).

--- a/template-catalog/templates/gitea.mdx
+++ b/template-catalog/templates/gitea.mdx
@@ -198,10 +198,12 @@ internalAccess: # internal firewall scope
 # GVC — but the password is used AS-IS, so change it before installing.
 postgres:
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: gitea
     password: change-me-gitea-db
     database: gitea
+  config:
+    credentialsSecretName: my-gitea-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 200m
     minMemory: 256Mi
@@ -254,7 +256,8 @@ Set `publicAccess.enabled: false` to keep Gitea inside the GVC and reach the UI 
 
 Bundled plumbing: the database serves Gitea only and is unreachable from outside the GVC, and nobody ever types this password into a client, so it stays a value.
 
-- `postgres.config.username` / `password` / `database` — Credentials for the bundled PostgreSQL, applied on first startup. **Change the password before installing** — the shipped `change-me-gitea-db` is a published placeholder.
+- `postgres.credentials.username` / `password` / `database` — Credentials for the bundled PostgreSQL, applied on first startup. **Change the password before installing** — the shipped `change-me-gitea-db` is a published placeholder.
+- `postgres.config.credentialsSecretName` — Name of the dictionary secret the chart creates from those three values and hands to the bundled PostgreSQL. Secret names are organization-wide, so give each release its own name; a second release left on the default is **refused at install** and creates nothing, leaving the first release untouched.
 - `postgres.resources` — Reservation and limit for the PostgreSQL container.
 - `postgres.volumeset.capacity` and `postgres.volumeset.autoscaling` — Initial Postgres volume size in GiB (minimum 10) and its autoscaling settings.
 - `postgres.internalAccess.type` — Controls which workloads can reach PostgreSQL.

--- a/template-catalog/templates/glitchtip.mdx
+++ b/template-catalog/templates/glitchtip.mdx
@@ -275,10 +275,12 @@ postgresHA:
 # Enable this and disable postgresHA for a lighter non-HA deployment.
 postgres:
   enabled: false
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: glitchtip
     password: change-me-glitchtip-db # change before installing
     database: glitchtip
+  config:
+    credentialsSecretName: my-glitchtip-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 
@@ -303,8 +305,7 @@ postgres:
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: my-glitchtip-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-glitchtip-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 ```
 
@@ -355,7 +356,9 @@ Set `publicAccess.enabled: false` for in-GVC reporters only, and reach the UI wi
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). GlitchTip is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
-Both database passwords are bundled plumbing — the database serves GlitchTip only and is unreachable from outside the GVC — but they are used as-is, so **change `postgresHA.postgres.password` or `postgres.config.password` before installing**. The shipped `change-me-glitchtip-db` is a published placeholder.
+Both database passwords are bundled plumbing — the database serves GlitchTip only and is unreachable from outside the GVC — but they are used as-is, so **change `postgresHA.postgres.password` or `postgres.credentials.password` before installing**. The shipped `change-me-glitchtip-db` is a published placeholder.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Warning>
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Version `1.0.1` and later turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
@@ -376,7 +379,7 @@ Registration is closed by default (`registration.enabled: false`) — an overrid
 | Login | The `adminEmail` / `adminPassword` keys of your auth secret |
 | Django admin (user management) | `https://<canonical>.cpln.app/admin/` |
 | PostgreSQL (internal, HA mode) | `RELEASE_NAME-postgres-ha-proxy.GVC_NAME.cpln.local:5432`, credentials in the `RELEASE_NAME-postgres-config` secret |
-| PostgreSQL (internal, single mode) | `RELEASE_NAME-postgres.GVC_NAME.cpln.local:5432`, credentials in the `RELEASE_NAME-pg-config` secret |
+| PostgreSQL (internal, single mode) | `RELEASE_NAME-postgres.GVC_NAME.cpln.local:5432`, credentials in the secret named by `postgres.config.credentialsSecretName` |
 
 ### Reporting Errors
 
@@ -445,7 +448,7 @@ Database backups are optional and disabled by default. They cover the PostgreSQL
         Set `backup.minio.endpoint` to the S3 API address including port. For the `minio` marketplace template deployed in the same GVC, this is `http://WORKLOAD_NAME:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket.
+        The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/grafana.mdx
+++ b/template-catalog/templates/grafana.mdx
@@ -231,10 +231,12 @@ postgresHA: # default: highly available PostgreSQL app database
 
 postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA first)
   enabled: false
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: grafana
     password: change-me-grafana-db-password # change before installing
     database: grafana
+  config:
+    credentialsSecretName: my-grafana-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 
@@ -259,8 +261,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: grafana-pg-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-grafana-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 
 redis: # Sentinel-mode Redis — alerting-HA coordination; required when replicas >= 2
@@ -488,7 +489,7 @@ A workload's built-in `CPLN_TOKEN` does **not** authenticate against the metrics
 | Internal (same GVC) | `http://{release}-grafana.{gvc}.cpln.local:3000` |
 | Login | `admin.user` / the payload of the `admin.passwordSecretName` secret — or whatever you have since changed the password to in the UI |
 | App database (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
-| App database (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
+| App database (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the secret named by `postgres.config.credentialsSecretName` |
 
 Health and readiness are served at `/api/health`, which reports the Grafana version and the app-database status:
 
@@ -561,7 +562,7 @@ Database backups are optional and disabled by default. They cover the app databa
         Set `backup.minio.endpoint` to the S3 API address including port. For the [MinIO](/template-catalog/templates/minio) template deployed in the same GVC, this is `http://WORKLOAD_NAME:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket.
+        The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/grafana.mdx
+++ b/template-catalog/templates/grafana.mdx
@@ -75,7 +75,7 @@ Optional features each need a secret or a bucket created **before** you install:
 | Authenticated SMTP | An [opaque secret](/guides/create-secret/opaque) with encoding `plain` holding the SMTP password, named in `smtp.passwordSecretName` |
 | Database backups | A bucket and access setup on AWS S3, Google Cloud Storage, or an S3-compatible server — see [Backing Up](#backing-up) |
 
-Change the app database password (`postgresHA.postgres.password` or `postgres.config.password`) before installing as well — it ships with a `change-me` placeholder default.
+Change the app database password (`postgresHA.postgres.password` or `postgres.credentials.password`) before installing as well — it ships with a `change-me` placeholder default.
 
 Once both secrets exist, install the template using your preferred method:
 
@@ -346,7 +346,9 @@ Firewall changes applied by an upgrade take up to about 30 seconds to propagate.
 
 ### App Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Grafana is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode. In HA mode `postgresHA.proxy.enabled` must stay `true` — that HAProxy endpoint is Grafana's stable database address, and disabling it is rejected at render.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Grafana is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode. In HA mode `postgresHA.proxy.enabled` must stay `true` — that HAProxy endpoint is Grafana's stable database address, and disabling it is rejected at render.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Warning>
 **Template versions before `1.2.1` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.2.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.

--- a/template-catalog/templates/infisical.mdx
+++ b/template-catalog/templates/infisical.mdx
@@ -117,10 +117,12 @@ internalAccess:
 # PostgreSQL — durable secret store
 postgres:
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: infisical
     password: change-me-infisical-pg   # change before installing
     database: infisical
+  config:
+    credentialsSecretName: my-infisical-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 250m
     maxCpu: 1000m
@@ -176,7 +178,8 @@ Off by default — the zero-config install works via the no-email admin-signup b
 
 ### PostgreSQL
 
-- `postgres.config.password` — The bundled database password. **Change it before installing.**
+- `postgres.credentials.password` — The bundled database password. **Change it before installing.**
+- `postgres.config.credentialsSecretName` — Name of the dictionary secret the chart creates from those three values and hands to the bundled PostgreSQL. Secret names are organization-wide, so give each release its own name; a second release left on the default is **refused at install** and creates nothing, leaving the first release untouched.
 - `postgres.volumeset.capacity` — Initial volume size in GiB (minimum 10).
 
 PostgreSQL stores everything: secrets, versions, projects, environments, and users.

--- a/template-catalog/templates/keycloak.mdx
+++ b/template-catalog/templates/keycloak.mdx
@@ -212,10 +212,12 @@ postgresHA:
 # Enable this and disable postgresHA for a lighter non-HA deployment.
 postgres:
   enabled: false
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: keycloak
     password: change-me-keycloak-db # change before installing
     database: keycloak
+  config:
+    credentialsSecretName: my-keycloak-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 
@@ -240,8 +242,7 @@ postgres:
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: my-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-keycloak-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 
 # ─── Access ───────────────────────────────────────────────────────────────────

--- a/template-catalog/templates/keycloak.mdx
+++ b/template-catalog/templates/keycloak.mdx
@@ -107,7 +107,7 @@ Version `1.1.0` moved the bootstrap admin login out of Helm values. Earlier vers
 |---|---|---|
 | Bootstrap admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `username` and `password` |
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
-| Database password | A value (`postgresHA.postgres.password` / `postgres.config.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgresHA.postgres.password` / `postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -281,7 +281,7 @@ Exactly one of the two stores must be enabled — the chart enforces this at ren
 
 - `postgresHA` (default) — A highly available PostgreSQL cluster from the [PostgreSQL Highly Available template](/template-catalog/templates/postgres-highly-available): 3 Patroni replicas, 3 etcd replicas, and an HAProxy endpoint that routes Keycloak's connections to the current leader. Do not disable the HA proxy (`postgresHA.proxy.enabled`) — Keycloak writes through the HAProxy leader endpoint, and the chart enforces this at render.
 - `postgres` — A single-instance PostgreSQL from the [PostgreSQL template](/template-catalog/templates/postgres), for lighter dev/test deployments. Set `postgresHA.enabled: false` and `postgres.enabled: true`.
-- `postgresHA.postgres.*` / `postgres.config.*` — Database credentials and database name. **Change the password before installing.**
+- `postgresHA.postgres.*` / `postgres.credentials.*` — Database credentials and database name. **Change the password before installing.**
 - `postgresHA.volumeset.capacity` / `postgres.volumeset.capacity` — Initial volume size in GiB (minimum 10, per replica for the HA store).
 
 <Warning>
@@ -319,7 +319,9 @@ On a first install of the default HA stack, the Keycloak container waits for the
 ## Important Notes
 
 - **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
-- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 - **The bootstrap admin is temporary by design** — log in, create a permanent admin, then remove it. Its credentials are seeded on first boot only; change the password in the admin console, not by editing the secret.
 - **Keep `publicAccess` enabled for browser SSO** — end-user browsers must reach Keycloak's login endpoints; disable it only for pure service-to-service deployments.
 - **Do not disable the HA proxy** (`postgresHA.proxy.enabled`) — Keycloak connects through the HAProxy leader endpoint for writes; the chart enforces this at render.

--- a/template-catalog/templates/langfuse.mdx
+++ b/template-catalog/templates/langfuse.mdx
@@ -271,10 +271,12 @@ postgres:
     maxCpu: 1
     minMemory: 512Mi
     maxMemory: 1Gi
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: langfuse
     password: change-me-langfuse-db
     database: langfuse
+  config:
+    credentialsSecretName: my-langfuse-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
 
@@ -379,9 +381,11 @@ Set `objectStore.provider` to `aws` or `gcp` and fill in the matching block; the
 
 The three datastore passwords are internal plumbing: PostgreSQL, Redis, and ClickHouse serve Langfuse only and are unreachable from outside the GVC. They are still used exactly as written, so **change all three before installing** — they ship as obvious `change-me-` placeholders:
 
-- `postgres.config.password`
+- `postgres.credentials.password`
 - `redis.auth.password`
 - `clickhouse.config.password`
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 Each datastore's `volumeset.capacity` is its initial size in GiB, with 10 the minimum.
 

--- a/template-catalog/templates/listmonk.mdx
+++ b/template-catalog/templates/listmonk.mdx
@@ -161,10 +161,12 @@ internalAccess:
 postgres: # default: single-instance PostgreSQL
   enabled: true
   image: postgres:18 # listmonk requires Postgres 12+
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: listmonk
     password: change-me-listmonk-db # change before installing
     database: listmonk
+  config:
+    credentialsSecretName: my-listmonk-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
   backup:
@@ -365,7 +367,7 @@ Database backups are optional and disabled by default. When enabled, a scheduled
         Create your bucket on the server. Set `backup.minio.bucket` to its name.
       </Step>
       <Step title="Set the endpoint and credentials">
-        Set `backup.minio.endpoint` to the S3 API address including port, and `backup.minio.accessKey` / `backup.minio.secretKey` to credentials with access to the bucket. No Cloud Account is required — the keys authenticate directly.
+        Set `backup.minio.endpoint` to the S3 API address including port. No Cloud Account is required — the credentials authenticate directly. The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/listmonk.mdx
+++ b/template-catalog/templates/listmonk.mdx
@@ -238,7 +238,9 @@ Firewall changes take roughly 30 seconds to a few minutes to propagate after an 
 
 ### Backing Store
 
-Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.config.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards.
+Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 The database holds everything except uploaded media: lists, subscribers, campaigns, templates, users, and all of the settings you configure in the admin UI.
 
@@ -255,7 +257,7 @@ Version `1.1.0` moved the Super Admin login out of Helm values. Earlier versions
 | Super Admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `username` and `password` |
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
 | Minimum-length check | At render, from the values | At container startup, from the secret — with a message naming the secret |
-| Database password | A value (`postgres.config.password` / `postgresHA.postgres.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgres.credentials.password` / `postgresHA.postgres.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -376,7 +378,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **Single instance by design — there is no `replicas` knob.** Listmonk runs its campaign workers in-process, so two instances against one database would send every campaign twice. The workload is pinned to one replica and rolls out without surge: the old replica stops before the new one starts, which means an upgrade or restart causes a brief gap in availability instead of overlapping senders. Durability comes from PostgreSQL and the uploads volume set.
 - **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
 - **Mind the minimum credential lengths** — a username under 3 characters or a password under 8 makes upstream's install step fail; the container catches this at startup and names the secret instead of looping on a misleading database message.
-- **Change the database password before installing** (`postgres.config.password` / `postgresHA.postgres.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design. Both the admin account and the database are seeded on first boot only.
+- **Change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design. Both the admin account and the database are seeded on first boot only.
 - **No mail is delivered until SMTP is configured** in **Admin → Settings → SMTP**. Before that, starting a campaign is not an error — it runs and finishes with zero messages sent.
 - **Keep `publicAccess` enabled for subscriber-facing pages to work.** Subscription forms, unsubscribe links, and tracking pixels must be reachable from the internet; the admin UI and API stay authentication-gated either way.
 - **Use `/health` for external health checks**, not `/api/health` — the latter requires an authenticated session.

--- a/template-catalog/templates/litellm.mdx
+++ b/template-catalog/templates/litellm.mdx
@@ -108,10 +108,12 @@ internalAccess:
 # PostgreSQL — virtual keys / spend / budgets
 postgres:
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: litellm
     password: change-me-litellm-pg     # change before installing
     database: litellm
+  config:
+    credentialsSecretName: my-litellm-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 250m
     maxCpu: 1000m
@@ -162,7 +164,8 @@ redis:
 
 ### PostgreSQL
 
-- `postgres.config.password` — The bundled database password. **Change it before installing.**
+- `postgres.credentials.password` — The bundled database password. **Change it before installing.**
+- `postgres.config.credentialsSecretName` — Name of the dictionary secret the chart creates from those three values and hands to the bundled PostgreSQL. Secret names are organization-wide, so give each release its own name; a second release left on the default is **refused at install** and creates nothing, leaving the first release untouched.
 - `postgres.volumeset.capacity` — Initial volume size in GiB (minimum 10).
 
 PostgreSQL stores all virtual keys, spend, teams, and budgets.

--- a/template-catalog/templates/metabase.mdx
+++ b/template-catalog/templates/metabase.mdx
@@ -273,7 +273,9 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 ### App Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Metabase is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Metabase is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Warning>
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
@@ -289,7 +291,7 @@ Version `1.1.0` moved the admin login out of Helm values. Earlier versions shipp
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
 | `admin.firstName` / `admin.lastName` / `siteName` | Values | Unchanged |
 | `encryptionKey.secretName` | Prerequisite opaque secret | Unchanged |
-| Database password | A value (`postgresHA.postgres.password` / `postgres.config.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgresHA.postgres.password` / `postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -405,7 +407,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 
 - **Back up the encryption-key secret** — losing or changing it means re-entering every saved database connection; rotation is only possible offline via Metabase's `rotate-encryption-key` command.
 - **Create both prerequisite secrets before installing** — a missing one leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
-- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
 - **A weak or malformed admin password keeps the workload unready by design** — Metabase's own check requires letters and digits, 8+ characters, and the container refuses to run setup if the email or password contains a double quote or a backslash. A failed bootstrap is fail-closed rather than exposing an open setup page.
 - **Metabase is single-replica in this template** — the default HA PostgreSQL backend removes the database as a failure point.
 - **Upgrades restart the single replica** — expect a few minutes of UI downtime per Helm upgrade; the HA app database keeps running and no data is lost.

--- a/template-catalog/templates/metabase.mdx
+++ b/template-catalog/templates/metabase.mdx
@@ -217,10 +217,12 @@ postgresHA: # default: highly available PostgreSQL app database
 
 postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA first)
   enabled: false
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: metabase
     password: change-me-metabase-db-password # change before installing
     database: metabase
+  config:
+    credentialsSecretName: my-metabase-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
   backup:
@@ -244,8 +246,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: metabase-pg-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-metabase-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 ```
 
@@ -331,7 +332,7 @@ To upgrade an existing install:
 | Internal (same GVC) | `http://{release}-metabase.{gvc}.cpln.local:3000` |
 | Login | The `email` / `password` in your `admin.secretName` secret — `cpln secret reveal my-metabase-admin -o yaml` |
 | App database (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
-| App database (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
+| App database (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the secret named by `postgres.config.credentialsSecretName` |
 
 ### Adding Data Sources
 
@@ -395,7 +396,7 @@ Database backups are optional and disabled by default. They cover the app databa
         Set `backup.minio.endpoint` to the S3 API address including port. For the `minio` marketplace template deployed in the same GVC, this is `http://WORKLOAD_NAME:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket.
+        The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/n8n.mdx
+++ b/template-catalog/templates/n8n.mdx
@@ -318,7 +318,9 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 ### Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). n8n is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). n8n is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Warning>
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
@@ -415,7 +417,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 - **Back up the encryption-key secret** — losing it permanently bricks every credential n8n has stored; never change it after first boot (n8n fails to start on a key mismatch).
 - **Create both prerequisite secrets before installing.** A missing one wedges the deployment with no log output at all; [Prerequisites](#prerequisites) gives the one command that diagnoses it.
 - **The owner secret is authoritative at every restart** — it is not a one-time bootstrap. Changing it changes the login; see [Upgrading From 1.0.x](#upgrading-from-1-0-x).
-- **Change the bundled database password** (`postgresHA.postgres.password` / `postgres.config.password`) before installing — it is used exactly as written. It stays a value deliberately: it is internal plumbing between n8n and its own database that nobody types.
+- **Change the bundled database password** (`postgresHA.postgres.password` / `postgres.credentials.password`) before installing — it is used exactly as written. It stays a value deliberately: it is internal plumbing between n8n and its own database that nobody types.
 - **The n8n main instance is single-replica by upstream design** — the default HA PostgreSQL backend removes the database as a failure point.
 - **Upgrades restart the single replica** — expect roughly a minute of editor/webhook downtime per Helm upgrade. The first upgrade after an install also re-applies the bundled database, which can add a couple of minutes.
 - **Access changes take time to propagate** — after toggling `publicAccess` or `internalAccess`, re-test over roughly 30 seconds to 5 minutes before concluding the knob is broken.

--- a/template-catalog/templates/n8n.mdx
+++ b/template-catalog/templates/n8n.mdx
@@ -262,10 +262,12 @@ postgresHA: # default: highly available PostgreSQL
 
 postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA first)
   enabled: false
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: n8n
     password: change-me-n8n-db-password # change before installing
     database: n8n
+  config:
+    credentialsSecretName: my-n8n-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
   backup:
@@ -289,8 +291,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: n8n-pg-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-n8n-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 ```
 
@@ -336,7 +337,7 @@ If you run more than one release of this template in the same organization, give
 | Internal (same GVC) | `http://{release}-n8n.{gvc}.cpln.local:5678` |
 | Login | The `email` and the password behind `passwordHash` in your `owner.secretName` secret |
 | PostgreSQL (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
-| PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
+| PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the secret named by `postgres.config.credentialsSecretName` |
 
 ### Webhooks
 
@@ -404,7 +405,7 @@ Database backups are optional and disabled by default. Enable them with `postgre
         Set `backup.minio.endpoint` to the S3 API address including port. For the `minio` marketplace template deployed in the same GVC, this is `http://WORKLOAD_NAME:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket.
+        The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/nocodb.mdx
+++ b/template-catalog/templates/nocodb.mdx
@@ -195,10 +195,12 @@ redis: # bundled single node — job/event pub-sub, cache, rate limiter (require
 postgres: # single instance (default) — PostgreSQL 18
   enabled: true
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: nocodb
     password: change-me-nocodb-db # change before installing; letters, digits, - and _ only
     database: nocodb
+  config:
+    credentialsSecretName: my-nocodb-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 250m
     maxCpu: 1000m
@@ -431,7 +433,9 @@ Redis runs with `maxmemory-policy noeviction`, and this is deliberate: an evicte
 
 ### Database
 
-Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.config.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
+Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 NocoDB connects to the single instance directly, or to the HAProxy leader endpoint in HA mode, and creates its own meta tables and one schema per base on first boot. `postgres.resources` / `postgresHA.resources` and the `volumeset.capacity` values (GiB, minimum 10, per replica in HA mode) size the backing store. `postgresHA.replicas` sets the number of Patroni replicas.
 
@@ -496,7 +500,7 @@ Database backups are optional and disabled by default. When enabled, a scheduled
         Create your bucket on the server. Set `backup.minio.bucket` to its name.
       </Step>
       <Step title="Set the endpoint and credentials">
-        Set `backup.minio.endpoint` to the S3 API address including port, and `backup.minio.accessKey` / `backup.minio.secretKey` to credentials with access to the bucket. No Cloud Account is required — the keys authenticate directly.
+        Set `backup.minio.endpoint` to the S3 API address including port. No Cloud Account is required — the credentials authenticate directly. The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>
@@ -518,7 +522,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **AWS S3 is keyless only** — use a cloud account plus a bucket-scoped IAM policy. Static keys are accepted only when `storage.s3.endpoint` points at an S3-compatible server.
 - **`admin.secretName` re-applies on every boot** — a password changed in the UI is reverted at the next restart. Leave it empty or treat the secret as the source of truth.
 - **The single-instance and HA database paths run different PostgreSQL majors** — 18 and 17 respectively. Choose before you have data; switching is a dump and restore.
-- **Change `postgres.config.password` (or `postgresHA.postgres.password`) and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
+- **Change `postgres.credentials.password` (or `postgresHA.postgres.password`) and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
 - **Set `nocodb.siteUrl` when NocoDB sits behind a custom domain**, with the scheme (`https://data.example.com`). It drives invitation and password-reset links and the auth cookie's secure flag, so a mismatch with the URL browsers use breaks both.
 - **Firewall changes take effect after a delay** — flipping `publicAccess.enabled` or `internalAccess.type` can take half a minute or more to be enforced after the upgrade reports success.
 - **With SMTP off, invitations and password resets cannot be delivered** — configure `smtp.*` before inviting collaborators.

--- a/template-catalog/templates/polaris.mdx
+++ b/template-catalog/templates/polaris.mdx
@@ -145,10 +145,12 @@ internalAccess: # who may reach Polaris from inside Control Plane
 # ─── Metastore: single-instance PostgreSQL (default) ──────────────
 postgres:
   enabled: true
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: polaris
     password: change-me-polaris-db # change before installing
     database: polaris
+  config:
+    credentialsSecretName: my-polaris-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 200m
     maxCpu: 500m
@@ -262,7 +264,9 @@ Exactly one of `postgres` (default) and `postgresHA` must be enabled — the cha
 | Footprint | 1 workload | 8 replicas across 3 workloads |
 | Time to ready | ~90 s | ~6 min |
 
-Switch by setting `postgres.enabled: false` and `postgresHA.enabled: true`. Polaris is wired to whichever is active automatically — the single instance directly, or the HAProxy leader endpoint in HA mode. **Change the database password before installing** in either mode (`postgres.config.password` or `postgresHA.postgres.password`); the default is an obvious placeholder.
+Switch by setting `postgres.enabled: false` and `postgresHA.enabled: true`. Polaris is wired to whichever is active automatically — the single instance directly, or the HAProxy leader endpoint in HA mode. **Change the database password before installing** in either mode (`postgres.credentials.password` or `postgresHA.postgres.password`); the default is an obvious placeholder.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 Each Polaris replica opens up to 20 JDBC connections, plus the bootstrap workload — about 21 of PostgreSQL's default 100 at `replicas: 1`, and about 61 at `replicas: 3`.
 
@@ -385,7 +389,7 @@ Any other Iceberg REST client — Spark, PyIceberg, Flink — connects the same 
 | OAuth2 token endpoint | `{base}/api/catalog/v1/oauth/tokens` |
 | Health and metrics | `http://{release}-polaris.{gvc}.cpln.local:8182/q/health` and `/q/metrics` — **in-GVC only** |
 | Credentials | `CLIENT_ID` / `CLIENT_SECRET` from your `rootCredentials` secret |
-| Metastore (single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
+| Metastore (single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the secret named by `postgres.config.credentialsSecretName` |
 | Metastore (HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
 
 Same-GVC clients use plain `http://` over the mesh's mTLS; external clients use `https://` with TLS terminated at the platform edge. A request with no bearer token, or a wrong client secret, is rejected with `401`.
@@ -427,7 +431,7 @@ Metastore backups are off by default and need no cloud account. Turn them on wit
     Create the bucket and a Control Plane [cloud account](/guides/create-cloud-account), grant its service account **Storage Object Admin** (`roles/storage.objectAdmin`) on the bucket, then set `provider: gcp` and the `gcp.bucket` and `gcp.cloudAccountName` values.
   </Tab>
   <Tab title="MinIO / S3-compatible">
-    No cloud account is needed — the keys authenticate directly. Set `provider: minio` and the `minio.endpoint`, `minio.bucket`, `minio.accessKey` and `minio.secretKey` values. A [seaweedfs](/template-catalog/templates/seaweedfs) or [minio](/template-catalog/templates/minio) deployment in the same GVC works as the target.
+    No cloud account is needed — the credentials authenticate directly. Set `provider: minio` plus `minio.endpoint` and `minio.bucket`. The two stores then differ on credentials: `postgresHA` takes `minio.accessKey` and `minio.secretKey` as values, while `postgres` takes a `minio.credentialsSecretName` naming a [dictionary secret](/guides/create-secret/dictionary) that holds the keys `accessKey` and `secretKey` — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command. A [seaweedfs](/template-catalog/templates/seaweedfs) or [minio](/template-catalog/templates/minio) deployment in the same GVC works as the target.
   </Tab>
 </Tabs>
 
@@ -440,7 +444,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **Root credentials are write-once**; they are applied only at first bootstrap. Rotate by creating a new principal through the management API.
 - **Rotating the token signing key invalidates every outstanding token** — clients must request a new one.
 - **`realm` is permanent.** Renaming it bootstraps a new, empty realm and hides the existing catalogs.
-- **Change the metastore password before installing** (`postgres.config.password` or `postgresHA.postgres.password`) — the default is a placeholder.
+- **Change the metastore password before installing** (`postgres.credentials.password` or `postgresHA.postgres.password`) — the default is a placeholder.
 - **No credential vending in this version.** Polaris and each query engine hold their own static object-storage credentials; keep `iceberg.rest-catalog.vended-credentials-enabled=false` in Trino.
 - **Health and metrics are in-GVC only.** They are served on port `8182`, which the public canonical endpoint does not route to.
 - **Polaris does not migrate its own database schema.** Treat a future Polaris version bump as an explicit schema step, not something startup handles.

--- a/template-catalog/templates/postgres.mdx
+++ b/template-catalog/templates/postgres.mdx
@@ -140,7 +140,7 @@ The secret my-postgres-credentials no longer exists. Workload updates are paused
 secret is added or the reference to the secret removed.
 ```
 
-Use `get-deployments` — plain `cpln workload get` has no `versions` key and will show you nothing. Creating the missing secret repairs it on its own in roughly **6 to 8.5 minutes** with no further action, or run `cpln workload force-redeployment RELEASE_NAME-postgres --gvc GVC_NAME` to clear it in about 90 seconds.
+Use `get-deployments` — plain `cpln workload get` has no `versions` key and will show you nothing. Creating the missing secret repairs it on its own with no further action, in roughly **5.5 to 10.5 minutes** measured across five templates, or run `cpln workload force-redeployment RELEASE_NAME-postgres --gvc GVC_NAME` to clear it in about 90 seconds.
 </Warning>
 
 Backups need a bucket, and for AWS or GCP a Control Plane Cloud Account, before they can be enabled — see [Backup Prerequisites](#backup-prerequisites). MinIO backups need a second dictionary secret holding `accessKey` and `secretKey`. Nothing else is required.

--- a/template-catalog/templates/postgres.mdx
+++ b/template-catalog/templates/postgres.mdx
@@ -1,33 +1,153 @@
 ---
 title: PostgreSQL
-description: Deploy PostgreSQL on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, and single-replica setup with optional scheduled S3, GCS, or MinIO backups.
-keywords: ['pg', 'postgres', 'rdbms', 'oltp', 'sql database', 'pgbouncer', 'connection pooler', 'pg_dump', 'wal', 'psql', 'pgadmin', 'rds alternative']
+description: Deploy PostgreSQL on Control Plane using the Template Catalog. Covers the prerequisite credentials secret, volumes, internal access, PgBouncer pooling, scheduled S3, GCS and MinIO backups, and upgrading from template version 3.3.0.
+keywords: ['pg', 'postgres', 'rdbms', 'oltp', 'sql database', 'pgbouncer', 'connection pooler', 'pg_dump', 'psql', 'pgadmin', 'rds alternative', 'dictionary secret', 'alter role', 'database template']
 ---
 
 ## Overview
 
-PostgreSQL is a powerful open-source relational database. This template deploys a single-replica PostgreSQL instance with persistent storage and optional scheduled backups to AWS S3, GCS, or a self-hosted MinIO instance.
+PostgreSQL is a powerful open-source relational database. This template deploys a single-replica PostgreSQL instance with persistent storage, an optional PgBouncer connection pooler, and optional scheduled backups to AWS S3, GCS, or a self-hosted MinIO instance.
+
+Database credentials are **not** template values. PostgreSQL reads its username, password and database name from a dictionary secret you create before installing, so no password passes through Helm or lands in the release.
+
+<Warning>
+**Template version 3.4.0 is a breaking security change.** `config.username`, `config.password` and `config.database` were removed, and an install or upgrade that still sets any of them now fails at render instead of silently falling back to a published default password. If you are running 3.3.0 or earlier, read [Upgrading From 3.3.0 or Earlier](#upgrading-from-3-3-0-or-earlier) before you touch the release.
+</Warning>
 
 <Note>
-PostgreSQL on Control Plane operates as a single-replica deployment. Do not scale up the replica count, as this would result in multiple isolated instances rather than a replicated cluster. For a highly available setup, use the [PostgreSQL Highly Available](/template-catalog/templates/postgres-highly-available) template instead.
+PostgreSQL on Control Plane operates as a single-replica deployment. Do not scale up the replica count, as this would result in multiple isolated instances rather than a replicated cluster. For a highly available setup, use the [PostgreSQL Highly Available](/template-catalog/templates/postgres-highly-available) template instead, or [Postgres Multi Location](/template-catalog/templates/postgres-multi-location) to span regions.
 </Note>
 
 ### What Gets Created
 
-- **Stateful Postgres Workload** — A single-replica PostgreSQL container with configurable resources.
-- **Volume Set** — Persistent storage for database data, with optional autoscaling.
-- **Secret** — A dictionary secret storing the database username and password, injected into the container at startup.
-- **Identity & Policy** — An identity bound to the workload with `reveal` access to the database credentials secret, and cloud storage access when backup is enabled.
-- **PgBouncer Workload** *(optional)* — A PgBouncer connection pooler deployed as a separate workload in front of PostgreSQL.
-- **Backup Cron Workload** *(optional)* — A scheduled `pg_dump` backup job that writes compressed SQL dumps to AWS S3, GCS, or MinIO.
+- **Stateful Postgres Workload** — (`RELEASE_NAME-postgres`): a single-replica PostgreSQL container serving TCP on port `5432`, with configurable resources.
+- **Volume Set** — (`RELEASE_NAME-pg-vs`): an `ext4` volume holding `PGDATA`, on general-purpose SSD with daily snapshots and 7-day retention, with optional autoscaling.
+- **Identity & Policy** — (`RELEASE_NAME-pg-identity`, `RELEASE_NAME-pg-policy`): an identity bound to the database, pooler and backup workloads, and a policy granting it `reveal` on exactly the credential secrets you created — nothing else. When backups are enabled, the identity also carries the Cloud Account binding the backup job uses to reach your bucket.
+- **PgBouncer Workload** *(optional)* — (`RELEASE_NAME-pgbouncer`): a connection pooler deployed as a separate workload in front of PostgreSQL, created when `pgbouncer.enabled: true`.
+- **Backup Cron Workload** *(optional)* — (`RELEASE_NAME-postgres-backup`): a scheduled `pg_dump` that writes compressed SQL dumps to AWS S3, GCS or MinIO, created when `backup.enabled: true`.
+
+The template creates **no credential secret of its own**. Every password lives in the prerequisite secrets described below.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Upgrading From 3.3.0 or Earlier
+
+Template versions up to 3.3.0 took the database credentials as plain Helm values and shipped a working default password for them, and wrote those credentials into a chart-owned secret named after the release. Version 3.4.0 removes both.
+
+| | 3.3.0 and earlier | 3.4.0 |
+|---|---|---|
+| Database credentials | `config.username`, `config.password`, `config.database` values | `config.credentialsSecretName` → a dictionary secret you create |
+| Credential secret | `RELEASE_NAME-pg-config`, created by the chart | Not created — credentials live only in your secret |
+| MinIO backup credentials | `backup.minio.accessKey`, `backup.minio.secretKey` values | `backup.minio.credentialsSecretName` → a dictionary secret you create |
+| Backup identity permissions | Bucket-scoped policy plus `aws::ReadOnlyAccess` | Bucket-scoped policy only |
+| `backup.schedule` | Any cron beginning with `*` failed to render | Accepts every cron form, including `*/15 * * * *` |
+
+<Warning>
+**Carrying old values forward stops the upgrade.** Each removed key is rejected at render, so `cpln helm upgrade` fails and your existing release is left untouched and running rather than quietly restarting against a different password:
+
+```text
+Error: execution error at (postgres/templates/workload-postgres.yaml:1:4): config.username was
+REMOVED in postgres 3.4.0. Database credentials are no longer values: create a `dictionary` secret
+holding the keys `username`, `password` and `database`, and set config.credentialsSecretName to its
+name. See Prerequisites in the README.
+```
+
+`config.password` and `config.database` each produce the same message under their own name, and MinIO backups produce:
+
+```text
+Error: ... backup.minio.accessKey and backup.minio.secretKey were REMOVED in postgres 3.4.0. Create a
+`dictionary` secret holding the keys `accessKey` and `secretKey`, and set
+backup.minio.credentialsSecretName to its name. See Storage setup in the README.
+```
+</Warning>
+
+<Steps>
+  <Step title="Read the credentials the database already uses">
+    Credentials are written into the data directory the first time the volume is initialized, so an existing database keeps whatever it was created with. Recover them from your current values file, or from the secret the old version created — do this **before** upgrading:
+
+    ```bash
+    cpln secret reveal RELEASE_NAME-pg-config -o yaml
+    ```
+
+    The keys are `username`, `password` and `database`.
+  </Step>
+  <Step title="Create the prerequisite secret with those same values">
+    Follow [Prerequisites](#prerequisites), using the existing username, password and database name. Using different values here does not change the database — it just leaves the workload unable to authenticate.
+  </Step>
+  <Step title="Remove the old keys from your values">
+    Delete `config.username`, `config.password` and `config.database`, and set `config.credentialsSecretName` to your secret's name. If you back up to MinIO, replace `backup.minio.accessKey` and `backup.minio.secretKey` with `backup.minio.credentialsSecretName`.
+  </Step>
+  <Step title="Upgrade, then rotate the password">
+    After the upgrade succeeds, change any password that came from a 3.3.x default — those defaults were published in the public template repository, so treat them as compromised. Rotate inside PostgreSQL and update the secret to match:
+
+    ```sql
+    ALTER ROLE appuser WITH PASSWORD 'NEW-STRONG-PASSWORD';
+    ```
+
+    Use your own username in place of `appuser`, then update the secret so the workload can still authenticate after a restart.
+  </Step>
+</Steps>
+
+<Warning>
+**The chart no longer creates `RELEASE_NAME-pg-config`.** Anything outside this release that referenced that secret by name — another workload's environment, a policy, or a parent chart that bundles PostgreSQL as a subchart — must be pointed at the secret you created instead. A reference to a secret that no longer exists does not fail loudly; it wedges the referring workload silently.
+</Warning>
+
+<Note>
+**`aws::ReadOnlyAccess` was removed from the backup identity, and no action is required from you.** Control Plane attaches each policy reference as a managed policy on a per-identity derived IAM role, so the identity's permissions are the union of those references. `ReadOnlyAccess` contains no write actions at all — its S3 portion is `Get*` and `List*` on `*` — so it was never carrying the backup upload; what it granted was read access to every bucket in the account. Backups continue to work without it. **Existing bucket policies are also unaffected:** a 30.9 MB multipart upload succeeded under the six-action policy documented by earlier template versions, because a multipart upload authorizes under `s3:PutObject`. The four additional actions in the [AWS S3](#aws-s3) policy below are defensive — they let a failed upload abort its own parts instead of leaving them to bill silently — not required.
+</Note>
+
+<Note>
+**`backup.schedule` now accepts every cron form.** In 3.3.0 and earlier, any schedule beginning with `*` — such as `*/15 * * * *` — failed to render with a raw YAML parse error naming a template file, because an unquoted YAML scalar starting with `*` is an alias indicator. If you worked around this with a digit-leading schedule, you can now use the interval form directly.
+</Note>
+
+## Prerequisites
+
+**One secret must exist before you install.** It holds the credentials your applications put in their connection strings. The values never pass through Helm, so they do not land in the release. Secrets are org-level, so no GVC flag is involved.
+
+<Steps>
+  <Step title="Create the database credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly three keys — `username`, `password` and `database`. PostgreSQL creates that user and that database on first boot:
+
+    ```bash
+    cpln secret create-dictionary --name my-postgres-credentials \
+      --entry username=postgres \
+      --entry password='YOUR-STRONG-PASSWORD' \
+      --entry database=mydb
+    ```
+
+    Set `config.credentialsSecretName` to the name you used.
+  </Step>
+  <Step title="Read the secret back later">
+    Pass `-o yaml`. A bare `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-postgres-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**Create the secret before installing, or the deployment wedges silently.** The template refuses to render when `config.credentialsSecretName` is blank, but a name that points at a secret which does not exist installs "successfully" and then never starts. The container never runs, so `cpln logs` returns **zero lines** — there is nothing to log, and every summary surface just looks like a slow deploy. The one place the reason appears is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-postgres --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-postgres-credentials no longer exists. Workload updates are paused until the
+secret is added or the reference to the secret removed.
+```
+
+Use `get-deployments` — plain `cpln workload get` has no `versions` key and will show you nothing. Creating the missing secret repairs it on its own in roughly **6 to 8.5 minutes** with no further action, or run `cpln workload force-redeployment RELEASE_NAME-postgres --gvc GVC_NAME` to clear it in about 90 seconds.
+</Warning>
+
+Backups need a bucket, and for AWS or GCP a Control Plane Cloud Account, before they can be enabled — see [Backup Prerequisites](#backup-prerequisites). MinIO backups need a second dictionary secret holding `accessKey` and `secretKey`. Nothing else is required.
+
 ## Installation
 
-This template has no external prerequisites unless backup is enabled. To install, follow the instructions for your preferred method:
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -56,7 +176,7 @@ This template has no external prerequisites unless backup is enabled. To install
 The default `values.yaml` for this template:
 
 ```yaml
-image: postgres:18  # versions before postgres:17 do not support the backup feature
+image: postgres:18  # versions before postgres:17 are compatible but do not support backup feature
 
 resources:
   minCpu: 200m
@@ -65,21 +185,25 @@ resources:
   maxMemory: 256Mi
 
 config:
-  username: username
-  password: password
-  database: test
+  # REQUIRED PREREQUISITE SECRET — CREATE IT BEFORE YOU INSTALL.
+  # A `dictionary` secret holding exactly three keys: `username`, `password` and
+  # `database`. If it does not exist at install time the deployment WEDGES
+  # silently — `cpln logs` returns nothing at all. See Prerequisites in the README
+  # for the exact `cpln secret create-dictionary` command.
+  credentialsSecretName: my-postgres-credentials
 
 volumeset:
   capacity: 10 # initial capacity in GiB (minimum is 10)
   autoscaling:
-    enabled: false
-    maxCapacity: 100 # Maximum capacity in GiB
-    minFreePercentage: 10 # Trigger scaling when free space drops below this percentage
-    scalingFactor: 1.2 # Multiply current capacity by this factor when scaling up
+    enabled: false # Set to true to enable autoscaling
+    maxCapacity: 100 # Maximum capacity in GiB when autoscaling is enabled
+    minFreePercentage: 10 # Minimum free percentage to trigger scaling when autoscaling is enabled
+    scalingFactor: 1.2 # Scaling factor to determine how much to scale up when autoscaling is triggered
 
-internalAccess:
+internalAccess: # Sets the internal firewall scope - if set to none, replicas will not be able to reach each other
   type: same-gvc # options: none, same-gvc, same-org, workload-list
-  workloads: # Note: can only be used if type is same-gvc or workload-list
+  workloads:  # Note: can only be used if type is same-gvc or workload-list
+    #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
     #- //gvc/GVC_NAME/workload/WORKLOAD_NAME
 
 pgbouncer:
@@ -94,10 +218,10 @@ pgbouncer:
     cpu: 200m
     memory: 128Mi
 
-backup: # compatible with Postgres 17+ only
+backup: # compatible with Postgres 17+
   enabled: false
   image: ghcr.io/controlplane-com/backup-images/postgres-backup:18.1.0 # tag 18.1.0 = Postgres 18, 17.1.0 = Postgres 17
-  schedule: "0 2 * * *" # cron schedule, default is daily at 2am UTC
+  schedule: "0 2 * * *"   # daily at 2am UTC
 
   resources:
     cpu: 100m
@@ -106,33 +230,34 @@ backup: # compatible with Postgres 17+ only
   provider: aws # Options: aws, gcp, or minio
 
   aws:
-    bucket: my-backup-bucket
+    bucket: my-postgres-bucket
     region: us-east-1
-    cloudAccountName: my-backup-cloudaccount
-    policyName: my-backup-policy
-    prefix: postgres/backups
+    cloudAccountName: my-s3-cloud-account
+    policyName: my-postgres-backup-policy # bucket-scoped IAM policy, see README
+    prefix: postgres/backups # folder name where your backups will be stored
 
   gcp:
-    bucket: my-backup-bucket
-    cloudAccountName: my-backup-cloudaccount
-    prefix: postgres/backups
+    bucket: my-postgres-bucket
+    cloudAccountName: my-gcs-cloud-account
+    prefix: postgres/backups # folder name where your backups will be stored
 
   minio: # Backup to a self-hosted MinIO workload (or any S3-compatible endpoint)
     endpoint: http://my-minio-workload:9000 # e.g. http://WORKLOAD_NAME:9000 for an internal MinIO template deployment
-    bucket: my-backup-bucket
-    accessKey: my-minio-username # matches the MinIO template's admin.username
-    secretKey: my-minio-password # matches the MinIO template's admin.password
-    prefix: postgres/backups
+    bucket: my-postgres-bucket
+    # REQUIRED PREREQUISITE SECRET when provider is `minio` — a `dictionary`
+    # secret holding `accessKey` and `secretKey`. See Storage setup in the README.
+    credentialsSecretName: my-postgres-minio-credentials
+    prefix: postgres/backups # folder name where your backups will be stored
 ```
 
 ### Credentials
 
-- `config.username` — PostgreSQL username. **Change before deploying to production.**
-- `config.password` — PostgreSQL password. **Change before deploying to production.**
-- `config.database` — Name of the database created on startup.
+- `config.credentialsSecretName` — Name of the dictionary secret holding `username`, `password` and `database`. PostgreSQL creates that user and that database on first boot, and this is the credential your applications put in their connection strings.
+
+The secret must exist before installing — see [Prerequisites](#prerequisites). The workload reads it through `cpln://secret/...` references, so the values appear in neither the Helm release nor the stored workload spec.
 
 <Note>
-These values are only applied on first startup when the data directory is empty. Updating them after the initial deployment will have no effect on the running database. To change credentials or the database name on an existing instance, use PostgreSQL's native commands (e.g. `ALTER USER`, `ALTER DATABASE`).
+These credentials are only applied on first startup when the data directory is empty. Rotating the secret afterwards does not change the stored password; change it inside PostgreSQL with `ALTER ROLE ... WITH PASSWORD` (and `ALTER DATABASE ... RENAME` for the database name) and update the secret to match.
 </Note>
 
 ### Resources
@@ -140,10 +265,14 @@ These values are only applied on first startup when the data directory is empty.
 - `resources.minCpu` / `resources.minMemory` — Minimum CPU and memory guaranteed to the workload.
 - `resources.maxCpu` / `resources.maxMemory` — Maximum CPU and memory the workload can use.
 
+<Note>
+On a stateful workload the ratio of `maxCpu` to `minCpu` may not exceed 4:1. The shipped `500m` / `200m` is 2.5:1; raising `maxCpu` without raising `minCpu` can cross the limit and is rejected when the workload is applied.
+</Note>
+
 ### Storage
 
 - `volumeset.capacity` — Initial volume size in GiB (minimum 10).
-- `volumeset.autoscaling.enabled` — Automatically expand the volume as it fills. When enabled:
+- `volumeset.autoscaling.enabled` — Allow the volume to grow as it fills. When enabled:
   - `maxCapacity` — Maximum volume size in GiB.
   - `minFreePercentage` — Trigger a scale-up when free space drops below this percentage.
   - `scalingFactor` — Multiply the current capacity by this factor when scaling up.
@@ -159,13 +288,7 @@ These values are only applied on first startup when the data directory is empty.
 | `same-org` | Allow access from all workloads in the same organization |
 | `workload-list` | Allow access only from specific workloads listed in `workloads` |
 
-### Connecting to PostgreSQL
-
-Once deployed, connect to the database from within the same GVC using:
-
-```text
-RELEASE_NAME-postgres.GVC_NAME.cpln.local:5432
-```
+Firewall changes take 30 to 150 seconds to propagate. After changing `internalAccess`, re-test rather than trusting the first response.
 
 ### PgBouncer Connection Pooling
 
@@ -173,11 +296,12 @@ PgBouncer is an optional connection pooler that sits in front of PostgreSQL and 
 
 When enabled, PgBouncer is deployed as a separate workload and becomes the primary connection endpoint for your applications:
 
-```
+```text
 RELEASE_NAME-pgbouncer.GVC_NAME.cpln.local:5432
 ```
 
 - `pgbouncer.enabled` — Enable or disable PgBouncer.
+- `pgbouncer.image` — PgBouncer container image.
 - `pgbouncer.poolMode` — Controls how connections are reused:
 
 | Mode | Description |
@@ -192,30 +316,40 @@ RELEASE_NAME-pgbouncer.GVC_NAME.cpln.local:5432
 - `pgbouncer.resources.cpu` / `pgbouncer.resources.memory` — Resources allocated to each PgBouncer replica.
 
 <Note>
-PgBouncer shares the same credentials and identity as the PostgreSQL workload — no additional secrets or IAM configuration is required. The `userlist.txt` and `pgbouncer.ini` are generated automatically from your `config.username`, `config.password`, and `config.database` values at startup.
+PgBouncer reads the same credentials secret and identity as the PostgreSQL workload — no additional secrets or IAM configuration is required. Its `userlist.txt` and `pgbouncer.ini` are generated at startup from the `username`, `password` and `database` keys in that secret.
+</Note>
+
+<Note>
+PgBouncer's own admin console (`-d pgbouncer`) rejects the database user with `FATAL: not allowed`. The image restricts admin access to the `postgres` user; this is upstream behavior, not a template setting.
 </Note>
 
 ### Backup
 
-Backup is disabled by default. When enabled, a cron workload runs `pg_dump` on the configured schedule and uploads compressed SQL dumps to AWS S3 or GCS.
+Backup is disabled by default. When enabled, a cron workload runs `pg_dump` on the configured schedule and uploads compressed SQL dumps to AWS S3, GCS or MinIO. The job authenticates with the username and password from your credentials secret and dumps the database named in it.
 
 <Note>
 Backup requires PostgreSQL 17 or later. Set `backup.image` to match your PostgreSQL version: `ghcr.io/controlplane-com/backup-images/postgres-backup:18.1.0` for Postgres 18, or `ghcr.io/controlplane-com/backup-images/postgres-backup:17.1.0` for Postgres 17.
 </Note>
 
 - `backup.enabled` — Enable scheduled backups.
-- `backup.schedule` — Cron expression for backup frequency (default: daily at 2am UTC).
+- `backup.image` — Backup container image, matched to your PostgreSQL major version.
+- `backup.schedule` — Cron expression for backup frequency (default: daily at 2am UTC). Interval forms such as `*/15 * * * *` are accepted.
 - `backup.provider` — `aws`, `gcp`, or `minio`.
 - `backup.resources.cpu` / `backup.resources.memory` — Resources for the backup cron container.
+- `backup.PROVIDER.prefix` — Folder path within the bucket where backups are stored.
+
+The **AWS S3** and **MinIO** paths were exercised end to end at the shipped settings, with the resulting objects confirmed from outside the cluster and a dump downloaded and restored to verify its contents; the AWS path was also exercised at 30.9 MB to force a multipart upload. **GCS** renders and binds correctly but was not exercised in the same run — rehearse it before relying on it.
 
 ## Backup Prerequisites
 
+Only needed when `backup.enabled: true`.
+
 ### AWS S3
 
-Before enabling backup with `provider: aws`, complete the following in your AWS account:
-
 1. Create an S3 bucket. Set `backup.aws.bucket` to its name and `backup.aws.region` to its region.
-2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
+
+2. If you do not have a Control Plane Cloud Account set up, follow the [Create a Cloud Account](/guides/create-cloud-account) guide. Set `backup.aws.cloudAccountName` to its name.
+
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
 ```json
@@ -230,7 +364,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",
@@ -241,34 +379,45 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 }
 ```
 
-4. Set `backup.aws.policyName` to the name of the policy created in step 3.
+4. Set `backup.aws.policyName` to the name of the policy created in step 3. The template attaches it to the workload's identity, and attaches nothing else — the bucket in your policy is the only storage the backup job can reach.
+
 5. Set `backup.aws.prefix` to the folder path where backups will be stored.
 
 ### GCS
 
-Before enabling backup with `provider: gcp`, complete the following in your GCP account:
-
 1. Create a GCS bucket. Set `backup.gcp.bucket` to its name.
-2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.gcp.cloudAccountName` to its name.
-3. Add the **Storage Admin** role to the GCP service account associated with the Cloud Account.
+
+2. If you do not have a Control Plane Cloud Account set up, follow the [Create a Cloud Account](/guides/create-cloud-account) guide. Set `backup.gcp.cloudAccountName` to its name.
+
+3. Add the **Storage Admin** role to the GCP service account associated with the Cloud Account. The template additionally binds the identity to `roles/storage.objectAdmin` on exactly the bucket in `backup.gcp.bucket`.
+
 4. Set `backup.gcp.prefix` to the folder path where backups will be stored.
 
 ### MinIO
 
-Before enabling backup with `provider: minio`, ensure your MinIO instance is accessible:
+No Cloud Account is needed — credentials are supplied as a secret.
 
 1. Create a bucket in MinIO. Set `backup.minio.bucket` to its name.
-2. Set `backup.minio.endpoint` to the MinIO S3 API address including the port. For the `minio` marketplace template deployed in the same GVC, use `http://WORKLOAD_NAME:9000`.
-3. Set `backup.minio.accessKey` and `backup.minio.secretKey` to the MinIO root credentials — these match the `admin.username` and `admin.password` values from the MinIO template installation.
+
+2. Set `backup.minio.endpoint` to the MinIO S3 API address including the port. For the [minio](/template-catalog/templates/minio) template deployed in the same GVC, use `http://WORKLOAD_NAME:9000`.
+
+3. Create a [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name. For the `minio` template these are its `admin.username` and `admin.password`:
+
+```bash
+cpln secret create-dictionary --name my-postgres-minio-credentials \
+  --entry accessKey=MINIO_ACCESS_KEY \
+  --entry secretKey=MINIO_SECRET_KEY
+```
+
 4. Set `backup.minio.prefix` to the folder path where backups will be stored.
 
 <Note>
-MinIO backup requires no Control Plane Cloud Account — credentials are passed directly to the backup job.
+The policy this template creates grants the workload `reveal` on both the database credentials secret and the MinIO credentials secret, and on nothing else.
 </Note>
 
 ## Restoring a Backup
 
-Run the following from a client with access to the backup bucket:
+Run the following from a client with access to the backup bucket, using the username and password from your credentials secret.
 
 **AWS S3:**
 
@@ -321,14 +470,39 @@ aws s3 cp "s3://BUCKET_NAME/PREFIX/BACKUP_FILE.sql.gz" - --endpoint-url "http://
 unset PGPASSWORD AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 ```
 
+## Connecting
+
+This template exposes no public endpoint. Everything below is reachable from inside the GVC only.
+
+| Path | Address | Notes |
+|---|---|---|
+| PostgreSQL, pooled | `RELEASE_NAME-pgbouncer.GVC_NAME.cpln.local:5432` | Only when `pgbouncer.enabled: true`. Prefer this endpoint when the pooler is on. |
+| PostgreSQL, direct | `RELEASE_NAME-postgres.GVC_NAME.cpln.local:5432` | Subject to `internalAccess.type`. |
+| Credentials | `cpln secret reveal CREDENTIALS_SECRET_NAME -o yaml` | Never stored in the Helm release. |
+
+## Important Notes
+
+- **Create the credentials secret before installing.** A reference to a secret that does not exist wedges the workload with no log output at all; see [Prerequisites](#prerequisites) for the one command that shows the reason.
+- **Credentials are read only when the volume is first initialized.** Rotating the secret afterwards does not change the stored password — use `ALTER ROLE` inside PostgreSQL and update the secret to match.
+- **Do not scale past one replica.** This is a single instance on a single volume, not a replicated cluster.
+- **Data lives on the volume set** and survives redeploys; `cpln helm uninstall` deletes it, taking the database with it. Your credentials secret is yours and is left alone.
+- **A `cpln helm upgrade` restarts the server.** Nothing serializes the rollout on a stateful workload, so treat every upgrade as a short planned write outage. The first upgrade after an install re-applies resources even when the values are byte-identical.
+- **Upgrading from 3.3.0 or earlier is a breaking change** — the removed keys stop the upgrade rather than resetting a password. See [Upgrading From 3.3.0 or Earlier](#upgrading-from-3-3-0-or-earlier).
+
 ## External References
 
 <CardGroup cols={2}>
     <Card title="PostgreSQL Documentation" icon="database" href="https://www.postgresql.org/docs/">
     Official PostgreSQL documentation
     </Card>
+    <Card title="PostgreSQL Backup and Restore" icon="book" href="https://www.postgresql.org/docs/current/backup-dump.html">
+    Upstream guidance on logical dumps and restores
+    </Card>
     <Card title="PgBouncer Documentation" icon="database" href="https://www.pgbouncer.org/config.html">
     PgBouncer configuration reference
+    </Card>
+    <Card title="Cloud Accounts" icon="cloud" href="https://docs.controlplane.com/guides/create-cloud-account">
+    Create a Control Plane Cloud Account for backup storage access
     </Card>
     <Card title="Backup Image Source" icon="github" href="https://github.com/controlplane-com/backup-images/tree/main/postgres-backup">
     Source code for the PostgreSQL backup container image

--- a/template-catalog/templates/temporal.mdx
+++ b/template-catalog/templates/temporal.mdx
@@ -139,10 +139,12 @@ postgresHA: # default: highly available PostgreSQL
 
 postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA first)
   enabled: false
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: temporal
     password: change-me-temporal-db-password # change before installing
     database: temporal
+  config:
+    credentialsSecretName: my-temporal-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
   backup:
@@ -166,8 +168,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: temporal-pg-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-temporal-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 ```
 
@@ -200,7 +201,13 @@ Both workloads are internal-only — there is no public-access option in this te
 
 ### Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Temporal is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Temporal is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
+
+<Warning>
+**Leave `postgres.credentials.database` set to `temporal`.** The server reads its database name as the literal `temporal`, and auto-setup creates only the visibility store alongside it — so any other value wedges the install permanently on `Unable to setup SQL schema: no usable database connection found`. Template version `1.1.0` refuses to render rather than let that happen, and names the reason.
+</Warning>
 
 <Warning>
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
@@ -214,7 +221,7 @@ Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/ligh
 | Namespace | `default` |
 | Web UI (internal) | `http://{release}-temporal-ui.{gvc}.cpln.local:8080` |
 | PostgreSQL (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
-| PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
+| PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the secret named by `postgres.config.credentialsSecretName` |
 
 <Warning>
 Always use the full `.cpln.local` FQDN in worker and client connection config — short workload names do not resolve.
@@ -308,7 +315,7 @@ Database backups are optional and disabled by default. They cover the Temporal d
         Set `backup.minio.endpoint` to the S3 API address including port. For the `minio` marketplace template deployed in the same GVC, this is `http://WORKLOAD_NAME:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket.
+        The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>
@@ -318,7 +325,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 
 ## Important Notes
 
-- **Change the database password** (`postgresHA.postgres.password` / `postgres.config.password`) before installing.
+- **Change the database password** (`postgresHA.postgres.password` / `postgres.credentials.password`) before installing.
 - **`historyShards` is permanent** — the shard count is fixed at the cluster's first boot and can never be changed; the server refuses a different value later. Size it before installing (512 suits most deployments).
 - **Never expose the Web UI publicly** — it has no built-in authentication. To offer browser access from outside the internal scope, put your own authenticating proxy in front of it.
 - **Temporal connects and runs schema setup as the database superuser** provisioned by the PostgreSQL subchart — it needs `CREATE DATABASE` and DDL rights at every version upgrade.

--- a/template-catalog/templates/tooljet.mdx
+++ b/template-catalog/templates/tooljet.mdx
@@ -136,10 +136,12 @@ internalAccess:
 
 postgres: # app DB + ToolJet Database
   image: postgres:16
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: tooljet
     password: change-me-tooljet-pg # change before installing
     database: tooljet # tooljet_db is auto-created alongside it
+  config:
+    credentialsSecretName: my-tooljet-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 250m
     maxCpu: 1000m
@@ -193,7 +195,9 @@ One PostgreSQL instance from the [postgres](/template-catalog/templates/postgres
 | `tooljet_db` | The ToolJet Database — user tables created in the UI, served through the in-image PostgREST. |
 | `sample_db` | Sample data created by ToolJet's boot scripts. |
 
-**Change `postgres.config.password` before installing** — it seeds the database on first boot and cannot be changed afterwards by editing values. `postgres.volumeset.capacity` sets the initial data volume size in GiB (minimum 10), and `postgres.resources` bounds the database container.
+**Change `postgres.credentials.password` before installing** — it seeds the database on first boot and cannot be changed afterwards by editing values. `postgres.volumeset.capacity` sets the initial data volume size in GiB (minimum 10), and `postgres.resources` bounds the database container.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Note>
 The ToolJet Database is a core part of ToolJet 3.x and cannot be turned off.
@@ -283,7 +287,7 @@ Configure SMTP at the **initial install**. ToolJet seeds its mail settings from 
 - **Claim the Super Admin account right after install** — the first visitor to complete onboarding owns the instance.
 - **Configure SMTP at initial install** — enabling it via a later upgrade silently does nothing.
 - **`tooljet.replicas` of 2 or more requires `redis.enabled: true`**, and both the Redis data node and sentinel must stay at one replica.
-- **Change `postgres.config.password` before installing** — it seeds the database on first boot and is not updated by later value edits.
+- **Change `postgres.credentials.password` before installing** — it seeds the database on first boot and is not updated by later value edits.
 - **All ToolJet state lives in PostgreSQL** — apps, users, and ToolJet Database tables survive restarts and upgrades. Uninstalling deletes the database volume set and everything in it.
 - **ToolJet is licensed under the AGPL** — the deployed image is the LTS build and runs the free tier without a license key.
 

--- a/template-catalog/templates/twenty.mdx
+++ b/template-catalog/templates/twenty.mdx
@@ -188,10 +188,12 @@ redis: # bundled single node — job queues + cache (required)
 postgres: # single instance (default) — PostgreSQL 18
   enabled: true
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: twenty
     password: change-me-twenty-db # change before installing; letters, digits, - and _ only
     database: twenty
+  config:
+    credentialsSecretName: my-twenty-db-credentials # secret names are org-wide — give each release its own
   resources:
     minCpu: 250m
     maxCpu: 1000m
@@ -404,7 +406,9 @@ Redis runs with `maxmemory-policy noeviction` and `appendonly yes`, and this is 
 
 ### Database
 
-Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.config.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
+Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 Twenty connects to the single instance directly, or to the HAProxy leader endpoint in HA mode, and creates the `uuid-ossp` and `unaccent` extensions itself on first boot. `postgres.resources` / `postgresHA.resources` and the `volumeset.capacity` values (GiB, minimum 10, per replica in HA mode) size the backing store.
 
@@ -470,7 +474,7 @@ Database backups are optional and disabled by default. When enabled, a scheduled
         Create your bucket on the server. Set `backup.minio.bucket` to its name.
       </Step>
       <Step title="Set the endpoint and credentials">
-        Set `backup.minio.endpoint` to the S3 API address including port, and `backup.minio.accessKey` / `backup.minio.secretKey` to credentials with access to the bucket. No Cloud Account is required — the keys authenticate directly.
+        Set `backup.minio.endpoint` to the S3 API address including port. No Cloud Account is required — the credentials authenticate directly. The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>
@@ -487,7 +491,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **The single-instance and HA paths run different PostgreSQL majors** — 18 and 17 respectively. Choose before you have data; switching is a dump and restore.
 - **`twenty.replicas` above `1` requires `storage.type: s3`** — the shared local volume set lives in one location and cannot be snapshotted, so S3 is the production recommendation regardless of replica count.
 - **AWS S3 is keyless only** — use a cloud account plus a bucket-scoped IAM policy. Static keys are accepted only when `storage.s3.endpoint` points at an S3-compatible server.
-- **Change `postgres.config.password` (or `postgresHA.postgres.password`) and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
+- **Change `postgres.credentials.password` (or `postgresHA.postgres.password`) and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
 - **Set `twenty.serverUrl` when Twenty sits behind a custom domain**, with the scheme (`https://crm.example.com`). A mismatch with the URL browsers use breaks auth callbacks and CORS with opaque errors.
 - **SMTP, AI provider keys, rate limits, and OAuth/SSO are not values knobs** — configure them in **Settings → Admin Panel → Configuration Variables** inside the app.
 - **Foreign data wrappers ("remote objects") are unavailable** — that feature needs upstream's custom PostgreSQL image, which this template does not deploy.

--- a/template-catalog/templates/umami.mdx
+++ b/template-catalog/templates/umami.mdx
@@ -57,7 +57,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 **Creating the secret afterwards does not release the wedge on its own** — it stayed at zero replicas for nearly five minutes after the secret existed. Run `cpln workload force-redeployment {release}-umami --gvc {gvc}` to pick it up.
 </Warning>
 
-Nothing else is required for a default install. Optional: a bucket and access setup for one of the supported providers if you enable database backups — see [Backing Up](#backing-up). Change the database password (`postgres.config.password` or `postgresHA.postgres.password`) before installing as well; it ships with a `change-me` placeholder default.
+Nothing else is required for a default install. Optional: a bucket and access setup for one of the supported providers if you enable database backups — see [Backing Up](#backing-up). Change the database password (`postgres.credentials.password` or `postgresHA.postgres.password`) before installing as well; it ships with a `change-me` placeholder default.
 
 Once the secret exists, install the template using your preferred method:
 
@@ -263,7 +263,9 @@ Access changes take up to a couple of minutes to propagate — every measured tr
 
 ### Backing Store
 
-Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.config.password` / `postgresHA.postgres.password`).
+Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`).
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Warning>
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, which is off by default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.

--- a/template-catalog/templates/umami.mdx
+++ b/template-catalog/templates/umami.mdx
@@ -54,7 +54,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 <Warning>
 **A missing app secret wedges the install rather than failing it.** `cpln helm install` still exits 0 and reports every resource created, but the Umami workload never starts — it sits at zero replicas. `cpln logs` shows **nothing at all**, because no container ever starts; the real reason appears only under `status.versions[].message` of `cpln workload get-deployments {release}-umami --gvc {gvc} -o yaml`, which names the missing secret: `The secret <name> no longer exists. Workload updates are paused until the secret is added or the reference to the secret removed.`
 
-**Creating the secret afterwards does not release the wedge on its own** — it stayed at zero replicas for nearly five minutes after the secret existed. Run `cpln workload force-redeployment {release}-umami --gvc {gvc}` to pick it up.
+Creating the secret afterwards **does** release it, without further action, but slowly — measured between 5.5 and 10.5 minutes across five templates, so poll rather than time-box it. To skip the wait, run `cpln workload force-redeployment {release}-umami --gvc {gvc}`.
 </Warning>
 
 Nothing else is required for a default install. Optional: a bucket and access setup for one of the supported providers if you enable database backups — see [Backing Up](#backing-up). Change the database password (`postgres.credentials.password` or `postgresHA.postgres.password`) before installing as well; it ships with a `change-me` placeholder default.

--- a/template-catalog/templates/umami.mdx
+++ b/template-catalog/templates/umami.mdx
@@ -179,10 +179,12 @@ tracker:
 postgres: # default: single-instance PostgreSQL
   enabled: true
   image: postgres:18
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: umami
     password: change-me-umami-db # change before installing
     database: umami
+  config:
+    credentialsSecretName: my-umami-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
   backup:
@@ -320,7 +322,7 @@ Database backups are optional and disabled by default. They cover the analytics 
         Create your bucket on the server. Set `backup.minio.bucket` to its name.
       </Step>
       <Step title="Set the endpoint and credentials">
-        Set `backup.minio.endpoint` to the S3 API address including port, and `backup.minio.accessKey` / `backup.minio.secretKey` to credentials with access to the bucket. No Cloud Account is required — the keys authenticate directly.
+        Set `backup.minio.endpoint` to the S3 API address including port. No Cloud Account is required — the credentials authenticate directly. The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/unleash.mdx
+++ b/template-catalog/templates/unleash.mdx
@@ -216,10 +216,12 @@ postgresHA: # default: highly available PostgreSQL
 
 postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA first)
   enabled: false
-  config:
+  credentials: # the chart writes these into the secret named below — nothing for you to create
     username: unleash
     password: change-me-unleash-db-password # change before installing
     database: unleash
+  config:
+    credentialsSecretName: my-unleash-db-credentials # secret names are org-wide — give each release its own
   volumeset:
     capacity: 10 # initial capacity in GiB (minimum is 10)
   backup:
@@ -243,8 +245,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
     minio:
       endpoint: http://my-minio-workload:9000
       bucket: unleash-pg-backup-bucket
-      accessKey: my-minio-username
-      secretKey: my-minio-password
+      credentialsSecretName: my-unleash-minio-credentials # dictionary secret holding accessKey + secretKey
       prefix: postgres/backups
 ```
 
@@ -330,7 +331,7 @@ To upgrade an existing install:
 | Internal (same GVC) | `http://{release}-unleash.{gvc}.cpln.local:4242` |
 | Login | The `username` / `password` in your `admin.secretName` secret — `cpln secret reveal my-unleash-admin -o yaml` |
 | PostgreSQL (internal, HA mode) | `{release}-postgres-ha-proxy.{gvc}.cpln.local:5432`, credentials in the `{release}-postgres-config` secret |
-| PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the `{release}-pg-config` secret |
+| PostgreSQL (internal, single mode) | `{release}-postgres.{gvc}.cpln.local:5432`, credentials in the secret named by `postgres.config.credentialsSecretName` |
 
 ### API Tokens
 
@@ -404,7 +405,7 @@ Database backups are optional and disabled by default. They cover the PostgreSQL
         Set `backup.minio.endpoint` to the S3 API address including port. For the `minio` marketplace template deployed in the same GVC, this is `http://WORKLOAD_NAME:9000`.
       </Step>
       <Step title="Set credentials">
-        Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket.
+        The two backing stores take these differently. In HA mode (`postgresHA`), set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. In single-instance mode (`postgres`), those two values were removed: create a [dictionary secret](/guides/create-secret/dictionary) holding the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name — see [MinIO backup prerequisites](/template-catalog/templates/postgres#minio) for the exact command.
       </Step>
     </Steps>
   </Tab>

--- a/template-catalog/templates/unleash.mdx
+++ b/template-catalog/templates/unleash.mdx
@@ -270,7 +270,9 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 ### Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`). Unleash is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Unleash is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+
+If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
 <Warning>
 **Template version `1.0.0` did not compact the etcd cluster inside the bundled highly available database**, so etcd's backend grows with time alone and goes read-only once it reaches its 2 GiB quota — after roughly 110 days — taking PostgreSQL failover with it. Only installs running the HA database are affected (`postgresHA.enabled`, the default here); see [etcd History Compaction](/template-catalog/templates/postgres-highly-available#etcd-history-compaction) for the mechanism and the symptoms. Upgrade to `1.0.1` or later to turn compaction on: that stops further growth but cannot shrink a backend that has already grown, and a cluster that has already raised a `NOSPACE` alarm needs operator recovery rather than an upgrade.
@@ -286,7 +288,7 @@ Version `1.1.0` moved the initial admin login out of Helm values. Earlier versio
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
 | `apiTokens.secretName` | Prerequisite dictionary secret | Unchanged |
 | Database startup | Migrations ran immediately at boot | The start script waits for the database first |
-| Database password | A value (`postgresHA.postgres.password` / `postgres.config.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgresHA.postgres.password` / `postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -413,7 +415,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 ## Important Notes
 
 - **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
-- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.config.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
 - **Admin credentials and API tokens are seeded on first boot only** — they live in the database afterwards; change the password or manage tokens in the admin UI, not by editing the secrets.
 - **Backend tokens must stay secret** (server-side SDKs, `/api/client`); frontend tokens are safe to embed in browsers (`/api/frontend`). A `401` usually means the wrong token type or environment.
 - **The free edition ships exactly two environments** (`development`, `production`) — SSO, role-based access control, multiple projects, change requests, and audit logs require an Unleash Enterprise license and are not available in this template.

--- a/template-catalog/templates/weaviate.mdx
+++ b/template-catalog/templates/weaviate.mdx
@@ -50,7 +50,7 @@ The secret my-weaviate-api-key no longer exists. Workload updates are paused unt
 the secret is added or the reference to the secret removed.
 ```
 
-Read it with `cpln workload get-deployments {release}-weaviate --gvc {gvc} -o yaml`. Creating the secret afterwards does **not** release the deployment on its own — it stayed wedged for a full five minutes of polling in testing. Run `cpln workload force-redeployment {release}-weaviate --gvc {gvc}`, which cleared it in about 90 seconds.
+Read it with `cpln workload get-deployments {release}-weaviate --gvc {gvc} -o yaml`. Creating the secret afterwards **does** release it, without further action, but slowly — measured between 5.5 and 10.5 minutes across five templates, so poll rather than time-box it. To skip the wait, run `cpln workload force-redeployment {release}-weaviate --gvc {gvc}`, which cleared it in about 90 seconds.
 </Warning>
 
 ### AI Provider Keys


### PR DESCRIPTION
The single docs PR for postgres 3.4.x and **all twenty** templates that bundle it. Nothing else is outstanding on the docs side for this work.

## What this covers

`postgres` 3.4.0 moved the database credentials out of values into a dictionary secret, and 3.4.1 followed. Twenty parent templates have now adopted it (PRs #448–#454 in the templates repo), which changes three things a reader copies from the page: the values block, the name of the secret the credentials live in, and the MinIO backup credentials.

## The first commit on this branch was half a fix

Worth being explicit, since it is why this PR grew. The earlier commit renamed `postgres.config.password` → `postgres.credentials.password` in **prose** on seven pages. But:

- All **twenty** pages still showed the old `config: {username, password, database}` shape in their Configuration YAML block — the block users actually copy.
- **No page at all** documented `postgres.config.credentialsSecretName`, which is the knob you must set to run two releases of a template in one organization.

So the seven "done" pages were not done, and the remaining thirteen were untouched. This commit fixes all twenty.

## Two defects found while checking the pages against the shipped charts

Neither was part of the intended scope; both were found by diffing each page against its template's `values.yaml` and rendering the chart rather than reading the subchart.

**1. Seven Connecting tables named a secret that no longer exists.** The single-instance row said credentials live in `{release}-pg-config`. The chart has not created that secret since 3.4.0 — `postgres.mdx` carries a warning saying exactly that — so the row pointed readers at nothing. Confirmed by rendering: single mode emits `my-temporal-db-credentials` (the user-named secret) and no `-pg-config`. Affected glitchtip, grafana, metabase, n8n, polaris, temporal, unleash.

**2. The two backing stores now take MinIO credentials differently.** `postgres` 3.4.1 requires a prerequisite dictionary secret via `backup.minio.credentialsSecretName` and **fails at render** if `accessKey`/`secretKey` are present. `postgres-highly-available` 2.4.2 still takes them as plain values. Twelve pages document both stores from one Backing Up section and told readers to set the values — correct for HA, a render failure in single mode. Each now says which store takes which.

## Also corrected

- **temporal** — `postgres.credentials.database` must stay `temporal`. 1.1.0 added a render guard after testing found any other value wedges the install permanently on `Unable to setup SQL schema: no usable database connection found`. The page had no mention of it.
- **fusionauth** — the page said "change before deploying to production" about credentials that ship as the literal strings `username` / `password` with database `test`. They work exactly as written rather than failing loudly, which is the point, so the page now says so.

## Deliberately not changed

- **airflow** — its bundled postgres is its own, not the subchart, so `postgres.config.*` is still correct there. A blind rename across the catalog would have broken this page; it was caught by checking the Chart.yaml dependency rather than the key name.
- **Templates still pinned to postgres 3.2.1 / 3.3.0** — their pages are accurate as they stand.

## Verification

- Every page's YAML block diffed against its template's shipped `values.yaml`.
- Both `postgres` and `postgres-highly-available` MinIO paths rendered to confirm which credential shape each takes, and that the prerequisite secret is referenced by the policy but never created by the chart.
- `npx mintlify broken-links` — nothing in `template-catalog`. (One pre-existing `headlamp` link in `mk8s/add-ons/dashboard.mdx` is unrelated and untouched.)