### PR TITLE
docs: postgres-highly-available 2.5.0 and its fourteen adopters

### DIFF
--- a/template-catalog/templates/chatwoot.mdx
+++ b/template-catalog/templates/chatwoot.mdx
@@ -52,7 +52,7 @@ Chatwoot signs its sessions and encrypts sensitive columns with four keys that y
     Store a copy somewhere safe, outside Control Plane. All four keys are write-once for the life of the installation.
   </Step>
   <Step title="Change the bundled credentials">
-    Change the database password (`postgresHA.postgres.password` or `postgres.credentials.password`) and the Redis password (`redis.auth.password`) from their placeholder defaults before installing. Both seed their component on first boot and are not updated by later value edits.
+    Change the database password (`postgres.credentials.password`) and the Redis password (`redis.auth.password`) from their placeholder defaults before installing. Both seed their component on first boot and are not updated by later value edits.
   </Step>
 </Steps>
 
@@ -445,7 +445,7 @@ Enable exactly one of `postgresHA` (default) or `postgres` — the chart refuses
 - **`postgresHA` (default)** — 3× Patroni PostgreSQL 17.5 with etcd and a HAProxy leader endpoint. Its image ships pgvector natively, which is why it is the default. A first install on this path takes roughly eight minutes.
 - **`postgres`** — One PostgreSQL instance for lighter, non-production deployments. It reaches ready in a few minutes but has no failover.
 
-In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it seeds the database on first boot and is not updated by later value edits.
+In both modes, **change the database password before installing** (`postgres.credentials.password`) — it seeds the database on first boot and is not updated by later value edits.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 

--- a/template-catalog/templates/glitchtip.mdx
+++ b/template-catalog/templates/glitchtip.mdx
@@ -234,10 +234,11 @@ redis:
 # replicas, and an HAProxy leader-routing endpoint GlitchTip connects to.
 postgresHA:
   enabled: true
-  postgres:
-    username: glitchtip
-    password: change-me-glitchtip-db # change before installing
-    database: glitchtip
+  config:
+    # Name of the dictionary secret this chart creates and the bundled
+    # postgres-highly-available reads. One secret feeds whichever store
+    # is enabled, built from postgres.credentials.* above.
+    credentialsSecretName: my-glitchtip-db-credentials
   replicas: 3
   volumeset:
     capacity: 10 # initial capacity in GiB per replica (minimum is 10)
@@ -356,7 +357,7 @@ Set `publicAccess.enabled: false` for in-GVC reporters only, and reach the UI wi
 
 Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). GlitchTip is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
-Both database passwords are bundled plumbing — the database serves GlitchTip only and is unreachable from outside the GVC — but they are used as-is, so **change `postgresHA.postgres.password` or `postgres.credentials.password` before installing**. The shipped `change-me-glitchtip-db` is a published placeholder.
+Both database passwords are bundled plumbing — the database serves GlitchTip only and is unreachable from outside the GVC — but they are used as-is, so **change `postgres.credentials.password` or `postgres.credentials.password` before installing**. The shipped `change-me-glitchtip-db` is a published placeholder.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 

--- a/template-catalog/templates/grafana.mdx
+++ b/template-catalog/templates/grafana.mdx
@@ -75,7 +75,7 @@ Optional features each need a secret or a bucket created **before** you install:
 | Authenticated SMTP | An [opaque secret](/guides/create-secret/opaque) with encoding `plain` holding the SMTP password, named in `smtp.passwordSecretName` |
 | Database backups | A bucket and access setup on AWS S3, Google Cloud Storage, or an S3-compatible server — see [Backing Up](#backing-up) |
 
-Change the app database password (`postgresHA.postgres.password` or `postgres.credentials.password`) before installing as well — it ships with a `change-me` placeholder default.
+Change the app database password (`postgres.credentials.password`) before installing as well — it ships with a `change-me` placeholder default.
 
 Once both secrets exist, install the template using your preferred method:
 
@@ -347,7 +347,7 @@ Firewall changes applied by an upgrade take up to about 30 seconds to propagate.
 
 ### App Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Grafana is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode. In HA mode `postgresHA.proxy.enabled` must stay `true` — that HAProxy endpoint is Grafana's stable database address, and disabling it is rejected at render.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password`). Grafana is wired to the active database automatically: the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode. In HA mode `postgresHA.proxy.enabled` must stay `true` — that HAProxy endpoint is Grafana's stable database address, and disabling it is rejected at render.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 

--- a/template-catalog/templates/keycloak.mdx
+++ b/template-catalog/templates/keycloak.mdx
@@ -107,7 +107,7 @@ Version `1.1.0` moved the bootstrap admin login out of Helm values. Earlier vers
 |---|---|---|
 | Bootstrap admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `username` and `password` |
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
-| Database password | A value (`postgresHA.postgres.password` / `postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -171,10 +171,11 @@ admin:
 # replicas, and an HAProxy leader-routing endpoint Keycloak connects to.
 postgresHA:
   enabled: true
-  postgres:
-    username: keycloak
-    password: change-me-keycloak-db # change before installing
-    database: keycloak
+  config:
+    # Name of the dictionary secret this chart creates and the bundled
+    # postgres-highly-available reads. One secret feeds whichever store
+    # is enabled, built from postgres.credentials.* above.
+    credentialsSecretName: my-keycloak-db-credentials
   replicas: 3
   volumeset:
     capacity: 10 # initial capacity in GiB per replica (minimum is 10)
@@ -282,7 +283,7 @@ Exactly one of the two stores must be enabled — the chart enforces this at ren
 
 - `postgresHA` (default) — A highly available PostgreSQL cluster from the [PostgreSQL Highly Available template](/template-catalog/templates/postgres-highly-available): 3 Patroni replicas, 3 etcd replicas, and an HAProxy endpoint that routes Keycloak's connections to the current leader. Do not disable the HA proxy (`postgresHA.proxy.enabled`) — Keycloak writes through the HAProxy leader endpoint, and the chart enforces this at render.
 - `postgres` — A single-instance PostgreSQL from the [PostgreSQL template](/template-catalog/templates/postgres), for lighter dev/test deployments. Set `postgresHA.enabled: false` and `postgres.enabled: true`.
-- `postgresHA.postgres.*` / `postgres.credentials.*` — Database credentials and database name. **Change the password before installing.**
+- `postgres.credentials.*` / `postgres.credentials.*` — Database credentials and database name. **Change the password before installing.**
 - `postgresHA.volumeset.capacity` / `postgres.volumeset.capacity` — Initial volume size in GiB (minimum 10, per replica for the HA store).
 
 <Warning>
@@ -320,7 +321,7 @@ On a first install of the default HA stack, the Keycloak container waits for the
 ## Important Notes
 
 - **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
-- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **Change the database password before installing** (`postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 - **The bootstrap admin is temporary by design** — log in, create a permanent admin, then remove it. Its credentials are seeded on first boot only; change the password in the admin console, not by editing the secret.

--- a/template-catalog/templates/listmonk.mdx
+++ b/template-catalog/templates/listmonk.mdx
@@ -240,7 +240,7 @@ Firewall changes take roughly 30 seconds to a few minutes to propagate after an 
 
 ### Backing Store
 
-Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards.
+Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgres.credentials.password`); it seeds the database on first boot and cannot be changed by editing values afterwards.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -259,7 +259,7 @@ Version `1.1.0` moved the Super Admin login out of Helm values. Earlier versions
 | Super Admin login | `admin.username` and `admin.password` values | `admin.secretName` — a dictionary secret you create, holding `username` and `password` |
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
 | Minimum-length check | At render, from the values | At container startup, from the secret — with a message naming the secret |
-| Database password | A value (`postgres.credentials.password` / `postgresHA.postgres.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgres.credentials.password` / `postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -380,7 +380,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **Single instance by design — there is no `replicas` knob.** Listmonk runs its campaign workers in-process, so two instances against one database would send every campaign twice. The workload is pinned to one replica and rolls out without surge: the old replica stops before the new one starts, which means an upgrade or restart causes a brief gap in availability instead of overlapping senders. Durability comes from PostgreSQL and the uploads volume set.
 - **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
 - **Mind the minimum credential lengths** — a username under 3 characters or a password under 8 makes upstream's install step fail; the container catches this at startup and names the secret instead of looping on a misleading database message.
-- **Change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design. Both the admin account and the database are seeded on first boot only.
+- **Change the database password before installing** (`postgres.credentials.password` / `postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design. Both the admin account and the database are seeded on first boot only.
 - **No mail is delivered until SMTP is configured** in **Admin → Settings → SMTP**. Before that, starting a campaign is not an error — it runs and finishes with zero messages sent.
 - **Keep `publicAccess` enabled for subscriber-facing pages to work.** Subscription forms, unsubscribe links, and tracking pixels must be reachable from the internet; the admin UI and API stay authentication-gated either way.
 - **Use `/health` for external health checks**, not `/api/health` — the latter requires an authenticated session.

--- a/template-catalog/templates/metabase.mdx
+++ b/template-catalog/templates/metabase.mdx
@@ -274,7 +274,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 ### App Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Metabase is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password`). Metabase is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -292,7 +292,7 @@ Version `1.1.0` moved the admin login out of Helm values. Earlier versions shipp
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
 | `admin.firstName` / `admin.lastName` / `siteName` | Values | Unchanged |
 | `encryptionKey.secretName` | Prerequisite opaque secret | Unchanged |
-| Database password | A value (`postgresHA.postgres.password` / `postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -408,7 +408,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 
 - **Back up the encryption-key secret** — losing or changing it means re-entering every saved database connection; rotation is only possible offline via Metabase's `rotate-encryption-key` command.
 - **Create both prerequisite secrets before installing** — a missing one leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
-- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **Change the database password before installing** (`postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
 - **A weak or malformed admin password keeps the workload unready by design** — Metabase's own check requires letters and digits, 8+ characters, and the container refuses to run setup if the email or password contains a double quote or a backslash. A failed bootstrap is fail-closed rather than exposing an open setup page.
 - **Metabase is single-replica in this template** — the default HA PostgreSQL backend removes the database as a failure point.
 - **Upgrades restart the single replica** — expect a few minutes of UI downtime per Helm upgrade; the HA app database keeps running and no data is lost.

--- a/template-catalog/templates/n8n.mdx
+++ b/template-catalog/templates/n8n.mdx
@@ -319,7 +319,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 ### Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). n8n is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password`). n8n is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -418,7 +418,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 - **Back up the encryption-key secret** — losing it permanently bricks every credential n8n has stored; never change it after first boot (n8n fails to start on a key mismatch).
 - **Create both prerequisite secrets before installing.** A missing one wedges the deployment with no log output at all; [Prerequisites](#prerequisites) gives the one command that diagnoses it.
 - **The owner secret is authoritative at every restart** — it is not a one-time bootstrap. Changing it changes the login; see [Upgrading From 1.0.x](#upgrading-from-1-0-x).
-- **Change the bundled database password** (`postgresHA.postgres.password` / `postgres.credentials.password`) before installing — it is used exactly as written. It stays a value deliberately: it is internal plumbing between n8n and its own database that nobody types.
+- **Change the bundled database password** (`postgres.credentials.password`) before installing — it is used exactly as written. It stays a value deliberately: it is internal plumbing between n8n and its own database that nobody types.
 - **The n8n main instance is single-replica by upstream design** — the default HA PostgreSQL backend removes the database as a failure point.
 - **Upgrades restart the single replica** — expect roughly a minute of editor/webhook downtime per Helm upgrade. The first upgrade after an install also re-applies the bundled database, which can add a couple of minutes.
 - **Access changes take time to propagate** — after toggling `publicAccess` or `internalAccess`, re-test over roughly 30 seconds to 5 minutes before concluding the knob is broken.

--- a/template-catalog/templates/nocodb.mdx
+++ b/template-catalog/templates/nocodb.mdx
@@ -433,7 +433,7 @@ Redis runs with `maxmemory-policy noeviction`, and this is deliberate: an evicte
 
 ### Database
 
-Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
+Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgres.credentials.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -522,7 +522,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **AWS S3 is keyless only** — use a cloud account plus a bucket-scoped IAM policy. Static keys are accepted only when `storage.s3.endpoint` points at an S3-compatible server.
 - **`admin.secretName` re-applies on every boot** — a password changed in the UI is reverted at the next restart. Leave it empty or treat the secret as the source of truth.
 - **The single-instance and HA database paths run different PostgreSQL majors** — 18 and 17 respectively. Choose before you have data; switching is a dump and restore.
-- **Change `postgres.credentials.password` (or `postgresHA.postgres.password`) and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
+- **Change `postgres.credentials.password` and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
 - **Set `nocodb.siteUrl` when NocoDB sits behind a custom domain**, with the scheme (`https://data.example.com`). It drives invitation and password-reset links and the auth cookie's secure flag, so a mismatch with the URL browsers use breaks both.
 - **Firewall changes take effect after a delay** — flipping `publicAccess.enabled` or `internalAccess.type` can take half a minute or more to be enforced after the upgrade reports success.
 - **With SMTP off, invitations and password resets cannot be delivered** — configure `smtp.*` before inviting collaborators.

--- a/template-catalog/templates/polaris.mdx
+++ b/template-catalog/templates/polaris.mdx
@@ -168,10 +168,11 @@ postgres:
 # upgrades and automatic failover
 postgresHA:
   enabled: false
-  postgres:
-    username: polaris
-    password: change-me-polaris-db # change before installing
-    database: polaris
+  config:
+    # Name of the dictionary secret this chart creates and the bundled
+    # postgres-highly-available reads. One secret feeds whichever store
+    # is enabled, built from postgres.credentials.* above.
+    credentialsSecretName: my-polaris-db-credentials
   replicas: 3
   volumeset:
     capacity: 10 # initial capacity in GiB per replica (minimum is 10)
@@ -264,7 +265,7 @@ Exactly one of `postgres` (default) and `postgresHA` must be enabled — the cha
 | Footprint | 1 workload | 8 replicas across 3 workloads |
 | Time to ready | ~90 s | ~6 min |
 
-Switch by setting `postgres.enabled: false` and `postgresHA.enabled: true`. Polaris is wired to whichever is active automatically — the single instance directly, or the HAProxy leader endpoint in HA mode. **Change the database password before installing** in either mode (`postgres.credentials.password` or `postgresHA.postgres.password`); the default is an obvious placeholder.
+Switch by setting `postgres.enabled: false` and `postgresHA.enabled: true`. Polaris is wired to whichever is active automatically — the single instance directly, or the HAProxy leader endpoint in HA mode. **Change the database password before installing** in either mode (`postgres.credentials.password` or `postgres.credentials.password`); the default is an obvious placeholder.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -444,7 +445,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **Root credentials are write-once**; they are applied only at first bootstrap. Rotate by creating a new principal through the management API.
 - **Rotating the token signing key invalidates every outstanding token** — clients must request a new one.
 - **`realm` is permanent.** Renaming it bootstraps a new, empty realm and hides the existing catalogs.
-- **Change the metastore password before installing** (`postgres.credentials.password` or `postgresHA.postgres.password`) — the default is a placeholder.
+- **Change the metastore password before installing** (`postgres.credentials.password` or `postgres.credentials.password`) — the default is a placeholder.
 - **No credential vending in this version.** Polaris and each query engine hold their own static object-storage credentials; keep `iceberg.rest-catalog.vended-credentials-enabled=false` in Trino.
 - **Health and metrics are in-GVC only.** They are served on port `8182`, which the public canonical endpoint does not route to.
 - **Polaris does not migrate its own database schema.** Treat a future Polaris version bump as an explicit schema step, not something startup handles.

--- a/template-catalog/templates/postgres-highly-available.mdx
+++ b/template-catalog/templates/postgres-highly-available.mdx
@@ -26,9 +26,48 @@ For production use, maintain at least 3 PostgreSQL replicas and 3 etcd replicas.
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+## Prerequisites
+
+<Warning>
+**Version `2.5.0` is a breaking change.** The `postgres` block was removed: `postgres.username`, `postgres.password` and `postgres.database` are now a prerequisite secret. An install or upgrade that still sets any of them **fails at render**, before anything is applied, and the error names the replacement. If you are running `2.4.x`, read [Upgrading From 2.4.x](#upgrading-from-24x) first.
+</Warning>
+
+**One `dictionary` secret must exist before you install.** These are the credentials your applications put in their connection strings, so they are not values — putting them in values would land them in the Helm release.
+
+```bash
+cpln secret create-dictionary --name my-postgres-ha-credentials \
+  --entry username=myuser \
+  --entry password='YOUR-STRONG-PASSWORD' \
+  --entry database=mydb
+```
+
+Set `config.credentialsSecretName` to the name you used. Secret names are organization-wide, so give each release its own.
+
+<Warning>
+**If the secret does not exist at install time, the deployment wedges silently.** `cpln logs` returns **zero lines** — the container never starts, so it has nothing to log. The one place the reason appears is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-postgres-ha --gvc GVC_NAME -o yaml
+```
+
+Note this is `get-deployments` — plain `cpln workload get` has no `versions` field. Creating the secret repairs the deployment on its own in roughly 5.5 to 10.5 minutes, or force a redeployment to skip the wait.
+</Warning>
+
+Enabling backups to MinIO needs a second `dictionary` secret — see [Backup Prerequisites](#backup-prerequisites).
+
+## Upgrading From 2.4.x
+
+Delete the `postgres:` block from your values, create the credentials secret above, and set `config.credentialsSecretName`.
+
+<Warning>
+**Use the credentials your cluster already has.** They were applied when the data directory was first initialised and are still what PostgreSQL enforces. Putting *new* values in the secret does not change the running database — it just gives your applications a password that no longer works.
+</Warning>
+
+Versions `2.4.2` and earlier shipped `username: username` and `password: password` as defaults. If your cluster is still running those, treat them as compromised: they are published in a public repository. Change them inside PostgreSQL with `ALTER ROLE ... WITH PASSWORD` and put the new value in the secret.
+
 ## Installation
 
-This template has no external prerequisites unless backup is enabled. To install, follow the instructions for your preferred method:
+To install, follow the instructions for your preferred method:
 
 <CardGroup cols={2}>
     <Card title="UI" href="/template-catalog/install-manage/ui" icon="laptop">
@@ -67,10 +106,10 @@ resources:
 
 image: controlplanecorporation/patroni-postgres:0.7
 
-postgres:
-  username: username
-  password: password
-  database: test
+config:
+  # REQUIRED prerequisite `dictionary` secret holding `username`, `password`
+  # and `database`. It must EXIST BEFORE INSTALL.
+  credentialsSecretName: my-postgres-ha-credentials
 
 multiZone: false
 
@@ -162,19 +201,20 @@ backup:
   minio: # Backup to a self-hosted MinIO workload (or any S3-compatible endpoint)
     endpoint: http://my-minio-workload:9000 # e.g. http://WORKLOAD_NAME:9000 for an internal MinIO template deployment
     bucket: pg-ha-backup-bucket
-    accessKey: my-minio-username # matches the MinIO template's admin.username
-    secretKey: my-minio-password # matches the MinIO template's admin.password
+    # REQUIRED prerequisite `dictionary` secret holding `accessKey` and
+    # `secretKey`, only when backups are enabled with provider: minio
+    credentialsSecretName: my-postgres-ha-minio-credentials
     prefix: postgres/backups
 ```
 
 ### Credentials
 
-- `postgres.username` — PostgreSQL superuser username. **Change before deploying to production.**
-- `postgres.password` — PostgreSQL superuser password. **Change before deploying to production.**
-- `postgres.database` — Name of the database created on first startup.
+- `config.credentialsSecretName` — Name of the `dictionary` secret holding `username`, `password` and `database`. PostgreSQL creates that user and that database on first boot, and this is the credential your applications put in their connection strings.
+
+The secret must exist before you install — see [Prerequisites](#prerequisites). The cluster reads it through `cpln://secret/...` references, so the values appear in neither the Helm release nor the stored workload spec.
 
 <Note>
-These values are only applied on first startup when the data directory is empty. Updating them after the initial deployment will have no effect on the running database. To change credentials or the database name on an existing instance, use PostgreSQL's native commands (e.g. `ALTER USER`, `ALTER DATABASE`).
+These credentials are only applied on first startup, when the data directory is empty. Rotating the secret afterwards does not change the stored password; change it inside PostgreSQL with `ALTER ROLE ... WITH PASSWORD` and update the secret to match.
 </Note>
 
 ### PostgreSQL Cluster
@@ -353,7 +393,13 @@ Before enabling backup with `provider: minio`, ensure your MinIO instance is acc
 
 1. Create a bucket in MinIO. Set `backup.minio.bucket` to its name.
 2. Set `backup.minio.endpoint` to the MinIO S3 API address including the port. For the `minio` marketplace template deployed in the same GVC, use `http://WORKLOAD_NAME:9000`.
-3. Set `backup.minio.accessKey` and `backup.minio.secretKey` to the MinIO root credentials — these match the `admin.username` and `admin.password` values from the MinIO template installation.
+3. Create a [dictionary secret](/guides/create-secret/dictionary) holding exactly the keys `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name. For the `minio` template these are its `admin.username` and `admin.password`:
+
+```bash
+cpln secret create-dictionary --name my-postgres-ha-minio-credentials \
+  --entry accessKey=MINIO_ACCESS_KEY \
+  --entry secretKey=MINIO_SECRET_KEY
+```
 4. Set `backup.minio.prefix` to the folder path where backups will be stored.
 
 <Note>

--- a/template-catalog/templates/temporal.mdx
+++ b/template-catalog/templates/temporal.mdx
@@ -201,7 +201,7 @@ Both workloads are internal-only — there is no public-access option in this te
 
 ### Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Temporal is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password`). Temporal is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -325,7 +325,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 
 ## Important Notes
 
-- **Change the database password** (`postgresHA.postgres.password` / `postgres.credentials.password`) before installing.
+- **Change the database password** (`postgres.credentials.password`) before installing.
 - **`historyShards` is permanent** — the shard count is fixed at the cluster's first boot and can never be changed; the server refuses a different value later. Size it before installing (512 suits most deployments).
 - **Never expose the Web UI publicly** — it has no built-in authentication. To offer browser access from outside the internal scope, put your own authenticating proxy in front of it.
 - **Temporal connects and runs schema setup as the database superuser** provisioned by the PostgreSQL subchart — it needs `CREATE DATABASE` and DDL rights at every version upgrade.

--- a/template-catalog/templates/twenty.mdx
+++ b/template-catalog/templates/twenty.mdx
@@ -406,7 +406,7 @@ Redis runs with `maxmemory-policy noeviction` and `appendonly yes`, and this is 
 
 ### Database
 
-Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
+Enable exactly one of `postgres` (single instance, default) or `postgresHA` (highly available) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgres.credentials.password`); it seeds the database on first boot and cannot be changed by editing values afterwards. Use only letters, digits, `-`, and `_` — the password is embedded in the connection URL.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -491,7 +491,7 @@ In HA mode, `postgresHA.backup.mode` selects `logical` (scheduled `pg_dump`) or 
 - **The single-instance and HA paths run different PostgreSQL majors** — 18 and 17 respectively. Choose before you have data; switching is a dump and restore.
 - **`twenty.replicas` above `1` requires `storage.type: s3`** — the shared local volume set lives in one location and cannot be snapshotted, so S3 is the production recommendation regardless of replica count.
 - **AWS S3 is keyless only** — use a cloud account plus a bucket-scoped IAM policy. Static keys are accepted only when `storage.s3.endpoint` points at an S3-compatible server.
-- **Change `postgres.credentials.password` (or `postgresHA.postgres.password`) and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
+- **Change `postgres.credentials.password` and `redis.auth.password` before installing** — both seed their component on first boot, and both are embedded in connection URLs, so use only letters, digits, `-`, and `_`.
 - **Set `twenty.serverUrl` when Twenty sits behind a custom domain**, with the scheme (`https://crm.example.com`). A mismatch with the URL browsers use breaks auth callbacks and CORS with opaque errors.
 - **SMTP, AI provider keys, rate limits, and OAuth/SSO are not values knobs** — configure them in **Settings → Admin Panel → Configuration Variables** inside the app.
 - **Foreign data wrappers ("remote objects") are unavailable** — that feature needs upstream's custom PostgreSQL image, which this template does not deploy.

--- a/template-catalog/templates/umami.mdx
+++ b/template-catalog/templates/umami.mdx
@@ -57,7 +57,7 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 Creating the secret afterwards **does** release it, without further action, but slowly — measured between 5.5 and 10.5 minutes across five templates, so poll rather than time-box it. To skip the wait, run `cpln workload force-redeployment {release}-umami --gvc {gvc}`.
 </Warning>
 
-Nothing else is required for a default install. Optional: a bucket and access setup for one of the supported providers if you enable database backups — see [Backing Up](#backing-up). Change the database password (`postgres.credentials.password` or `postgresHA.postgres.password`) before installing as well; it ships with a `change-me` placeholder default.
+Nothing else is required for a default install. Optional: a bucket and access setup for one of the supported providers if you enable database backups — see [Backing Up](#backing-up). Change the database password (`postgres.credentials.password` or `postgres.credentials.password`) before installing as well; it ships with a `change-me` placeholder default.
 
 Once the secret exists, install the template using your preferred method:
 
@@ -265,7 +265,7 @@ Access changes take up to a couple of minutes to propagate — every measured tr
 
 ### Backing Store
 
-Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgresHA.postgres.password`).
+Enable exactly one of `postgres` (single-instance, default) or `postgresHA` (HA) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password` / `postgres.credentials.password`).
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 

--- a/template-catalog/templates/unleash.mdx
+++ b/template-catalog/templates/unleash.mdx
@@ -271,7 +271,7 @@ postgres: # dev/lightweight: single-instance PostgreSQL (disable postgresHA firs
 
 ### Database
 
-Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`). Unleash is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
+Enable exactly one of `postgresHA` (production, default) or `postgres` (dev/lightweight) — see [Choosing a Database Mode](#choosing-a-database-mode). In both modes, **change the database password before installing** (`postgres.credentials.password`). Unleash is wired to the active database automatically — the HAProxy leader endpoint in HA mode, or the single instance directly in dev mode.
 
 If you run more than one release of this template in the same organization, give each its own `postgres.config.credentialsSecretName`. Secret names are organization-wide, so a second release left on the default name is **refused at install** and creates nothing — the first release is unaffected.
 
@@ -289,7 +289,7 @@ Version `1.1.0` moved the initial admin login out of Helm values. Earlier versio
 | Chart-created admin secret | Held the admin credentials | None; the template creates no admin secret at all |
 | `apiTokens.secretName` | Prerequisite dictionary secret | Unchanged |
 | Database startup | Migrations ran immediately at boot | The start script waits for the database first |
-| Database password | A value (`postgresHA.postgres.password` / `postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
+| Database password | A value (`postgres.credentials.password`) | Unchanged — still a value, because it is bundled plumbing nobody logs in with |
 
 <Warning>
 **An upgrade that still carries either removed key is rejected at render, before anything is applied.** Each guard names its replacement, and there is no compatibility fallback — the version bump is the migration path. A real upgrade carrying an old key failed at render, created no Helm revision, and left the running release healthy and untouched:
@@ -416,7 +416,7 @@ In HA mode, `backup.mode` selects `logical` (scheduled `pg_dump` via a cron work
 ## Important Notes
 
 - **Create the admin secret before installing** — a missing prerequisite secret leaves the workload waiting on something that does not exist, with zero log lines. See [Prerequisites](#prerequisites) for how to diagnose it.
-- **Change the database password before installing** (`postgresHA.postgres.password` / `postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
+- **Change the database password before installing** (`postgres.credentials.password`) — it is bundled plumbing, used exactly as given, and it remains a value by design.
 - **Admin credentials and API tokens are seeded on first boot only** — they live in the database afterwards; change the password or manage tokens in the admin UI, not by editing the secrets.
 - **Backend tokens must stay secret** (server-side SDKs, `/api/client`); frontend tokens are safe to embed in browsers (`/api/frontend`). A `401` usually means the wrong token type or environment.
 - **The free edition ships exactly two environments** (`development`, `production`) — SSO, role-based access control, multiple projects, change requests, and audit logs require an Unleash Enterprise license and are not available in this template.


### PR DESCRIPTION
Covers templates#457 (pgHA 2.5.0) and templates#458 (the 14 adopters), since the two are one user-visible change.

## postgres-highly-available

The page opened with *"This template has no external prerequisites unless backup is enabled."* That is now false in the ordinary case — `2.5.0` requires a credentials secret on **every** install, and without it the deployment wedges with **zero log lines**.

Four things were stale and would have actively misled: the values block still showed the removed `postgres:` `username`/`password`/`database`; the Credentials section documented those three keys; the MinIO backup block showed `accessKey`/`secretKey`; and the MinIO setup step told users to set them directly.

Added **Prerequisites** (with the `create-dictionary` command and the wedge diagnostic) and **Upgrading From 2.4.x**.

The upgrade warning matters more than the mechanics: these credentials are applied only when the data directory is **first initialised**, so putting *new* values in the secret does not change a running cluster — it hands your applications a password the database will reject. Separately, `2.4.2` and earlier shipped `username: username` / `password: password`; anyone still on those should treat them as **compromised** rather than simply upgrade, since they are published in a public repository.

## The fourteen adopters

**29 references across 13 pages** — the removed credential block in each YAML sample, plus the prose telling users to change `postgresHA.postgres.password`.

The replacement is simpler than what it replaces: **one secret, built from `postgres.credentials.*`, feeds whichever store is enabled.** Users no longer keep two credential blocks in sync depending on which backing store they chose.

`cdc-pipeline` has no docs page, so nothing to update there.

## Verified

- Each page's documented secret name compared against the name the **shipped chart actually creates** — all 13 match
- Every documented value on the pgHA page diffed against the shipped `2.5.0` `values.yaml`
- All three new anchors resolve (`#prerequisites`, `#upgrading-from-24x`, `#backup-prerequisites`)
- `npx mintlify broken-links` — nothing in `template-catalog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)