### PR TITLE
docs: pg-ha cluster metrics (templates #483)

### DIFF
--- a/template-catalog/templates/postgres-highly-available.mdx
+++ b/template-catalog/templates/postgres-highly-available.mdx
@@ -1,6 +1,6 @@
 ---
 title: PostgreSQL Highly Available
-description: Deploy PostgreSQL Highly Available on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, Patroni clustering with etcd consensus and HAProxy, and optional backups to S3, GCS, or MinIO.
+description: Deploy PostgreSQL Highly Available on Control Plane using the Template Catalog. Covers configuration, volumes, scaling, Patroni clustering with etcd consensus and HAProxy, and optional backups to S3, GCS, or MinIO Covers Patroni cluster metrics scraped into the built-in Grafana stack.
 keywords: ['pg ha', 'postgres ha', 'postgres cluster', 'streaming replication', 'leader election', 'rds alternative', 'aurora alternative', 'pgbouncer', 'wal', 'failover', 'primary replica']
 ---
 
@@ -352,6 +352,35 @@ Two backup modes are available. Set `backup.enabled: true`, choose a `mode`, and
 
 **WAL-G backup settings:**
 - `backup.walg.intervalSeconds` — Interval between base backups in seconds (default: `21600`, every 6 hours).
+
+## Cluster Metrics
+
+From version 2.7.0, Patroni's Prometheus metrics are scraped into Control Plane's built-in metrics stack automatically. There is no exporter to run and nothing to configure — they appear in Grafana alongside the standard workload metrics, labelled by `workload`, `replica`, and `container`.
+
+| Metric | Tells you |
+|---|---|
+| `patroni_primary` | Which replica currently holds the leader lock — `1` on exactly one member. |
+| `patroni_replica` | Which members are followers. |
+| `patroni_postgres_streaming` | Whether a follower is actually streaming from the primary. |
+| `patroni_xlog_location` | WAL position per member — the basis for replication lag. |
+| `patroni_postgres_timeline` | Timeline number; increments on every failover. |
+| `patroni_dcs_last_seen` | When this member last reached etcd. |
+| `patroni_failsafe_mode_is_active` | `1` while the primary is riding out an etcd outage instead of demoting. |
+| `patroni_cluster_unlocked` | `1` when no member holds the leader lock. |
+
+Worth alerting on: `patroni_primary` summing to anything other than `1` across the cluster, `patroni_cluster_unlocked` staying `1`, or `patroni_postgres_streaming` dropping to `0` on a follower.
+
+<Note>
+These are **cluster-state** metrics, not database performance. They answer who is primary, whether replication is streaming, and whether a failover happened — not connection counts, cache hit ratio, or slow queries. Those would require a `postgres_exporter` sidecar, which this template does not include.
+</Note>
+
+You can also query them directly from the org's Prometheus federation endpoint:
+
+```bash
+curl -H "Authorization: Bearer $(cpln profile token)" \
+  --get --data-urlencode 'match[]=patroni_primary' \
+  'https://metrics.cpln.io/metrics/org/ORG_NAME/api/v1/federate'
+```
 
 ## Backup Prerequisites
 


### PR DESCRIPTION
## What

`postgres-highly-available` 2.7.0 scrapes Patroni's Prometheus metrics into Control Plane's built-in metrics stack (controlplane-com/templates#483).

The template README documents it — but **this page had no mention of metrics anywhere**, so for anyone reading the docs rather than the chart, the feature would have been invisible.

## Added

- The eight metric families with what each one tells you
- The alerts worth setting: `patroni_primary` summing to anything other than `1`, `patroni_cluster_unlocked` staying `1`, `patroni_postgres_streaming` dropping to `0` on a follower
- A direct `/federate` query for checking values outside Grafana

## Two things stated rather than left implicit

**They are cluster-state metrics, not database performance.** They answer who is primary, whether replication is streaming, and whether a failover happened — not connection counts, cache hit ratio, or slow queries. Those need a `postgres_exporter` sidecar this template does not ship. Worth being explicit so nobody enables this expecting query stats.

**There is nothing to configure** — no knob, no exporter, on by default.

Page `description` extended so the feature surfaces in search rather than only being findable by scrolling.

Structurally validated: frontmatter intact, `Note` 6/6 and `Warning` 6/6 balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
