### PR TITLE
docs: the audit session's user-facing changes (templates #473-#481)

### DIFF
--- a/template-catalog/templates/clickhouse.mdx
+++ b/template-catalog/templates/clickhouse.mdx
@@ -4,6 +4,10 @@ description: Deploy ClickHouse on Control Plane using the Template Catalog. Cove
 keywords: ['column store', 'olap', 'analytics db', 'duckdb alternative', 'redshift alternative', 'snowflake alternative', 'time series', 'click house template', 'data warehouse', 'columnar database', 'real-time analytics', 'azure blob storage', 'hetzner object storage', 'dictionary secret', 'clickhouse-client']
 ---
 
+<Warning>
+**Version 2.8.0 moves the Azure Storage account key out of values.** It was a plain template value, so it landed in your Helm release and in a stored config file. It is now a `dictionary` secret you create before installing, named by `azure.credentialsSecretName` and holding the key `accountKey` — the same shape the GCS and Hetzner credentials already use. An upgrade that still carries `azure.accountKey` is refused at render, with a message naming the replacement. Only affects `provider: azure`.
+</Warning>
+
 ## Overview
 
 ClickHouse is a high-performance, column-oriented analytical database designed for real-time querying and data warehousing at scale. This template deploys ClickHouse in either **single-node** or **cluster** mode depending on how locations are configured, backed by object storage (AWS S3, GCS, Azure Blob Storage, or Hetzner Object Storage) for long-term scalable storage and a local volume for fast read caching.

--- a/template-catalog/templates/debezium-server.mdx
+++ b/template-catalog/templates/debezium-server.mdx
@@ -4,6 +4,12 @@ description: Deploy Debezium Server on Control Plane for standalone Change Data 
 keywords: ['debezium', 'cdc', 'change data capture', 'database streaming', 'postgresql cdc', 'mysql cdc', 'kafka connector', 'event streaming', 'data pipeline', 'wal', 'binlog']
 ---
 
+<Warning>
+**Version 1.2.0 moves every credential out of values.** The source database password, the offset and schema-history stores, all six sink types and the schema registry were plain values that ended up in your Helm release. They are now keys in one `dictionary` secret you create before installing, named by `credentialsSecretName`. Which keys you need depends on your source and sink — the template README lists them per combination.
+
+Five settings that were previously inferred from a credential being non-empty now have explicit switches: `source.mongodb.useConnectionString`, and `authEnabled` on the offset Redis store, the schema-history Redis store, the Redis sink and the Pulsar sink. An upgrade that still carries a removed credential is refused at render.
+</Warning>
+
 ## Overview
 
 Debezium Server is a standalone Change Data Capture (CDC) application that tails a database's transaction log and streams row-level change events to a messaging system. Unlike Debezium connectors that run inside Kafka Connect, Debezium Server runs as a self-contained process — no Kafka Connect cluster required.

--- a/template-catalog/templates/mimir.mdx
+++ b/template-catalog/templates/mimir.mdx
@@ -4,6 +4,10 @@ description: Deploy Grafana Mimir on Control Plane using the Template Catalog. A
 keywords: ['prometheus remote_write', 'metrics storage', 'long-term metrics', 'promql', 'tsdb', 'time series database', 'grafana datasource', 'cortex alternative', 'thanos alternative', 'x-scope-orgid', 'multi-tenant metrics', 'mimir template']
 ---
 
+<Warning>
+**Version 1.2.0 moves the MinIO object-storage credentials out of values.** They were plain values that landed in your Helm release. They are now a `dictionary` secret you create before installing, holding `accessKey` and `secretKey`.
+</Warning>
+
 ## Overview
 
 Grafana Mimir is a long-term Prometheus metrics store you own. This template deploys Mimir in monolithic mode: your own collectors (Prometheus, Grafana Alloy, OpenTelemetry) push metrics in via Prometheus `remote_write`, and anything that speaks PromQL — your own Grafana, dashboards, scripts — queries them back, with metric blocks durably stored in your object bucket.

--- a/template-catalog/templates/postgres-highly-available.mdx
+++ b/template-catalog/templates/postgres-highly-available.mdx
@@ -4,6 +4,17 @@ description: Deploy PostgreSQL Highly Available on Control Plane using the Templ
 keywords: ['pg ha', 'postgres ha', 'postgres cluster', 'streaming replication', 'leader election', 'rds alternative', 'aurora alternative', 'pgbouncer', 'wal', 'failover', 'primary replica']
 ---
 
+<Warning>
+**This version fixes three backup defects and one that breaks connection pooling.** All four are worth checking on an existing install, because three of them are invisible until you try to restore.
+
+- **No base backup for the first six hours.** The backup sidecar skipped its first run and then slept the full interval, so WAL archived normally while there was nothing to restore against. Check that a base backup actually exists before relying on your backups.
+- **The backup sidecar was killed for running out of memory.** At the previous 128Mi limit it died partway through, which on Azure and GCS meant **no base backup at all** — silently, because an out-of-memory kill logs nothing.
+- **A password containing a double quote broke every PgBouncer login.** The credential was written into PgBouncer's user list unescaped. Only affects installs with `pgbouncer.enabled: true`.
+- **The consensus timeouts were an invalid combination.** Patroni silently rewrote them, so a cluster configured to tolerate a 30-second etcd outage actually gave up after 14 and demoted a healthy primary. The cluster now also keeps serving through an etcd outage rather than failing over, provided every member is still reachable.
+
+**Upgrading does not retune a cluster that already exists.** The consensus timeouts were written to etcd when the cluster was created and the chart is never consulted again. The template README gives the single `patronictl edit-config` command to move a running cluster.
+</Warning>
+
 ## Overview
 
 PostgreSQL Highly Available deploys a production-ready PostgreSQL cluster using Patroni for automatic leader election and failover, with etcd providing distributed consensus. An optional HAProxy workload routes all write traffic to the current primary replica, providing a stable connection endpoint regardless of which replica holds the leader role.

--- a/template-catalog/templates/postgres-multi-location.mdx
+++ b/template-catalog/templates/postgres-multi-location.mdx
@@ -4,6 +4,10 @@ description: Deploy a single PostgreSQL 17 Patroni cluster stretched across Cont
 keywords: ['postgres multi region', 'cross-region postgres', 'geo replication', 'disaster recovery database', 'patroni', 'etcd quorum', 'streaming replication', 'automatic failover', 'warm standby', 'rds multi-az alternative', 'aurora global alternative', 'pgbouncer', 'wal-g', 'regional redundancy']
 ---
 
+<Warning>
+**Version 1.1.0 widens the failover timing margin.** The previous values were valid and honoured as written, so clusters on 1.0.x are correctly configured and need no action. The change gives a cross-region cluster more room to ride out a slow link before demoting a healthy primary, at the cost of taking worst-case failover from 45 to 60 seconds. Upgrading does not change a cluster that already exists — its timings live in etcd from the moment it was created.
+</Warning>
+
 ## Overview
 
 Postgres Multi-Location deploys **one** PostgreSQL 17 Patroni cluster whose members span several Control Plane locations: a single primary that takes all traffic, asynchronous streaming replicas in the other locations, and automatic promotion of a replica in a surviving location when the primary's location is lost. An HAProxy tier in every location routes connections to whichever member currently holds the leader lock, so applications connect to a stable name in their own region and never need to know where the primary is.

--- a/template-catalog/templates/prometheus.mdx
+++ b/template-catalog/templates/prometheus.mdx
@@ -4,6 +4,10 @@ description: Deploy Prometheus on Control Plane using the Template Catalog. A se
 keywords: ['metrics storage', 'time series database', 'promql', 'monitoring', 'remote_write receiver', 'scrape configs', 'thanos store api', 'grafana datasource', 'observability', 'mimir alternative', 'ha prometheus', 'prometheus template']
 ---
 
+<Warning>
+**Version 1.2.0 moves the MinIO object-storage credentials out of values.** They were plain values that landed in your Helm release. They are now a `dictionary` secret you create before installing, holding `accessKey` and `secretKey`. Only affects installs using MinIO for long-term storage.
+</Warning>
+
 ## Overview
 
 Prometheus is the standard open-source metrics database. This template deploys a single Prometheus server with the remote-write receiver enabled and a durable TSDB volume: your own senders push metrics in via Prometheus `remote_write` (or Prometheus scrapes targets you configure), and anything that speaks PromQL — your own Grafana, dashboards, scripts — queries them back. An optional co-located Thanos sidecar (on by default) exposes the Store API for a Thanos Query tier and can upload TSDB blocks to your object bucket for long-term durability.

--- a/template-catalog/templates/thanos.mdx
+++ b/template-catalog/templates/thanos.mdx
@@ -4,6 +4,10 @@ description: Deploy Thanos on Control Plane using the Template Catalog. A global
 keywords: ['thanos query', 'global query view', 'metrics federation', 'promql', 'prometheus dedup', 'store gateway', 'compactor', 'downsampling', 'grafana datasource', 'long-term metrics', 'observability', 'cortex alternative', 'mimir alternative', 'thanos template']
 ---
 
+<Warning>
+**Version 1.2.0 moves the MinIO object-storage credentials out of values.** They were plain values that landed in your Helm release. They are now a `dictionary` secret you create before installing, holding `accessKey` and `secretKey`.
+</Warning>
+
 ## Overview
 
 Thanos turns many independent Prometheus servers into one queryable metrics system. This template deploys Thanos Query — a stateless global PromQL layer that fans each query out over the gRPC Store API endpoints you list (typically the Thanos sidecar of each [Prometheus template](/template-catalog/templates/prometheus) install, across GVCs and regions) and deduplicates HA pairs — plus an optional object-storage tier (Store Gateway + Compactor) that serves and manages long-term metric history from your bucket.

--- a/template-catalog/templates/timescaledb-highly-available.mdx
+++ b/template-catalog/templates/timescaledb-highly-available.mdx
@@ -4,6 +4,17 @@ description: Deploy a highly available TimescaleDB cluster on Control Plane. A P
 keywords: ['timescale ha', 'tsdb ha', 'timescaledb cluster', 'time-series database', 'hypertables', 'patroni', 'etcd', 'haproxy', 'automatic failover', 'streaming replication', 'postgres extension', 'pg ha', 'pgbouncer', 'timescale cloud alternative', 'metrics store']
 ---
 
+<Warning>
+**This version fixes three backup defects and one that breaks connection pooling.** All four are worth checking on an existing install, because three of them are invisible until you try to restore.
+
+- **No base backup for the first six hours.** The backup sidecar skipped its first run and then slept the full interval, so WAL archived normally while there was nothing to restore against. Check that a base backup actually exists before relying on your backups.
+- **The backup sidecar was killed for running out of memory.** At the previous 128Mi limit it died partway through, which on Azure and GCS meant **no base backup at all** — silently, because an out-of-memory kill logs nothing.
+- **A password containing a double quote broke every PgBouncer login.** The credential was written into PgBouncer's user list unescaped. Only affects installs with `pgbouncer.enabled: true`.
+- **The consensus timeouts were an invalid combination.** Patroni silently rewrote them, so a cluster configured to tolerate a 30-second etcd outage actually gave up after 14 and demoted a healthy primary. The cluster now also keeps serving through an etcd outage rather than failing over, provided every member is still reachable.
+
+**Upgrading does not retune a cluster that already exists.** The consensus timeouts were written to etcd when the cluster was created and the chart is never consulted again. The template README gives the single `patronictl edit-config` command to move a running cluster.
+</Warning>
+
 ## Overview
 
 TimescaleDB Highly Available deploys the TimescaleDB time-series database (a PostgreSQL 18 extension) as a Patroni-managed cluster with automatic failover. Three replicas — one leader plus two hot standbys — form the cluster over an etcd consensus store, and an HAProxy leader endpoint routes all writes to the current primary. When the leader fails, Patroni promotes a standby and HAProxy re-selects the new primary automatically, giving applications a single stable endpoint. Optional PgBouncer connection pooling and scheduled logical backups to AWS S3, GCS, or MinIO are included.

--- a/template-catalog/templates/timescaledb.mdx
+++ b/template-catalog/templates/timescaledb.mdx
@@ -4,6 +4,10 @@ description: Deploy TimescaleDB — the PostgreSQL 18 time-series database — o
 keywords: ['timescale', 'tsdb', 'time-series database', 'hypertables', 'continuous aggregates', 'columnar compression', 'retention policy', 'pg', 'postgres extension', 'iot telemetry', 'metrics store', 'pgbouncer', 'influxdb alternative', 'dictionary secret', 'pg_dumpall']
 ---
 
+<Warning>
+**Version 1.2.0 moves the MinIO backup credentials out of values.** They were plain values that landed in your Helm release. They are now a `dictionary` secret you create before installing, holding `accessKey` and `secretKey`. Only affects installs backing up to MinIO.
+</Warning>
+
 ## Overview
 
 TimescaleDB is a time-series database built as a PostgreSQL extension. This template deploys a single-instance PostgreSQL 18 server with the TimescaleDB Community extension preloaded and auto-created, giving you hypertables, columnar compression, continuous aggregates, and retention policies alongside regular relational tables — all through any PostgreSQL client or ORM. Optional PgBouncer connection pooling and scheduled backups to AWS S3, GCS, or a self-hosted MinIO instance are included.

--- a/template-catalog/templates/uptime-kuma.mdx
+++ b/template-catalog/templates/uptime-kuma.mdx
@@ -6,7 +6,7 @@ keywords: ['pingdom alternative', 'uptimerobot alternative', 'statuspage alterna
 
 ## Overview
 
-Uptime Kuma is a self-hosted uptime monitoring tool (MIT-licensed) — outside-in HTTP(s), TCP, DNS, and ping checks against your apps and third-party dependencies, alerts through 90+ notification providers, and public status pages. This template deploys a single stateful workload with its SQLite database on a persistent volume, served on the canonical `*.cpln.app` endpoint. The admin account is created by the **first visitor** to the URL — complete the [first-visit setup](#first-visit-setup) immediately after installing.
+Uptime Kuma is a self-hosted uptime monitoring tool (MIT-licensed) — outside-in HTTP(s), TCP, DNS, and ping checks against your apps and third-party dependencies, alerts through 90+ notification providers, and public status pages. This template deploys a single stateful workload with its SQLite database on a persistent volume, served on port `3001`. The dashboard ships **closed to the internet**, because the admin account is created by the **first visitor** to reach it — complete the [first-visit setup](#first-visit-setup) over a port-forward before exposing anything.
 
 ### Architecture
 
@@ -54,15 +54,30 @@ None — a default install needs no secrets, cloud accounts, or external resourc
 Uptime Kuma has no way to preset admin credentials — the admin account is created through a setup wizard by the **first person to open the URL**. The template preselects SQLite, so the wizard asks only for the admin username and password.
 
 <Warning>
-Open the dashboard and create the admin account **immediately after install**. Until you complete the setup wizard, anyone who can reach the endpoint can claim the instance by creating the admin account. Once one account exists, the wizard is permanently disabled.
+**From version 1.2.0 the dashboard is not published to the internet by default.** Because the admin account belongs to whoever opens the setup wizard first, an exposed install can be claimed by a stranger before you get to it. Claim the account over a port-forward, then decide whether to expose the instance.
 </Warning>
 
 <Steps>
   <Step title="Wait for the workload to become ready">
-    A fresh install is typically ready within a minute. Find the canonical endpoint under `status.canonicalEndpoint` of the `{release}-uptime-kuma` workload.
+    A fresh install is typically ready within a minute.
   </Step>
-  <Step title="Open the endpoint and create the admin account">
-    Visit `https://<canonical>.cpln.app` — you are redirected to the setup wizard. Choose an admin username and a strong password.
+  <Step title="Open a tunnel to the private dashboard">
+    ```bash
+    cpln port-forward RELEASE_NAME-uptime-kuma 3001:3001 --gvc GVC_NAME
+    ```
+
+    This reaches the workload even though it is closed to the internet, and works without opening any firewall.
+  </Step>
+  <Step title="Create the admin account">
+    Open `http://localhost:3001` — you are redirected to the setup wizard. Choose an admin username and a strong password. Once one account exists, the wizard is permanently disabled.
+  </Step>
+  <Step title="Expose it, if you want public status pages">
+    ```bash
+    cpln helm upgrade RELEASE_NAME ./uptime-kuma/versions/1.2.0 --gvc GVC_NAME \
+      --set publicAccess.enabled=true
+    ```
+
+    A firewall change takes roughly 30 seconds to a few minutes to propagate, so give it time before deciding it did not work.
   </Step>
 </Steps>
 
@@ -98,7 +113,7 @@ internalAccess: # internal firewall scope (in-GVC callers, e.g. status-page cons
 
 ### Access
 
-- `publicAccess.enabled` — Serve the dashboard and status pages on the canonical `*.cpln.app` HTTPS endpoint (default). The dashboard is gated by Uptime Kuma's own login; status pages are public by design. Set to `false` for an internal-only instance (external requests are blocked at the edge; in-GVC callers still reach it per `internalAccess`).
+- `publicAccess.enabled` — Serve the dashboard and status pages on the canonical `*.cpln.app` HTTPS endpoint. **Defaults to `false`** since version 1.2.0: on a fresh install the admin account is unclaimed, so the instance is closed to the internet until you create it (see [First-Visit Setup](#first-visit-setup)). Set to `true` once the account exists — the dashboard is then gated by Uptime Kuma's own login, and status pages are public by design. In-GVC callers reach it per `internalAccess` either way.
 - `internalAccess.type` — Internal firewall scope of the Uptime Kuma workload:
 
 | Type | Description |
@@ -112,8 +127,9 @@ internalAccess: # internal firewall scope (in-GVC callers, e.g. status-page cons
 
 | What | Value |
 |---|---|
-| Dashboard (public) | `https://<canonical>.cpln.app` — `status.canonicalEndpoint` of `{release}-uptime-kuma` |
-| Status pages (public) | `https://<canonical>.cpln.app/status/{slug}` — no login required |
+| Dashboard (private, default) | `cpln port-forward {release}-uptime-kuma 3001:3001 --gvc {gvc}` then `http://localhost:3001` |
+| Dashboard (after enabling `publicAccess`) | `https://<canonical>.cpln.app` — `status.canonicalEndpoint` of `{release}-uptime-kuma` |
+| Status pages (after enabling `publicAccess`) | `https://<canonical>.cpln.app/status/{slug}` — no login required |
 | Internal (same GVC) | `http://{release}-uptime-kuma.{gvc}.cpln.local:3001` |
 | Login | The admin account you create in the [first-visit setup](#first-visit-setup) |
 


### PR DESCRIPTION
## What

Documents the user-facing changes from controlplane-com/templates **#473–#481**. Independent of docs #275, which is an earlier batch — no overlap, and either can merge first.

## uptime-kuma — the only behavioural change, and the page was actively wrong

The page told readers to visit the canonical endpoint and create the admin account. On 1.2.0 that endpoint returns **403** on a fresh install, so the instruction no longer worked.

The warning the page already carried — *"anyone who can reach the endpoint can claim the instance"* — is now the **reason** for the change rather than a caveat about it. Rewrote the first-visit flow around `cpln port-forward`, corrected the Access bullet and the Connecting table, and fixed the overview sentence that still promised a public endpoint.

## The Patroni pages get the most detail, deliberately

Three of the four fixes are **invisible until you try to restore**:

- no base backup for the first six hours of every install (WAL archived the whole time, so everything looked healthy)
- the backup sidecar killed for running out of memory — on Azure and GCS that meant potentially **no base backup at all**, silently, because an OOM kill logs nothing
- a password containing a double quote broke **every** PgBouncer login

So the notice tells readers to **check that a base backup exists** rather than assume it. It also repeats that upgrading does **not** retune a cluster that already exists — the consensus timeouts live in etcd from creation, and the README has the one `patronictl` command.

`postgres-multi-location`'s notice says plainly that clusters on 1.0.x were already correct and need no action, so nobody upgrades out of misplaced alarm.

## The rest

`clickhouse`, `debezium-server`, `prometheus`, `thanos`, `mimir`, `timescaledb` get credential-conversion notices following the pattern #275 established: state the version, what moved out of values, what the reader must do.

## Validation

Checked structurally rather than by eye — frontmatter intact and `Warning`/`Steps`/`Step` tags balanced on all ten pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
