### PR TITLE
docs: quota_utilization_percent metric

### DIFF
--- a/guides/default-metrics.mdx
+++ b/guides/default-metrics.mdx
@@ -1,7 +1,7 @@
 ---
 title: Default Metrics
 description: Reference of built-in metrics available for orgs, HTTP/gRPC traffic, volumes, replicas, CPU, memory, GPU, and network usage.
-keywords: ['prometheus metrics', 'rps', 'qps', 'latency p95', 'response time', 'cpu utilization', 'memory utilization', 'gpu usage', 'storage metrics', 'metric names']
+keywords: ['prometheus metrics', 'rps', 'qps', 'latency p95', 'response time', 'cpu utilization', 'memory utilization', 'gpu usage', 'storage metrics', 'metric names', 'quota utilization']
 ---
 
 ### Org Metrics
@@ -18,6 +18,7 @@ keywords: ['prometheus metrics', 'rps', 'qps', 'latency p95', 'response time', '
 - `threat_detection_forward_enabled`: 0 or 1 indicating if threat detection forwarding is enabled for the org (syslog)
 - `threat_detection_forward_total`: Total of all threat events forwarded to the Syslog target
 - `threat_detection_alerts`: Increments when a threat detection alert is generated
+- `quota_utilization_percent`: Utilization of an org [quota](/reference/quota) as a percentage of its maximum: `(current / max) * 100`. The `quota_name` label identifies the quota (e.g. `workloads-per-gvc`), and the `dimensions` label distinguishes instances of per-resource quotas (e.g. the GVC a `workloads-per-gvc` quota applies to). Only quotas at or above 50% utilization are reported; below that threshold the series is not published
 
 ### HTTP/GRPC
 

--- a/reference/quota.mdx
+++ b/reference/quota.mdx
@@ -19,6 +19,10 @@ Current resources with a quota:
 
 If your [org](/reference/org) requires additional resources, please email [support@controlplane.com](mailto:support@controlplane.com)
 
+## Metrics
+
+Quota utilization is published to your org's [built-in metrics](/guides/default-metrics) as `quota_utilization_percent`, so you can chart it and alert on quotas approaching their limit before hitting them. Only quotas at or above 50% utilization are reported.
+
 ## Permissions
 
 The permissions below are used to define [policies](/reference/policy) together with one or more of the four [principal types](/concepts/access-control):


### PR DESCRIPTION
Documents the new `quota_utilization_percent` org metric (published by the scheduler, recorded by the metrics-writer):

- `guides/default-metrics.mdx`: added under Org Metrics — value semantics, `quota_name`/`dimensions` labels, and the ≥50% publish threshold (series below it are absent, not zero).
- `reference/quota.mdx`: new Metrics section cross-linking to the built-in metrics page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWuNr3f9HQ6DijYEGcpTpR