### PR TITLE
docs: credential audit + aws::ReadOnlyAccess removal

### DIFF
--- a/template-catalog/templates/cassandra.mdx
+++ b/template-catalog/templates/cassandra.mdx
@@ -283,6 +283,12 @@ Set `backup.enabled: true`, set `backup.type`, and fill in the cloud storage blo
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.1.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -295,7 +301,11 @@ Set `backup.enabled: true`, set `backup.type`, and fill in the cloud storage blo
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/cassandra.mdx
+++ b/template-catalog/templates/cassandra.mdx
@@ -6,6 +6,12 @@ title: Cassandra
 
 Apache Cassandra is a distributed NoSQL database designed for high availability and linear scalability. This template deploys a Cassandra 5.0 cluster in a single location where each node owns a slice of the token ring and replicates data to peers according to the configured replication factor. Optional scheduled backups and periodic anti-entropy repair are included.
 
+Cluster credentials are **not** template values. Cassandra reads its superuser password, application role and keyspace from a dictionary secret you create before installing, so no password passes through Helm or lands in the release.
+
+<Warning>
+**Template version 1.1.0 is a breaking security change.** `superuserPassword`, `username`, `password` and `keyspaceName` were removed, and an install or upgrade that still sets any of them now fails at render instead of silently falling back to a published default password. If you are running 1.0.1 or earlier, read [Upgrading From 1.0.x](#upgrading-from-1-0-x) before you touch the release.
+</Warning>
+
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
@@ -21,6 +27,47 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 - **Repair Cron Workload** *(optional, enabled by default)* — Runs `nodetool repair` on a schedule to keep data consistent across replicas.
 
 ## Prerequisites
+
+**One `dictionary` secret must exist before you install.** These are the credentials you type into every client and connection string, so they are not values — a value would leave them in the Helm release.
+
+<Steps>
+  <Step title="Create the credentials secret">
+    A [dictionary secret](/guides/create-secret/dictionary) holding exactly four keys. `superuserPassword` is the built-in `cassandra` role, used for JMX and by the repair cron; `username`, `password` and `keyspace` are the application role and its keyspace, created on first boot:
+
+    ```bash
+    cpln secret create-dictionary --name my-cassandra-credentials \
+      --entry superuserPassword='YOUR-SUPERUSER-PASSWORD' \
+      --entry username=myuser \
+      --entry password='YOUR-STRONG-PASSWORD' \
+      --entry keyspace=mykeyspace
+    ```
+
+    Set `credentialsSecretName` to the name you used. Secret names are org-wide, so give each release its own.
+  </Step>
+  <Step title="Read the secret back later">
+    Pass `-o yaml`. A bare `cpln secret reveal` prints only a summary table, not the values:
+
+    ```bash
+    cpln secret reveal my-cassandra-credentials -o yaml
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+**Create the secret before installing, or the deployment wedges silently.** The template refuses to render when `credentialsSecretName` is blank, but a name pointing at a secret that does not exist installs "successfully" and then never starts. The container never runs, so `cpln logs` returns **zero lines** — there is nothing to log, and every summary surface just looks like a slow deploy. The one place the reason appears is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-cassandra --gvc GVC_NAME -o yaml
+```
+
+```text
+The secret my-cassandra-credentials no longer exists. Workload updates are paused until the
+secret is added or the reference to the secret removed.
+```
+
+Use `get-deployments` — plain `cpln workload get` has no `versions` key and will show you nothing. Creating the missing secret repairs it on its own in roughly **5.5 to 10.5 minutes**, or run `cpln workload force-redeployment RELEASE_NAME-cassandra --gvc GVC_NAME` to clear it in about 90 seconds.
+</Warning>
+
 
 This template has no external prerequisites unless backup is enabled. To install, follow the instructions for your preferred method:
 
@@ -46,6 +93,48 @@ This template has no external prerequisites unless backup is enabled. To install
     </Card>
 </CardGroup>
 
+## Upgrading From 1.0.x
+
+Template versions up to 1.0.1 took the cluster credentials as plain Helm values and shipped working defaults for them — `supersecretpassword` for the built-in `cassandra` role and `password` for the application role. Version 1.1.0 removes all four keys.
+
+| | 1.0.x | 1.1.0 |
+|---|---|---|
+| Credentials | `superuserPassword`, `username`, `password`, `keyspaceName` values | `credentialsSecretName` → a dictionary secret you create |
+| Where the passwords live | The Helm release | Only the secret you create |
+
+<Warning>
+**Carrying the old values forward stops the upgrade.** The removed keys are rejected at render, so `cpln helm upgrade` fails and your existing release is left untouched and running:
+
+```text
+Error: execution error at (cassandra/templates/identity.yaml:1:4): cassandra: superuserPassword,
+username, password and keyspaceName were REMOVED — they are now a `dictionary` secret you create,
+named by credentialsSecretName, holding the keys `superuserPassword`, `username`, `password` and
+`keyspace`. Delete them from your values. See Prerequisites in the README.
+```
+</Warning>
+
+<Steps>
+  <Step title="Recover the credentials the cluster already uses">
+    Bootstrap runs once and is flagged on disk, so an existing cluster keeps whatever it was created with. Take the values from your current values file.
+  </Step>
+  <Step title="Create the secret with those same values">
+    Follow [Prerequisites](#prerequisites). `keyspaceName` becomes the `keyspace` entry. Different values here do not change the cluster — they just leave clients unable to authenticate.
+  </Step>
+  <Step title="Remove the old keys and upgrade">
+    Delete all four, set `credentialsSecretName`, then upgrade.
+  </Step>
+  <Step title="Rotate anything that came from a default">
+    `supersecretpassword` and `password` were published in the public template repository, so treat them as compromised:
+
+    ```sql
+    ALTER USER cassandra WITH PASSWORD 'NEW-SUPERUSER-PASSWORD';
+    ALTER ROLE myuser WITH PASSWORD 'NEW-STRONG-PASSWORD';
+    ```
+
+    Then update the secret so the workloads still authenticate on restart.
+  </Step>
+</Steps>
+
 ## Configuration
 
 The default `values.yaml` for this template:
@@ -56,10 +145,7 @@ replicas: 3
 replicationFactor: 1
 
 # IMPORTANT: Change all credentials before deploying to production
-superuserPassword: supersecretpassword
-username: username
-password: password
-keyspaceName: mydatabase
+credentialsSecretName: my-cassandra-credentials # see Prerequisites — must exist before install
 
 image: cassandra:5.0
 cpu: 1
@@ -164,7 +250,7 @@ Host:     {release-name}-cassandra-0.{gvc-name}.cpln.local
 Port:     9042
 Username: {username}
 Password: {password}
-Keyspace: {keyspaceName}
+Keyspace: the `keyspace` entry of your credentials secret
 ```
 
 ### Repair

--- a/template-catalog/templates/clickhouse.mdx
+++ b/template-catalog/templates/clickhouse.mdx
@@ -150,6 +150,12 @@ This template creates its own GVC, named by `gvc.name` (default `clickhouse-gvc`
 
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 2.6.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -162,7 +168,11 @@ This template creates its own GVC, named by `gvc.name` (default `clickhouse-gvc`
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/cockroach.mdx
+++ b/template-catalog/templates/cockroach.mdx
@@ -261,6 +261,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.4.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -273,7 +279,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/elasticsearch.mdx
+++ b/template-catalog/templates/elasticsearch.mdx
@@ -212,6 +212,12 @@ The backup schedule uses **Quartz cron format** with 6 fields (seconds, minutes,
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.0.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -224,7 +230,11 @@ The backup schedule uses **Quartz cron format** with 6 fields (seconds, minutes,
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/ess.mdx
+++ b/template-catalog/templates/ess.mdx
@@ -8,6 +8,12 @@ keywords: ['ess', 'secret sync', 'aws secrets manager', 'azure key vault', 'gcp 
 
 The External Secret Syncer (ESS) continuously syncs secrets and parameters from external providers into Control Plane secrets. This template deploys ESS as a workload that polls your configured providers on a set interval and creates or updates Control Plane secrets to match.
 
+The sync configuration is **not** a template value. It carries provider credentials — a Vault token, AWS access keys, a 1Password service-account token — so you supply it as an opaque secret holding your whole `sync.yaml`.
+
+<Warning>
+**Template version 2.1.0 is a breaking security change.** `essConfig` was removed, and an install or upgrade that still sets it now fails at render. If you are running 2.0.x, read [Upgrading From 2.0.x](#upgrading-from-2-0-x) before you touch the release.
+</Warning>
+
 ### How It Works
 
 ESS runs as a workload on Control Plane. Your provider configuration and secrets list are stored in a Control Plane secret and mounted into the workload as `sync.yaml`. On startup, ESS schedules a polling loop for each configured secret. At each interval, it fetches the latest value from the external provider and creates or updates the corresponding Control Plane secret via the API.
@@ -42,6 +48,51 @@ This template does not create a GVC. You must deploy it into an existing GVC.
 1. A secret or parameter stored in one of the [supported providers](#supported-providers).
 2. Credentials with read access to the desired secret (API token, IAM keys, etc.). Alternatively, you can use a cloud access [identity](/reference/identity) instead of supplying keys directly.
 
+**Your sync configuration must exist as an `opaque` secret before you install.** It carries those provider
+credentials, so it is not a template value — a value would put every one of them in the Helm release. It is
+also a configuration *file*, and a `cpln://secret` reference inside a file is never resolved, so individual
+keys cannot be swapped out either. The whole file is therefore yours.
+
+<Steps>
+  <Step title="Write your sync.yaml">
+    The `providers` and `secrets` schema is documented under [Configuration](#configuration).
+
+    ```yaml
+    # sync.yaml
+    providers:
+      - name: my-vault
+        vault:
+          address: https://my-vault.com:8200
+          token: YOUR-VAULT-TOKEN
+        syncInterval: 1m
+    secrets:
+      - name: my-app-secret
+        provider: my-vault
+        type: opaque
+        path: secret/data/my-app
+        key: password
+    ```
+  </Step>
+  <Step title="Create the secret and point the chart at it">
+    ```bash
+    cpln secret create-opaque --name my-ess-config --encoding plain -f sync.yaml
+    ```
+
+    Set `configSecretName` to the name you used. Secret names are org-wide, so give each release its own.
+  </Step>
+</Steps>
+
+<Warning>
+**If the secret does not exist at install time, the deployment wedges silently.** `cpln logs` returns **zero
+lines** — the container never starts, so it has nothing to log. Read `status.versions[].message` instead:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-ess --gvc GVC_NAME -o yaml
+```
+
+Use `get-deployments` — plain `cpln workload get` has no `versions` key.
+</Warning>
+
 ### Installation
 
 To install, follow the instructions for your preferred method:
@@ -68,12 +119,47 @@ To install, follow the instructions for your preferred method:
     </Card>
 </CardGroup>
 
+## Upgrading From 2.0.x
+
+Version 2.1.0 removes `essConfig`. The **schema is unchanged** — migrating is a verbatim lift of that block into a file, minus the top-level `essConfig:` wrapper.
+
+<Warning>
+**Carrying `essConfig` forward stops the upgrade.** It is rejected at render, so `cpln helm upgrade` fails and your existing syncer is left untouched and running:
+
+```text
+Error: execution error at (ess/templates/identity.yaml:1:4): ess: essConfig was REMOVED — it holds
+provider credentials (Vault token, AWS keys, 1Password token), so it is now an `opaque` secret you
+create, named by configSecretName, whose entire value is your sync.yaml. Delete essConfig from your
+values. See Prerequisites in the README.
+```
+</Warning>
+
+<Steps>
+  <Step title="Move your essConfig block into sync.yaml">
+    Copy it verbatim and drop the `essConfig:` wrapper, so `providers:` and `secrets:` become top-level keys.
+  </Step>
+  <Step title="Create the secret and point the chart at it">
+    ```bash
+    cpln secret create-opaque --name my-ess-config --encoding plain -f sync.yaml
+    ```
+
+    Delete `essConfig` from your values and set `configSecretName`.
+  </Step>
+  <Step title="Rotate every credential that was in your values file">
+    They were stored in the Helm release, so treat them as exposed — reissue the Vault token, AWS keys or 1Password service-account token, then update `sync.yaml` and the secret.
+  </Step>
+</Steps>
+
+<Note>
+**Why the whole file, and not individual keys.** A `cpln://secret` reference is resolved only for environment variables. Inside a mounted configuration file it stays literal text, so there is no way to swap out just the token — the file itself has to be the secret.
+</Note>
+
 ## Configuration
 
 The default `values.yaml` for this template:
 
 ```yaml
-image: ghcr.io/controlplane-com/cpln-build/external-secret-syncer:v1.3.4
+image: ghcr.io/controlplane-com/cpln-build/external-secret-syncer:v2.0.0
 
 resources:
   cpu: 200m
@@ -181,11 +267,11 @@ essConfig:
 - `resources.cpu` / `resources.memory` — Resource limits for the workload container.
 - `port` — Port for the ESS HTTP admin API (default: `3004`). Used for health checks and manual sync triggers.
 - `allowedIp` — List of CIDRs allowed to reach the ESS admin API externally. Replace the placeholder with your IP, or use `0.0.0.0/0` to allow all.
-- `essConfig` — The full sync configuration — providers and secrets (see below).
+- `configSecretName` — Name of the opaque secret holding your `sync.yaml`, the full sync configuration. See [Prerequisites](#prerequisites).
 
 ### Providers
 
-Each entry in `essConfig.providers` defines a connection to an external secret store. Every provider must have a unique `name`. An optional `syncInterval` sets the default polling interval for all secrets using that provider.
+Each entry in `providers` defines a connection to an external secret store. Every provider must have a unique `name`. An optional `syncInterval` sets the default polling interval for all secrets using that provider.
 
 | Provider | Required Fields |
 |----------|----------------|
@@ -263,7 +349,7 @@ GCP Secret Manager optionally accepts `credentials.clientEmail` and `credentials
 
 ### Secrets
 
-Each entry in `essConfig.secrets` maps an external secret to a Control Plane secret. Each secret must specify a `name`, a `provider`, and exactly one sync type.
+Each entry in `secrets` maps an external secret to a Control Plane secret. Each secret must specify a `name`, a `provider`, and exactly one sync type.
 
 #### `opaque` — Single value
 

--- a/template-catalog/templates/fusionauth.mdx
+++ b/template-catalog/templates/fusionauth.mdx
@@ -92,6 +92,38 @@ To install, follow the instructions for your preferred method:
     </Card>
 </CardGroup>
 
+## Upgrading From 2.4.0
+
+**One thing changed: the default `postgres.credentials.password` is now `change-me-fusionauth-db` instead of `password`.**
+
+The bundled database initialized its data directory with whatever password was in force at **first boot**, and changing the value afterwards does not change the database. So:
+
+- **If you already set your own password**, nothing changes — upgrade normally.
+- **If you never overrode it**, your database's password is literally `password`. Do one of these before upgrading, or FusionAuth will fail to authenticate:
+
+<Steps>
+  <Step title="Keep it working as-is">
+    Set `postgres.credentials.password: password` explicitly in your values. The upgrade is then a no-op.
+  </Step>
+  <Step title="Or rotate it properly (recommended)">
+    `password` was a published default, so treat it as compromised. Change it inside Postgres first, then set the value to match:
+
+    ```sql
+    ALTER ROLE username WITH PASSWORD 'YOUR-STRONG-PASSWORD';
+    ```
+  </Step>
+</Steps>
+
+`postgres.credentials.username` and `postgres.credentials.database` are deliberately unchanged for the same reason — they are baked into the initialized data directory, and `database` also forms the JDBC URL.
+
+<Note>
+**These credentials stay values rather than becoming a prerequisite secret, and that is deliberate.** The chart creates the secret from them, the bundled Postgres is the only consumer, and no human types this password anywhere else. `database` could not move to a secret in any case: it is interpolated into the JDBC connection string at render time, where a `cpln://` reference would be literal text.
+</Note>
+
+<Warning>
+**Complete the FusionAuth setup wizard immediately after installing.** Inbound traffic is open to `0.0.0.0/0` by default and FusionAuth has no administrator until the wizard is finished, so whoever reaches it first creates that account. If you cannot complete it right away, install with `firewall.external.inboundAllowCIDR` restricted to your own address and widen it afterwards — allow a couple of minutes for a firewall change to propagate.
+</Warning>
+
 ## Configuration
 
 The default `values.yaml` for this template:
@@ -116,7 +148,7 @@ postgres:
   image: postgres:18
   credentials: # the chart writes these into the secret named below — nothing for you to create
     username: username
-    password: password
+    password: change-me-fusionauth-db # used EXACTLY as given — change it before installing
     database: test
   config:
     credentialsSecretName: my-fusionauth-db-credentials # secret names are org-wide — give each release its own
@@ -141,7 +173,7 @@ postgres:
   # Postgres backup configuration (compatible with Postgres 17+)
   backup:
     enabled: false
-    image: controlplanecorporation/pg-backup:18.1.0 # tag 18.1.0 = Postgres 18, 17.1.0 = Postgres 17
+    image: ghcr.io/controlplane-com/backup-images/postgres-backup:18.1.0 # tag 18.1.0 = Postgres 18, 17.1.0 = Postgres 17
     schedule: "0 2 * * *" # daily at 2am UTC
 
     resources:

--- a/template-catalog/templates/langfuse.mdx
+++ b/template-catalog/templates/langfuse.mdx
@@ -89,6 +89,12 @@ Both ClickHouse and Langfuse use one bucket with separate key prefixes. Pick one
   <Step title="Create a bucket-scoped IAM policy">
     Create an IAM policy with the following JSON (replace `YOUR_BUCKET_NAME`) and set `objectStore.aws.policyName` to its name:
 
+    <Warning>
+    **Version 1.2.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+    **Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+    </Warning>
+
     ```json
     {
         "Version": "2012-10-17",
@@ -101,7 +107,11 @@ Both ClickHouse and Langfuse use one bucket with separate key prefixes. Pick one
                     "s3:DeleteObject",
                     "s3:ListBucket",
                     "s3:GetObjectVersion",
-                    "s3:DeleteObjectVersion"
+                    "s3:DeleteObjectVersion",
+                    "s3:GetBucketLocation",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:ListMultipartUploadParts"
                 ],
                 "Resource": [
                     "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/mariadb.mdx
+++ b/template-catalog/templates/mariadb.mdx
@@ -317,6 +317,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.4.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -329,7 +335,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/mongodb-cluster.mdx
+++ b/template-catalog/templates/mongodb-cluster.mdx
@@ -475,6 +475,12 @@ Complete the following in your AWS account before installing:
   <Step title="Create an IAM policy">
     Create an IAM policy with the following JSON (replace `YOUR_BUCKET_NAME`) and set `backup.aws.policyName` to its name:
 
+    <Warning>
+    **Version 1.1.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+    **Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+    </Warning>
+
     ```json
     {
         "Version": "2012-10-17",
@@ -487,7 +493,11 @@ Complete the following in your AWS account before installing:
                     "s3:DeleteObject",
                     "s3:ListBucket",
                     "s3:GetObjectVersion",
-                    "s3:DeleteObjectVersion"
+                    "s3:DeleteObjectVersion",
+                    "s3:GetBucketLocation",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:ListMultipartUploadParts"
                 ],
                 "Resource": [
                     "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/mongodb.mdx
+++ b/template-catalog/templates/mongodb.mdx
@@ -273,6 +273,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.4.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -285,7 +291,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/mysql.mdx
+++ b/template-catalog/templates/mysql.mdx
@@ -309,6 +309,12 @@ Only needed when `backup.enabled: true`.
 
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.5.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -321,7 +327,11 @@ Only needed when `backup.enabled: true`.
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/opensearch.mdx
+++ b/template-catalog/templates/opensearch.mdx
@@ -22,6 +22,10 @@ OpenSearch is an open-source distributed search and analytics engine. This templ
 This template does not create a GVC. You must deploy it into an existing GVC.
 </Note>
 
+<Warning>
+**Upgrade to 1.0.2 — versions 1.0.0 and 1.0.1 do not work outside a GVC named `test-gvc`, and one option granted org-wide secret access.** See [Upgrading From 1.0.x](#upgrading-from-1-0-x). Both defects have been present since 1.0.0.
+</Warning>
+
 ## Prerequisites
 
 Prerequisites are only required if you plan to enable automated backups (`backup.enabled: true`). Skip this section if backups are not needed.
@@ -92,6 +96,30 @@ To install, follow the instructions for your preferred method:
     </Card>
 </CardGroup>
 
+## Upgrading From 1.0.x
+
+Version 1.0.2 fixes five defects, all present since 1.0.0. Two of them matter regardless of how you configured the template.
+
+### The identity links were hardcoded to `test-gvc`
+
+Both workloads' `identityLink` and both policies' `principalLinks` pointed at `//gvc/test-gvc/identity/...` rather than at your GVC. An install into any GVC not literally named `test-gvc` created its identity in your GVC while every reference pointed into one you do not have.
+
+There is nothing to migrate — upgrade to 1.0.2 and the links resolve correctly.
+
+### The demo-logs policy granted `reveal` on every secret in your org
+
+When `demoLogs.enabled: true`, the demo-logs policy carried a `targetQuery` of `match: all` with an empty `terms` list alongside its `targetLinks`. That query resolves to **every secret in the organization**, not just the one the demo pipeline needs — so the demo-logs identity was granted `reveal` on all of them.
+
+<Warning>
+**If you ran 1.0.0 or 1.0.1 with `demoLogs.enabled: true`, treat every secret in that organization as having been readable by that identity.** Upgrading to 1.0.2 narrows the policy to the single Fluent Bit config secret, but it does not undo past access — review what that organization holds and rotate anything sensitive.
+</Warning>
+
+### The remaining three
+
+- **Backup provider conditions never compared anything.** A GCP backup also emitted an AWS binding pointing at a nonexistent cloud account.
+- **`aws::ReadOnlyAccess` is no longer attached** to the identity. It granted read on every bucket in the account and carried none of the write actions a snapshot repository needs; backups work without it.
+- **An unsupported `backup.provider` now fails at render** instead of installing cleanly and silently configuring no snapshot repository at all. An odd `replicas` count is enforced too.
+
 ## Configuration
 
 The default `values.yaml` for this template:
@@ -142,7 +170,7 @@ backup:
 
   provider: aws # Options: aws or gcp
 
-  schedule: "0 2 * * *" # Daily at 2am UTC
+  schedule: 0 2 * * * # Daily at 2am UTC
 
   retention:
     maxAge: 30d     # Delete snapshots older than 30 days
@@ -273,6 +301,16 @@ Once deployed, connect to the cluster from within the same GVC using:
 ```text
 http://RELEASE_NAME-opensearch.GVC_NAME.cpln.local:9200
 ```
+
+## Important Notes
+
+- **The security plugin is disabled — there is no authentication.** Any workload permitted by `internal_access` has full read/write admin access to every index, and there are no credentials anywhere in this template. Keep `internal_access.type` as narrow as your deployment allows, and prefer `workload-list` over `same-org` for anything sensitive.
+- **`replicas` must be odd.** An even count cannot form a quorum and is rejected at render from 1.0.2.
+- **Enabling backups on a running cluster fails for a few minutes before it succeeds.** The snapshot repository plugin installs at node startup, so every node must roll before the repository can be registered — meanwhile the setup job logs `repository type [s3] does not exist` and restarts. It retries until all nodes carry the plugin, about 4–5 minutes for three nodes, and then succeeds. Enabling backups at install time avoids this entirely.
+- **Switching `backup.provider` on an existing release leaves the old cloud binding attached.** The API merges identity updates and never removes a provider block once set, so an AWS-then-GCP switch leaves the identity holding both. Uninstall and reinstall if you need the old binding gone.
+- **Set the snapshot IAM policy to both bucket ARNs** — `arn:aws:s3:::BUCKET` and `arn:aws:s3:::BUCKET/*`. `s3:ListBucket` authorizes against the bucket itself, so a policy carrying only `/*` registers the repository and then fails when OpenSearch enumerates it.
+- **Use the fully-qualified internal hostname** — `RELEASE_NAME-opensearch.GVC_NAME.cpln.local:9200`. The bare workload name is not reliably resolvable.
+- **Uninstall deletes the volume sets.** Enable snapshots if the data matters.
 
 ## External References
 

--- a/template-catalog/templates/pgedge.mdx
+++ b/template-catalog/templates/pgedge.mdx
@@ -6,6 +6,12 @@ title: pgEdge Distributed PostgreSQL
 
 pgEdge is an active-active distributed PostgreSQL cluster using Spock multi-master replication. Every node accepts both reads and writes simultaneously, and data written to any node replicates to all others automatically. The cluster spans multiple geographic locations with configurable replicas per location, providing a globally distributed, fault-tolerant database with no single point of failure.
 
+Database credentials are **not** template values. pgEdge reads its username, password and database name from a dictionary secret you create before installing, so no password passes through Helm or lands in the release.
+
+<Warning>
+**Template version 1.1.0 is a breaking security change.** `postgres.username`, `postgres.password` and `postgres.database` were removed, and an install or upgrade that still sets any of them now fails at render instead of silently falling back to a published default password. If you are running 1.0.2 or earlier, read [Upgrading From 1.0.x](#upgrading-from-1-0-x) before you touch the release.
+</Warning>
+
 ### Architecture
 
 - **pgEdge** — Stateful workload running PostgreSQL 17 with the Spock extension. All nodes are active writers connected in a full-mesh replication ring. Each replica gets its own persistent volume.
@@ -26,6 +32,28 @@ pgEdge is an active-active distributed PostgreSQL cluster using Spock multi-mast
 
 - At least one Control Plane [location](/reference/location) to deploy into.
 - For backup: an AWS or GCP [cloud account](/guides/create-cloud-account) and a storage bucket.
+
+**One `dictionary` secret must exist before you install.** These are the credentials you type into every connection string, so they are not values — a value would leave them in the Helm release.
+
+```bash
+cpln secret create-dictionary --name my-pgedge-credentials \
+  --entry username=myuser \
+  --entry password='YOUR-STRONG-PASSWORD' \
+  --entry database=mydb
+```
+
+Set `postgres.credentialsSecretName` to the name you used. Secret names are org-wide, so give each release its own. pgcat uses the same password for its admin console, replacing the fixed `pgcat_admin` password earlier versions shipped.
+
+<Warning>
+**Create the secret before installing, or the deployment wedges silently.** The template refuses to render when `postgres.credentialsSecretName` is blank, but a name pointing at a secret that does not exist installs "successfully" and then never starts. The container never runs, so `cpln logs` returns **zero lines** — there is nothing to log. The one place the reason appears is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-pgedge --gvc GVC_NAME -o yaml
+```
+
+Use `get-deployments` — plain `cpln workload get` has no `versions` key. Creating the missing secret repairs it on its own in roughly **5.5 to 10.5 minutes**, or run `cpln workload force-redeployment RELEASE_NAME-pgedge --gvc GVC_NAME` to clear it in about 90 seconds.
+</Warning>
+
 
 ### Installation
 
@@ -53,6 +81,37 @@ To install, follow the instructions for your preferred method:
     </Card>
 </CardGroup>
 
+## Upgrading From 1.0.x
+
+Template versions up to 1.0.2 took the database credentials as plain Helm values and shipped a working default password. Version 1.1.0 removes them.
+
+<Warning>
+**Carrying the old values forward stops the upgrade.** The removed keys are rejected at render, so `cpln helm upgrade` fails and your existing cluster is left untouched and running:
+
+```text
+Error: execution error at (pgedge/templates/identity.yaml:3:4): pgedge: postgres.username,
+postgres.password and postgres.database were REMOVED — they are now a `dictionary` secret you
+create, named by postgres.credentialsSecretName, holding the keys `username`, `password` and
+`database`. Delete them from your values. See Prerequisites in the README.
+```
+</Warning>
+
+<Steps>
+  <Step title="Create the secret with the credentials the cluster already has">
+    Credentials were applied when the data directory was first initialized, so a new value does not change the cluster — it just leaves clients unable to authenticate. Follow [Prerequisites](#prerequisites) using your existing values.
+  </Step>
+  <Step title="Remove the old keys and upgrade">
+    Delete `postgres.username`, `postgres.password` and `postgres.database`, and set `postgres.credentialsSecretName`.
+  </Step>
+  <Step title="Rotate a default password">
+    `password` was published in the public template repository. Rotate with `ALTER ROLE myuser WITH PASSWORD '...'` on any node, then update the secret to match.
+  </Step>
+</Steps>
+
+<Note>
+**pgcat now builds its configuration at container start.** Its config is a TOML *file*, and a `cpln://` reference inside a file is never resolved — the platform only resolves them for environment variables. So rather than rendering the password into the file, 1.1.0 mounts a startup script that assembles the config from the secret at boot. Nothing changes in how you configure pgcat; the `pgcat.*` values are unchanged.
+</Note>
+
 ## Configuration
 
 The default `values.yaml` for this template:
@@ -77,9 +136,7 @@ resources:
   maxMemory: 4Gi
 
 postgres:
-  username: postgres
-  password: password
-  database: mydb
+  credentialsSecretName: my-pgedge-credentials # see Prerequisites — must exist before install
 
 multiZone: false  # Set to true to spread replicas across availability zones within each location
 
@@ -92,7 +149,7 @@ volumeset:
     scalingFactor: 1.2  # How much to scale up when triggered
 
 pgcat:
-  image: ghcr.io/postgresml/pgcat:latest
+  image: ghcr.io/postgresml/pgcat:v1.2.0 # pinned: `latest` makes installs non-reproducible
   poolMode: transaction  # options: session, transaction, statement
   defaultPoolSize: 25    # Real Postgres connections pgcat maintains per pool
   maxClientConn: 1000    # Maximum client connections pgcat accepts
@@ -109,7 +166,7 @@ internal_access: # Sets both pgedge and pgcat workloads
 
 backup:
   enabled: false
-  image: controlplanecorporation/pg-backup:17.1.0
+  image: ghcr.io/controlplane-com/backup-images/postgres-backup:17.1.0
   schedule: "0 2 * * *"   # daily at 2am UTC
 
   resources:

--- a/template-catalog/templates/pgedge.mdx
+++ b/template-catalog/templates/pgedge.mdx
@@ -304,6 +304,12 @@ When `backup.enabled` is `true`, a cron workload runs `pg_dump` on the configure
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Note the cloud account name.
 3. Create a new AWS IAM policy with the following JSON (replace `YOUR_BUCKET_NAME`):
 
+<Warning>
+**Version 1.1.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -316,7 +322,11 @@ When `backup.enabled` is `true`, a cron workload runs `pg_dump` on the configure
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/postgis.mdx
+++ b/template-catalog/templates/postgis.mdx
@@ -270,6 +270,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.4.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -282,7 +288,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/postgres-highly-available.mdx
+++ b/template-catalog/templates/postgres-highly-available.mdx
@@ -352,6 +352,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 2.5.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -364,7 +370,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/redis-cluster.mdx
+++ b/template-catalog/templates/redis-cluster.mdx
@@ -186,6 +186,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.4.4 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -198,7 +204,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/redis.mdx
+++ b/template-catalog/templates/redis.mdx
@@ -550,6 +550,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 3.5.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -562,7 +568,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/supabase.mdx
+++ b/template-catalog/templates/supabase.mdx
@@ -417,6 +417,12 @@ Switching `backup.mode` between `logical` and `walg` changes Postgres `archive_m
   <Step title="Create an IAM policy">
     Create an IAM policy with the following JSON (replace `YOUR_BUCKET_NAME`) and set `backup.aws.policyName` to its name:
 
+    <Warning>
+    **Version 1.1.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+    **Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+    </Warning>
+
     ```json
     {
         "Version": "2012-10-17",
@@ -429,7 +435,11 @@ Switching `backup.mode` between `logical` and `walg` changes Postgres `archive_m
                     "s3:DeleteObject",
                     "s3:ListBucket",
                     "s3:GetObjectVersion",
-                    "s3:DeleteObjectVersion"
+                    "s3:DeleteObjectVersion",
+                    "s3:GetBucketLocation",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:ListMultipartUploadParts"
                 ],
                 "Resource": [
                     "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/tailscale.mdx
+++ b/template-catalog/templates/tailscale.mdx
@@ -10,6 +10,12 @@ Tailscale is a mesh VPN built on WireGuard. This template deploys a Tailscale ga
 
 The gateway runs in a single configured location. Other locations are suspended so only one Tailscale node is active at a time.
 
+The auth key is **not** a template value. Tailscale reads it from an opaque secret you create before installing, so the key never passes through Helm or lands in the release.
+
+<Warning>
+**Template version 1.3.0 is a breaking change.** `AuthKey` was removed, and an install or upgrade that still sets it now fails at render. Two defaults also changed: the image tag is pinned, and `TS_HOSTNAME` no longer defaults to a leftover test name. If you are running 1.2.x, read [Upgrading From 1.2.x](#upgrading-from-1-2-x) before you touch the release.
+</Warning>
+
 ### What Gets Created
 
 - **Standard Workload** — The Tailscale gateway (`RELEASE_NAME-tailscale`), active in the configured location only. Advertises Control Plane's internal network CIDRs and the location's internal DNS server to Tailscale.
@@ -27,7 +33,15 @@ Complete the following in your Tailscale account before installing:
 
 ### 1. Create an Auth Key
 
-In the Tailscale [Admin UI → Settings → Keys](https://login.tailscale.com/admin/settings/keys), create a new auth key with **Reusable** and **Ephemeral** enabled. Save the key value — you will set it as `AuthKey` in your values.
+In the Tailscale [Admin UI → Settings → Keys](https://login.tailscale.com/admin/settings/keys), create a new auth key with **Reusable** and **Ephemeral** enabled. Save the key value, then store it in an opaque secret — it is not a template value:
+
+```bash
+printf '%s' 'tskey-auth-YOUR-KEY-HERE' | cpln secret create-opaque --name my-tailscale-authkey --encoding plain -f -
+```
+
+Set `authKeySecretName` to the name you used. Secret names are org-wide, so give each release its own.
+
+If the secret does not exist at install time the deployment wedges silently — `cpln logs` returns **zero lines**. Read `status.versions[].message` via `cpln workload get-deployments RELEASE_NAME-tailscale --gvc GVC_NAME -o yaml`; plain `cpln workload get` has no `versions` key.
 
 ### 2. Update the Tailscale ACL
 
@@ -82,6 +96,32 @@ To install, follow the instructions for your preferred method:
     </Card>
 </CardGroup>
 
+## Upgrading From 1.2.x
+
+Version 1.3.0 removes `AuthKey` and changes two defaults.
+
+| | 1.2.x | 1.3.0 |
+|---|---|---|
+| Auth key | `AuthKey` value, written into a chart-owned secret | `authKeySecretName` → an opaque secret you create |
+| `image.tag` | `stable` — floating | `v1.102.3` — pinned |
+| `TS_HOSTNAME` | `cpln-test-new` | `cpln-tailscale` |
+
+<Warning>
+**Carrying `AuthKey` forward stops the upgrade.** It is rejected at render, so `cpln helm upgrade` fails and your existing gateway is left untouched and running:
+
+```text
+Error: execution error at (tailscale/templates/identity.yaml:1:4): tailscale: AuthKey was REMOVED
+— it is now an `opaque` secret you create, named by authKeySecretName, whose entire value is the
+auth key. Delete AuthKey from your values. See Prerequisites in the README.
+```
+</Warning>
+
+Create the secret ([Prerequisites](#prerequisites)), delete `AuthKey`, and set `authKeySecretName`. You can reuse the same key or generate a new one — unlike a database password, a Tailscale auth key only authorizes the device at join time, so replacing it is safe for a node that has already joined.
+
+<Note>
+**`TS_HOSTNAME` previously defaulted to `cpln-test-new`,** a leftover from testing that became the advertised tailnet name of every install that did not override it. If you see `cpln-test-new` in your Tailscale admin console, that is a pre-1.3.0 deployment. Changing it renames the device on your tailnet.
+</Note>
+
 ## Configuration
 
 The default `values.yaml` for this template:
@@ -92,7 +132,7 @@ location: aws-us-east-1
 
 image:
   repository: tailscale/tailscale
-  tag: stable
+  tag: v1.102.3 # pinned: `stable` floats, so installs are not reproducible
 
 resources:
   cpu: 500m
@@ -100,7 +140,7 @@ resources:
 
 extraEnv:
   - name: TS_HOSTNAME
-    value: cpln-test-new
+    value: cpln-tailscale # the name this device advertises on your tailnet
   # - name: TS_EXTRA_ARGS
   #   value: --advertise-exit-node
 
@@ -122,12 +162,12 @@ locationDNS:
 
 deployHttpbinExample: true
 
-AuthKey: replaceWithYourTailscaleAuthKey
+authKeySecretName: my-tailscale-authkey # see Prerequisites — must exist before install
 ```
 
 ### Auth Key
 
-- `AuthKey` — Your Tailscale auth key. **Replace this before deploying.** The key must be created with the **Reusable** and **Ephemeral** options enabled.
+- `authKeySecretName` — Name of the opaque secret holding your Tailscale auth key. The key must be created with the **Reusable** and **Ephemeral** options enabled. See [Prerequisites](#prerequisites).
 
 ### Location
 

--- a/template-catalog/templates/tidb.mdx
+++ b/template-catalog/templates/tidb.mdx
@@ -398,6 +398,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
 2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
 3. Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`:
 
+<Warning>
+**Version 1.8.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -410,7 +416,11 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:GetObjectVersion",
-                "s3:DeleteObjectVersion"
+                "s3:DeleteObjectVersion",
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/timescaledb-highly-available.mdx
+++ b/template-catalog/templates/timescaledb-highly-available.mdx
@@ -8,6 +8,12 @@ keywords: ['timescale ha', 'tsdb ha', 'timescaledb cluster', 'time-series databa
 
 TimescaleDB Highly Available deploys the TimescaleDB time-series database (a PostgreSQL 18 extension) as a Patroni-managed cluster with automatic failover. Three replicas — one leader plus two hot standbys — form the cluster over an etcd consensus store, and an HAProxy leader endpoint routes all writes to the current primary. When the leader fails, Patroni promotes a standby and HAProxy re-selects the new primary automatically, giving applications a single stable endpoint. Optional PgBouncer connection pooling and scheduled logical backups to AWS S3, GCS, or MinIO are included.
 
+Database credentials are **not** template values. The cluster reads its username, password and database name from a dictionary secret you create before installing, so no password passes through Helm or lands in the release.
+
+<Warning>
+**Template version 1.1.0 is a breaking security change.** `postgres.username`, `postgres.password` and `postgres.database` were removed, along with `backup.minio.accessKey` and `backup.minio.secretKey`. An install or upgrade that still sets any of them now fails at render instead of silently falling back to a published default password. If you are running 1.0.1 or earlier, read [Upgrading From 1.0.x](#upgrading-from-1-0-x) before you touch the release.
+</Warning>
+
 <Info>
 TimescaleDB is licensed under the Timescale License (TSL) plus the PostgreSQL License. It is free to self-host at any scale, including all Community features (compression, continuous aggregates, retention); the license only forbids reselling TimescaleDB itself as a managed database service.
 </Info>
@@ -29,6 +35,63 @@ For high availability, keep at least 3 TimescaleDB replicas and 3 etcd replicas.
 
 <Note>
 This template does not create a GVC. You must deploy it into an existing GVC.
+</Note>
+
+## Prerequisites
+
+**One `dictionary` secret must exist before you install.** These are the credentials you type into every connection string, so they are not values — a value would leave them in the Helm release.
+
+```bash
+cpln secret create-dictionary --name my-timescaledb-ha-credentials \
+  --entry username=myuser \
+  --entry password='YOUR-STRONG-PASSWORD' \
+  --entry database=mydb
+```
+
+Set `postgres.credentialsSecretName` to the name you used. The TimescaleDB extension is created automatically in the database that secret names. Secret names are org-wide, so give each release its own.
+
+Backing up to MinIO needs a second dictionary secret holding `accessKey` and `secretKey` — see [Backup Prerequisites](#backup-prerequisites).
+
+<Warning>
+**Create the secret before installing, or the deployment wedges silently.** The template refuses to render when `postgres.credentialsSecretName` is blank, but a name pointing at a secret that does not exist installs "successfully" and then never starts. The container never runs, so `cpln logs` returns **zero lines** — there is nothing to log. The one place the reason appears is `status.versions[].message`:
+
+```bash
+cpln workload get-deployments RELEASE_NAME-timescaledb-ha --gvc GVC_NAME -o yaml
+```
+
+Use `get-deployments` — plain `cpln workload get` has no `versions` key. Creating the missing secret repairs it on its own in roughly **5.5 to 10.5 minutes**, or run `cpln workload force-redeployment RELEASE_NAME-timescaledb-ha --gvc GVC_NAME` to clear it in about 90 seconds.
+</Warning>
+
+
+## Upgrading From 1.0.x
+
+Version 1.1.0 removes `postgres.username`, `postgres.password` and `postgres.database`, plus `backup.minio.accessKey` and `backup.minio.secretKey`.
+
+<Warning>
+**Carrying the old values forward stops the upgrade.** The removed keys are rejected at render, so `cpln helm upgrade` fails and your existing cluster is left untouched and running:
+
+```text
+Error: execution error at (timescaledb-highly-available/templates/identity.yaml:2:4):
+timescaledb-highly-available: postgres.username, postgres.password and postgres.database were
+REMOVED — they are now a `dictionary` secret you create, named by postgres.credentialsSecretName,
+holding the keys `username`, `password` and `database`. Delete them from your values.
+```
+</Warning>
+
+<Steps>
+  <Step title="Create the secrets with the credentials the cluster already has">
+    Credentials were baked into the data directory at bootstrap, so a new value does not change the cluster. Use your existing values.
+  </Step>
+  <Step title="Remove the old keys and upgrade">
+    Delete the five removed keys and set the two `credentialsSecretName` values.
+  </Step>
+  <Step title="Rotate a default password">
+    `password` was published in the public template repository. Rotate with `ALTER ROLE` through the HAProxy leader endpoint, then update the secret to match.
+  </Step>
+</Steps>
+
+<Note>
+**Patroni now reads the credentials at container start**, rather than having them rendered into its configuration. The Patroni config is generated by the startup script from environment variables the platform resolves from your secret — a `cpln://` reference written into a config file would never be resolved. No configuration knobs changed.
 </Note>
 
 ## Installation
@@ -73,9 +136,7 @@ resources:
 image: timescale/timescaledb-ha:pg18.4-ts2.28.3 # PostgreSQL 18 + TimescaleDB 2.28.3 Community, Patroni bundled
 
 postgres:
-  username: username
-  password: password # change before installing
-  database: test # TimescaleDB extension is created automatically in this database
+  credentialsSecretName: my-timescaledb-ha-credentials # see Prerequisites — must exist before install
 
 multiZone: false # spread replicas across zones in the location
 
@@ -157,8 +218,7 @@ backup:
   minio: # self-hosted MinIO or any S3-compatible endpoint
     endpoint: http://my-minio-workload:9000 # e.g. http://WORKLOAD_NAME:9000 for an internal MinIO deployment
     bucket: my-backup-bucket
-    accessKey: my-minio-username # matches the MinIO template's admin.username
-    secretKey: my-minio-password # matches the MinIO template's admin.password
+    credentialsSecretName: my-timescaledb-ha-minio-credentials # dictionary secret with accessKey and secretKey
     prefix: timescaledb/backups
 ```
 
@@ -380,7 +440,7 @@ Before enabling backup with `provider: minio`, ensure your MinIO instance (or an
     Set `backup.minio.endpoint` to the S3 API address including the port. For the `minio` marketplace template deployed in the same GVC, use `http://WORKLOAD_NAME:9000`.
   </Step>
   <Step title="Set credentials">
-    Set `backup.minio.accessKey` and `backup.minio.secretKey` to credentials with access to the bucket. For the MinIO template, these match the `admin.username` and `admin.password` values. Set `backup.minio.prefix` to the folder path for backups.
+    Create a second [dictionary secret](/guides/create-secret/dictionary) holding exactly `accessKey` and `secretKey`, and set `backup.minio.credentialsSecretName` to its name. For the MinIO template these are its `admin.username` and `admin.password`. Set `backup.minio.prefix` to the folder path for backups.
   </Step>
 </Steps>
 

--- a/template-catalog/templates/timescaledb-highly-available.mdx
+++ b/template-catalog/templates/timescaledb-highly-available.mdx
@@ -386,6 +386,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
   </Step>
 </Steps>
 
+<Warning>
+**Version 1.1.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -393,14 +399,16 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket",
-                "s3:GetBucketLocation",
                 "s3:GetObject",
-                "s3:GetObjectVersion",
                 "s3:PutObject",
                 "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:GetObjectVersion",
                 "s3:DeleteObjectVersion",
-                "s3:AbortMultipartUpload"
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/timescaledb.mdx
+++ b/template-catalog/templates/timescaledb.mdx
@@ -368,6 +368,12 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
   </Step>
 </Steps>
 
+<Warning>
+**Version 1.1.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+**Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+</Warning>
+
 ```json
 {
     "Version": "2012-10-17",
@@ -375,14 +381,16 @@ Before enabling backup with `provider: aws`, complete the following in your AWS 
         {
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucket",
-                "s3:GetBucketLocation",
                 "s3:GetObject",
-                "s3:GetObjectVersion",
                 "s3:PutObject",
                 "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:GetObjectVersion",
                 "s3:DeleteObjectVersion",
-                "s3:AbortMultipartUpload"
+                "s3:GetBucketLocation",
+                "s3:AbortMultipartUpload",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::YOUR_BUCKET_NAME",

--- a/template-catalog/templates/weaviate.mdx
+++ b/template-catalog/templates/weaviate.mdx
@@ -389,6 +389,12 @@ With `backup.enabled: true`, a cron workload calls Weaviate's backup API on `bac
   <Step title="Create an IAM policy">
     Create an IAM policy with the following JSON, replacing `YOUR_BUCKET_NAME`, and set `backup.aws.policyName` to its name:
 
+    <Warning>
+    **Version 1.1.1 narrows AWS backup permissions.** This version removes `aws::ReadOnlyAccess` from the backup identity. That AWS managed policy granted read access to **every bucket in your AWS account** and contains no write actions at all, so it was never carrying the backup itself — but it *was* silently supplying any read action your own bucket-scoped policy happened to omit.
+
+    **Update your IAM policy to the full action list below before upgrading.** If it already matches, no action is needed. The identity now carries `cpln-connector` and your bucket-scoped policy only, which is strictly narrower than before. Nothing else changes.
+    </Warning>
+
     ```json
     {
         "Version": "2012-10-17",
@@ -401,7 +407,11 @@ With `backup.enabled: true`, a cron workload calls Weaviate's backup API on `bac
                     "s3:DeleteObject",
                     "s3:ListBucket",
                     "s3:GetObjectVersion",
-                    "s3:DeleteObjectVersion"
+                    "s3:DeleteObjectVersion",
+                    "s3:GetBucketLocation",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListBucketMultipartUploads",
+                    "s3:ListMultipartUploadParts"
                 ],
                 "Resource": [
                     "arn:aws:s3:::YOUR_BUCKET_NAME",


### PR DESCRIPTION
Docs for the whole audit session. **Two commits, 26 pages.**

Covers merged templates **#461–#464** and the open **#465**.

---

## Commit 1 — credential audit (7 pages)

opensearch, cassandra, pgedge, timescaledb-ha, tailscale, ess, fusionauth.

Five templates moved credentials out of values into prerequisite secrets, so each page gains a breaking-change warning, the secret-creation command, the silent-wedge diagnostic (`cpln logs` returns zero lines; `status.versions[].message` is the only signal), and an Upgrading section quoting the real render error.

**opensearch** documents five fixed defects instead. Two matter to anyone already running it: the identity links were hardcoded to `test-gvc` so no install outside that GVC worked, and with `demoLogs.enabled` the policy granted `reveal` on **every secret in the org**. The latter is written as a **disclosure** — upgrading narrows the policy but does not undo past access.

**fusionauth** explains why its credentials correctly *stay* values, and carries the migration note for the changed password default.

## Commit 2 — `aws::ReadOnlyAccess` removal (19 pages)

Companion to **#465**. Every backup-capable template attached `aws::ReadOnlyAccess` to its identity. That AWS managed policy grants read across the **entire account** and contains no write actions — it was never carrying the backup.

**The user-visible part is the IAM policy, not the ref.** `ReadOnlyAccess` was silently supplying any read action a user's bucket-scoped policy omitted, and most pages documented only six actions — missing `GetBucketLocation` and the three multipart actions. Each policy is widened to the ten postgres documents, with a warning to **update the IAM policy before upgrading**. Still bucket-scoped, so strictly narrower than what shipped.

None of these pages ever mentioned `ReadOnlyAccess` — it was attached by the chart and invisible to readers, which is part of why it survived this long.

---

## Verification

- Every values block diffed against the shipped `values.yaml` on its own branch — all match.
- All 19 policy pages now document exactly **10** s3 actions; every JSON block parses (checked after unindenting, since several nest the policy inside a `<Step>`).
- All in-page anchors resolve.
- `mint broken-links` clean apart from one pre-existing break in `mk8s/add-ons/dashboard.mdx`, untouched here.
- External URLs 200 except two illustrative example hosts and one rate-limited SVG attribution.

**No `overview.mdx` or `docs.json` changes** — every card and nav entry already exists.

**Merge order:** #465 is still open, so commit 2 describes versions not yet on `main`. Commits 1's templates are all merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
