### PR TITLE
docs: document supported header value operators on domain routes

### DIFF
--- a/reference/domain.mdx
+++ b/reference/domain.mdx
@@ -1,7 +1,7 @@
 ---
 title: Domain
 description: "Domain configuration for workloads with TLS certificates, geo-routing, path-based routing, and DNS verification modes (CNAME and NS delegation)."
-keywords: ['apex domain', 'subdomain', 'dns01', 'http01', 'fqdn', 'host header', 'wildcard cert', 'path route', 'subdomain route', 'cors', 'custom cert', 'mtls', 'client certificate', 'internal domain', 'private domain']
+keywords: ['apex domain', 'subdomain', 'dns01', 'http01', 'fqdn', 'host header', 'wildcard cert', 'path route', 'subdomain route', 'cors', 'custom cert', 'mtls', 'client certificate', 'client ip header', 'private domain']
 ---
 
 ## Domain Overview
@@ -186,11 +186,21 @@ The `headers` property allows routes to modify HTTP headers for all requests pro
 **Supported Operations:**
 - **`set`**: Sets or overrides headers for all HTTP requests processed by this route
 
-**Header Value Wildcards:**
-Header values support the following wildcards:
-- `%REQUESTED_SERVER_NAME%`: The server name requested by the client
-- `%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%`: The client IP address without port
-- `%START_TIME%`: The request start time
+**Dynamic Header Values:**
+
+A header value may embed one of the following variables. Variables can be combined with literal text in the same value (for example, `client=%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%`).
+
+| Variable | Replaced with |
+| --- | --- |
+| `%REQUESTED_SERVER_NAME%` | The TLS SNI (Server Name Indication) sent by the client during the TLS handshake. Empty for non-TLS requests. |
+| `%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%` | The client's remote IP address, without the source port. Commonly used to forward the original client IP to the workload. |
+| `%START_TIME%` | The time the request started, as an RFC 3339 UTC timestamp (for example, `2026-08-26T12:34:56.000Z`). |
+
+<Warning>
+
+Only the three variables listed above are accepted. Any other `%`-delimited token in a header value (including a supported variable with a format argument, such as `%START_TIME(%s)%`) is rejected when the domain is created or updated.
+
+</Warning>
 
 **Example:**
 ```yaml
@@ -200,6 +210,7 @@ headers:
       X-Custom-Header: "value"
       X-Client-IP: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
       X-Server-Name: "%REQUESTED_SERVER_NAME%"
+      X-Request-Start: "%START_TIME%"
 ```
 
 <Note>


### PR DESCRIPTION
## What

Expands the **Header Operations** section of `reference/domain.mdx` to properly document the special header value operators the API accepts in `headers.request.set` on a domain route.

The three operators were already listed, but with vague one-line descriptions and no explanation of where they come from or what happens with unsupported tokens. This change:

- Names them as command operators and describes precisely what each substitutes:
  - `%REQUESTED_SERVER_NAME%` — TLS SNI from the client handshake
  - `%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%` — client remote IP without the source port
  - `%START_TIME%` — request start time as an RFC 3339 UTC timestamp
- Notes that operators can be combined with literal text in a value.
- Adds a Warning that only these three are accepted — any other `%…%` token (including a supported operator with a format argument like `%START_TIME(%s)%`) is rejected on domain create/update, matching the schema validator.
- Adds `%START_TIME%` to the example.
- Swaps the redundant `internal domain` keyword (duplicated `private domain`) for `client ip header`.

## Source of truth

Allowlist matches the API schema validator in `nodelibs/schema/src/domain.ts` (`EnvoyHeaderValue`) and the MCP domain tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)